### PR TITLE
fix configuration not reading default config files

### DIFF
--- a/implementation/configuration/src/configuration_impl.cpp
+++ b/implementation/configuration/src/configuration_impl.cpp
@@ -235,8 +235,6 @@ bool configuration_impl::load(const std::string &_name) {
             its_file = "";
         }
     }
-
-    std::set<std::string> its_input;
     if (its_file != "") {
         its_input.insert(its_file);
     }


### PR DESCRIPTION
This local variable is redefined which causes it to revert to empty after the if block (default values for config files will not be taken into account)
