### PR TITLE
Fix multicast timeout crash on Windows

### DIFF
--- a/implementation/service_discovery/src/service_discovery_impl.cpp
+++ b/implementation/service_discovery/src/service_discovery_impl.cpp
@@ -166,13 +166,8 @@ service_discovery_impl::start() {
         }
         if (endpoint_ && !reliable_) {
             // rejoin multicast group
-#ifndef ANDROID
-            reinterpret_cast<udp_server_endpoint_impl*>(
-                    endpoint_.get())->join(sd_multicast_);
-#else
             dynamic_cast<udp_server_endpoint_impl*>(
                     endpoint_.get())->join(sd_multicast_);
-#endif
         }
     }
     is_suspended_ = false;
@@ -3351,13 +3346,8 @@ service_discovery_impl::on_last_msg_received_timer_expired(
 
         // Rejoin multicast group
         if (endpoint_ && !reliable_) {
-#ifndef ANDROID
-            reinterpret_cast<udp_server_endpoint_impl*>(
-                    endpoint_.get())->join(sd_multicast_);
-#else
             dynamic_cast<udp_server_endpoint_impl*>(
                     endpoint_.get())->join(sd_multicast_);
-#endif
         }
         {
             boost::system::error_code ec;


### PR DESCRIPTION
There is a crash that happens consistently for my team in our client application on Windows when the `service_discovery_impl::on_last_msg_received_timer_expired()` callback gets called due to the application no longer receiving SD multicast messages from our device because the device was turned off or disconnected.

The issue seems to be caused from the use of `reinterpret_cast` at https://github.com/GENIVI/vsomeip/blob/master/implementation/service_discovery/src/service_discovery_impl.cpp#L3355. I changed it to always use `dynamic_cast` and it no longer crashes. According to documentation, use of `reinterpret_cast` in certain scenarios is deemed unsafe. This must be one of them. See https://en.cppreference.com/w/cpp/language/reinterpret_cast and https://docs.microsoft.com/en-us/cpp/cpp/reinterpret-cast-operator?view=msvc-160.

We are using the `Visual Studio 16 2019` MSVC compiler.