### PR TITLE
Support REQUEST_ACK message type

### DIFF
--- a/implementation/utility/include/utility.hpp
+++ b/implementation/utility/include/utility.hpp
@@ -36,9 +36,7 @@ public:
     }
 
     static inline bool is_request(message_type_e _type) {
-        return ((_type < message_type_e::MT_NOTIFICATION)
-                || (_type >= message_type_e::MT_REQUEST_ACK
-                        && _type <= message_type_e::MT_REQUEST_NO_RETURN_ACK));
+        return (_type < message_type_e::MT_NOTIFICATION);
     }
 
     static inline bool is_request_no_return(std::shared_ptr<message> _message) {


### PR DESCRIPTION
This change supports REQUEST_ACK message type
for SOMEIPSRV_ONWIRE_09 in OPEN Alliance Automotive
Ethernet ECU Test Specification.