### PR TITLE
Allow adding InstanceIds durning runtime

### DIFF
--- a/documentation/vsomeipUserGuide
+++ b/documentation/vsomeipUserGuide
@@ -567,6 +567,15 @@ Contains the services of the service provider.
 +
 The id of the service.
 
+** `dynamic_instance` (optional)
++
+Configure if the instance_id is not known yet and will be configured during runtime. 
+This setup  also alows to configure the amount of instances during runtime (valid values:
+_true_ and _false_).
++
+If set to _true_ port configuration is done by dynamic_instance_unreliable and 
+dynamic_instance_reliable and setting the instance parameter is not required.
+
 ** `instance`
 +
 The id of the service instance.
@@ -605,6 +614,36 @@ Specifies whether magic cookies are enabled (valid values: _true_, _false_).
 Specifies that the communication with the service is unreliable respectively the
 UDP protocol is used for communication (valid values: the _port_ of the UDP
 endpoint).
+
+** `dynamic_instance_unreliable`
++
+Specifies that the communication with the service is unreliable respectively the 
+UDP protocol is used for communication. The given port range is used to create 
+dynamic instances. The amount of port numbers in the range define the maximum amount
+of instances that can be created during runtime.
+
+*** `first`
++
+The first entry of the port range.
+
+*** `last`
++
+The lowest last entry of the port service range.
+
+** `dynamic_instance_reliable`
++
+Specifies that the communication with the service is reliable respectively the 
+TCP protocol is used for communication. The given port range is used to create 
+dynamic instances. The amount of port numbers in the range define the maximum amount
+of instances that can be created during runtime.
+
+*** `first`
++
+The first entry of the port range.
+
+*** `last`
++
+The lowest last entry of the port service range.
 
 ** `events` (array)
 +

--- a/implementation/configuration/include/configuration.hpp
+++ b/implementation/configuration/include/configuration.hpp
@@ -273,6 +273,9 @@ public:
     virtual uint32_t get_statistics_interval() const = 0;
     virtual uint32_t get_statistics_min_freq() const = 0;
     virtual uint32_t get_statistics_max_messages() const = 0;
+
+    virtual bool add_service_instance(service_t service, instance_t instance) = 0;
+    virtual bool is_registered_service(service_t service, instance_t instance) = 0;
 };
 
 } // namespace vsomeip_v3

--- a/implementation/configuration/include/configuration_impl.hpp
+++ b/implementation/configuration/include/configuration_impl.hpp
@@ -299,6 +299,7 @@ private:
     void load_servicegroup(const boost::property_tree::ptree &_tree);
     void load_service(const boost::property_tree::ptree &_tree,
             const std::string &_unicast_address);
+    void add_service_to_maps(std::shared_ptr<service> its_service, bool use_magic_cookies);
     void load_event(std::shared_ptr<service> &_service,
             const boost::property_tree::ptree &_tree);
     void load_eventgroup(std::shared_ptr<service> &_service,
@@ -378,6 +379,11 @@ private:
 
     void load_secure_services(const configuration_element &_element);
     void load_secure_service(const boost::property_tree::ptree &_tree);
+    bool add_service_instance(service_t service, instance_t instance);
+    bool is_registered_service(service_t service, instance_t instance);
+    uint16_t claim_port(service_t _service, bool reliable);
+    uint16_t claim_port_unreliable(service_t _service);
+    uint16_t claim_port_reliable(service_t _service);
 
 private:
     std::mutex mutex_;
@@ -568,6 +574,15 @@ protected:
     uint32_t statistics_interval_;
     uint32_t statistics_min_freq_;
     uint32_t statistics_max_messages_;
+
+    // available ports to use with dynamic instance ids structure: {service: {port: in_use}}
+    std::mutex dynamic_services_mutex_;
+    std::map<service_t, std::shared_ptr<service>> dynamic_service_templates_;
+
+    std::map<service_t, std::pair<std::uint16_t, std::uint16_t>> reliable_ports_range_for_dynamic_services_;
+    std::map<service_t, std::pair<std::uint16_t, std::uint16_t>> unreliable_ports_range_for_dynamic_services_;
+    std::map<service_t, std::set<std::uint16_t>> used_reliable_ports_for_dynamic_services_;
+    std::map<service_t, std::set<std::uint16_t>> used_unreliable_ports_for_dynamic_services_;
 };
 
 } // namespace cfg

--- a/implementation/configuration/src/configuration_impl.cpp
+++ b/implementation/configuration/src/configuration_impl.cpp
@@ -4044,7 +4044,7 @@ bool configuration_impl::add_service_instance(service_t _service, instance_t _in
 
         auto its_port = claim_port_unreliable(_service);
         if (its_port == 0){
-            VSOMEIP_ERROR << "["<<__PRETTY_FUNCTION__ <<"] " << "could not claim port";
+            VSOMEIP_ERROR << __func__ << " - could not claim port";
             return false;
         }
 
@@ -4060,7 +4060,7 @@ bool configuration_impl::add_service_instance(service_t _service, instance_t _in
         add_service_to_maps(new_service, false);
     }
     else {
-        VSOMEIP_ERROR << "["<<__PRETTY_FUNCTION__ <<"] " << "no template service found for ["
+        VSOMEIP_ERROR << __func__ << " - no template service found for ["
         << std::hex << _service << "]";
         return false;
     }

--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -361,6 +361,18 @@ bool routing_manager_impl::offer_service(client_t _client,
         }
     }
 
+    // check if this is an unknown instance id
+    {
+        if (!configuration_->is_registered_service(_service, _instance)){
+            bool success = configuration_->add_service_instance(_service, _instance);
+            if(!success){
+                VSOMEIP_WARNING << "Add service instance for unknown instance id failed: ["
+                  << std::hex << std::setw(4) << std::setfill('0') << _service << "."
+                  << std::hex << std::setw(4) << std::setfill('0') << _instance << "]";
+            }
+        }
+    }
+
     // Check if the application hosted by routing manager is allowed to offer
     // offer_service requests of local proxies are checked in rms::on:message
     if (_client == get_client()) {


### PR DESCRIPTION
To allow creating services instances during runtime it was necessary to
provide the necessary ports used for communictation. Therefore new
parameters for the service configuration in the vsomeip.json were
created. "dynamic_instance_unrealiable" and "dynamic_instance_reliable"
both are defining a port range that can be used for instances created
during runtime. Also an service that has no predefined instance is
marked with the parameter dynamic_instance = "true". In this case its
not necessary to define a instance in the configuration.

Example Service Definition:
    {
        "service" : "1010",
        "dynamic_instance" : "true",
        "dynamic_instance_unreliable":
        {
            "first":30005,
            "last": 30010
        },
        ...
    }

The port list is handled by the configuration module. The configuration
offers new methods (claim_port_reliable and claim_port_unreliable) to
claim a port for a new instance. For each dynamic service a template
service is kept.

Additionally the routing_manager was extended so that dynamic instances
are created by using the template service when an offer_service for an
unknown instance on a dynamic service is called and a port for the
instance is claimed.