### PR TITLE
Fix big endian support in byteorder.hpp

### DIFF
--- a/implementation/utility/include/byteorder.hpp
+++ b/implementation/utility/include/byteorder.hpp
@@ -38,6 +38,8 @@
 #define VSOMEIP_BYTES_TO_WORD(x0, x1) (uint16_t((x1) << 8 | (x0)))
 #define VSOMEIP_BYTES_TO_LONG(x0, x1, x2, x3) (uint32_t((x3) << 24 | (x2) << 16 | (x1) << 8 | (x0)))
 
+#define VSOMEIP_WORDS_TO_LONG(x0, x1) (uint32_t((x1) << 16 | (x0)))
+
 #define VSOMEIP_WORD_BYTE0(x) (uint8_t((x) >> 8))
 #define VSOMEIP_WORD_BYTE1(x) (uint8_t((x) & 0xFF))
 
@@ -46,8 +48,8 @@
 #define VSOMEIP_LONG_BYTE2(x) (uint8_t(((x) >> 8) & 0xFF))
 #define VSOMEIP_LONG_BYTE3(x) (uint8_t((x) & 0xFF))
 
-#define VSOMEIP_LONG_WORD0(x) (uint16_t((((x) >> 16) & 0xFFFF))
-#define VSOMEIP_LONG_WORD1(x) (uint16_t(((x) & 0xFFFF))
+#define VSOMEIP_LONG_WORD0(x) (uint16_t(((x) >> 16) & 0xFFFF))
+#define VSOMEIP_LONG_WORD1(x) (uint16_t((x) & 0xFFFF))
 
 #else
 


### PR DESCRIPTION
This adds VSOMEIP_WORDS_TO_LONG and removes unmatched parenthesis
in VSOMEIP_LONG_WORD0 and VSOMEIP_LONG_WORD1