### PR TITLE
fix for issue #263, configuration option deserialize bug

### DIFF
--- a/implementation/service_discovery/src/configuration_option_impl.cpp
+++ b/implementation/service_discovery/src/configuration_option_impl.cpp
@@ -123,6 +123,8 @@ bool configuration_option_impl::deserialize(vsomeip_v3::deserializer *_from) {
                     is_successful = false;
                 }
             }
+        } else {
+              break;
         }
     } while (is_successful && _from->get_remaining() > 0);
 


### PR DESCRIPTION
After each character sequence another length field and a following character sequence are expected until a length field shall be set to 0x00. 
![image](https://user-images.githubusercontent.com/32973352/145240634-f2b61e35-e5f2-4b9b-b3b4-e799645d1c82.png)

https://www.autosar.org/fileadmin/user_upload/standards/foundation/1-2/AUTOSAR_PRS_SOMEIPServiceDiscoveryProtocol.pdf