### PR TITLE
Use Reference to Prevent Copying

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 2.8.12...3.23.3)
 project (vsomeip)
 
 set (VSOMEIP_NAME vsomeip3)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -3,7 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 2.8...3.23.2)
 
 set(EXAMPLE_CONFIG_FILES
     "../config/vsomeip.json"

--- a/examples/hello_world/CMakeLists.txt
+++ b/examples/hello_world/CMakeLists.txt
@@ -3,7 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required (VERSION 2.8.7)
+cmake_minimum_required (VERSION 2.8.7...3.23.2)
 project (vSomeIPHelloWorld)
 
 find_package(Threads REQUIRED)

--- a/examples/routingmanagerd/CMakeLists.txt
+++ b/examples/routingmanagerd/CMakeLists.txt
@@ -3,7 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 2.8...3.23.2)
 
 # Daemon
 add_executable(routingmanagerd routingmanagerd.cpp)

--- a/implementation/compat/runtime/src/application_impl.cpp
+++ b/implementation/compat/runtime/src/application_impl.cpp
@@ -638,7 +638,7 @@ application_impl::is_selective_event(
     if (its_service != eventgroups_.end()) {
         const auto its_instance = its_service->second.find(_instance);
         if (its_instance != its_service->second.end()) {
-            for (const auto eg : _eventgroups) {
+            for (const auto& eg : _eventgroups) {
                 const auto its_egrp = its_instance->second.find(eg);
                 if (its_egrp != its_instance->second.end()) {
                     is_selective = true;

--- a/implementation/configuration/src/configuration_impl.cpp
+++ b/implementation/configuration/src/configuration_impl.cpp
@@ -3972,7 +3972,7 @@ configuration_impl::load_overlay(const std::string &_name) {
         its_input.insert(its_overlay);
         read_data(its_input, its_elements, its_failed, false);
 
-        for (const auto f : its_failed)
+        for (const auto& f : its_failed)
             VSOMEIP_ERROR << "Reading configuration data from " << f << " failed!";
 
         is_overlay_ = true;

--- a/implementation/endpoints/src/endpoint_manager_base.cpp
+++ b/implementation/endpoints/src/endpoint_manager_base.cpp
@@ -158,7 +158,7 @@ endpoint_manager_base::log_client_states() const {
 
     {
         std::lock_guard<std::mutex> its_lock(local_endpoint_mutex_);
-        for (const auto e : local_endpoints_) {
+        for (const auto& e : local_endpoints_) {
             size_t its_queue_size = e.second->get_queue_size();
             if (its_queue_size > VSOMEIP_DEFAULT_QUEUE_WARN_SIZE) {
                 its_client_queue_sizes.push_back(

--- a/implementation/endpoints/src/endpoint_manager_impl.cpp
+++ b/implementation/endpoints/src/endpoint_manager_impl.cpp
@@ -983,9 +983,9 @@ endpoint_manager_impl::log_client_states() const {
         its_client_endpoints = client_endpoints_by_ip_;
     }
 
-    for (const auto its_address : its_client_endpoints) {
-        for (const auto its_port : its_address.second) {
-            for (const auto its_reliability : its_port.second) {
+    for (const auto& its_address : its_client_endpoints) {
+        for (const auto& its_port : its_address.second) {
+            for (const auto& its_reliability : its_port.second) {
                 size_t its_queue_size = its_reliability.second->get_queue_size();
                 if (its_queue_size > VSOMEIP_DEFAULT_QUEUE_WARN_SIZE)
                     its_client_queue_sizes.push_back(
@@ -1040,8 +1040,8 @@ endpoint_manager_impl::log_server_states() const {
         its_server_endpoints = server_endpoints_;
     }
 
-    for (const auto its_port : its_server_endpoints) {
-        for (const auto its_reliability : its_port.second) {
+    for (const auto& its_port : its_server_endpoints) {
+        for (const auto& its_reliability : its_port.second) {
             size_t its_queue_size = its_reliability.second->get_queue_size();
             if (its_queue_size > VSOMEIP_DEFAULT_QUEUE_WARN_SIZE)
                 its_client_queue_sizes.push_back(

--- a/implementation/endpoints/src/server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/server_endpoint_impl.cpp
@@ -757,7 +757,7 @@ size_t server_endpoint_impl<Protocol>::get_queue_size() const {
 
     {
         std::lock_guard<std::mutex> its_lock(mutex_);
-        for (const auto q : queues_) {
+        for (const auto& q : queues_) {
             its_queue_size += q.second.second.size();
         }
     }

--- a/implementation/routing/src/eventgroupinfo.cpp
+++ b/implementation/routing/src/eventgroupinfo.cpp
@@ -223,7 +223,7 @@ eventgroupinfo::update_remote_subscription(
             _id = its_item.second->get_id();
 
             // Copy acknowledgment states from existing subscription
-            for (const auto its_client : _subscription->get_clients()) {
+            for (const auto& its_client : _subscription->get_clients()) {
                 _subscription->set_client_state(its_client,
                         its_item.second->get_client_state(its_client));
             }
@@ -390,10 +390,10 @@ eventgroupinfo::send_initial_events(
     }
 
     // Send events
-    for (const auto its_event : its_reliable_events)
+    for (const auto& its_event : its_reliable_events)
         its_event->notify_one(VSOMEIP_ROUTING_CLIENT, _reliable);
 
-    for (const auto its_event : its_unreliable_events)
+    for (const auto& its_event : its_unreliable_events)
         its_event->notify_one(VSOMEIP_ROUTING_CLIENT, _unreliable);
 }
 

--- a/implementation/routing/src/remote_subscription.cpp
+++ b/implementation/routing/src/remote_subscription.cpp
@@ -135,7 +135,7 @@ std::set<client_t>
 remote_subscription::get_clients() const {
     std::lock_guard<std::mutex> its_lock(mutex_);
     std::set<client_t> its_clients;
-    for (const auto its_item : clients_)
+    for (const auto& its_item : clients_)
         its_clients.insert(its_item.first);
     return its_clients;
 }

--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -278,7 +278,7 @@ void routing_manager_impl::stop() {
         discovery_->stop();
     stub_->stop();
 
-    for (const auto client : ep_mgr_->get_connected_clients()) {
+    for (const auto& client : ep_mgr_->get_connected_clients()) {
         if (client != VSOMEIP_ROUTING_CLIENT) {
             remove_local(client, true);
         }
@@ -1163,7 +1163,7 @@ void routing_manager_impl::notify_one(service_t _service, instance_t _instance,
         if (its_event) {
             std::set<std::shared_ptr<endpoint_definition> > its_targets;
             const auto its_reliability = its_event->get_reliability();
-            for (const auto g : its_event->get_eventgroups()) {
+            for (const auto& g : its_event->get_eventgroups()) {
                 const auto its_eventgroup = find_eventgroup(_service, _instance, g);
                 if (its_eventgroup) {
                     const auto its_subscriptions = its_eventgroup->get_remote_subscriptions();
@@ -1887,7 +1887,7 @@ bool routing_manager_impl::deliver_notification(
                 // no subscribers for this specific event / check subscriptions
                 // to other events of the event's eventgroups
                 bool cache_event = false;
-                for (const auto eg : its_event->get_eventgroups()) {
+                for (const auto& eg : its_event->get_eventgroups()) {
                     std::shared_ptr<eventgroupinfo> egi = find_eventgroup(_service, _instance, eg);
                     if (egi) {
                         for (const auto &e : egi->get_events()) {
@@ -1927,7 +1927,7 @@ bool routing_manager_impl::deliver_notification(
                 utility::get_payload_size(_data, _length));
 
         if (its_event->get_type() != event_type_e::ET_SELECTIVE_EVENT) {
-            for (const auto its_local_client : its_event->get_subscribers()) {
+            for (const auto& its_local_client : its_event->get_subscribers()) {
                 if (its_local_client == host_->get_client()) {
                     deliver_message(_data, _length, _instance, _reliable,
                             _bound_client, _credentials, _status_check, _is_from_remote);
@@ -2412,7 +2412,7 @@ void routing_manager_impl::del_routing_info(service_t _service, instance_t _inst
                     // longer valid.
                     for (auto &its_event : its_eventgroup.second->get_events()) {
                         const auto its_subscribers = its_event->get_subscribers();
-                        for (const auto its_subscriber : its_subscribers) {
+                        for (const auto& its_subscriber : its_subscribers) {
                             if (its_subscriber != get_client()) {
                                 its_event->remove_subscriber(
                                         its_eventgroup.first, its_subscriber);
@@ -2436,14 +2436,14 @@ void routing_manager_impl::del_routing_info(service_t _service, instance_t _inst
         std::set<std::tuple<
             service_t, instance_t, eventgroup_t, client_t> > its_invalid;
 
-        for (const auto its_state : remote_subscription_state_) {
+        for (const auto& its_state : remote_subscription_state_) {
             if (std::get<0>(its_state.first) == _service
                     && std::get<1>(its_state.first) == _instance) {
                 its_invalid.insert(its_state.first);
             }
         }
 
-        for (const auto its_key : its_invalid)
+        for (const auto& its_key : its_invalid)
             remote_subscription_state_.erase(its_key);
     }
 
@@ -3770,7 +3770,7 @@ void routing_manager_impl::clear_targets_and_pending_sub_from_eventgroups(
                     // longer valid.
                     for (auto &its_event : its_eventgroup.second->get_events()) {
                         const auto its_subscribers = its_event->get_subscribers();
-                        for (const auto its_subscriber : its_subscribers) {
+                        for (const auto& its_subscriber : its_subscribers) {
                             if (its_subscriber != get_client()) {
                                 its_event->remove_subscriber(
                                         its_eventgroup.first, its_subscriber);
@@ -4112,7 +4112,7 @@ void routing_manager_impl::send_subscription(
         const remote_subscription_id_t _id) {
     if (host_->get_client() == _offering_client) {
         auto self = shared_from_this();
-        for (const auto its_client : _clients) {
+        for (const auto& its_client : _clients) {
             host_->on_subscription(_service, _instance, _eventgroup, its_client, own_uid_, own_gid_, true,
                 [this, self, _service, _instance, _eventgroup, its_client, _id]
                         (const bool _is_accepted) {
@@ -4138,7 +4138,7 @@ void routing_manager_impl::send_subscription(
             });
         }
     } else { // service hosted by local client
-        for (const auto its_client : _clients) {
+        for (const auto& its_client : _clients) {
             if (!stub_->send_subscribe(find_local(_offering_client), its_client,
                     _service, _instance, _eventgroup, _major, ANY_EVENT, _id)) {
                 try {
@@ -4266,7 +4266,7 @@ routing_manager_impl::send_unsubscription(client_t _offering_client,
 
     if (host_->get_client() == _offering_client) {
         auto self = shared_from_this();
-        for (const auto its_client : _removed) {
+        for (const auto& its_client : _removed) {
             host_->on_subscription(_service, _instance,
                     _eventgroup, its_client, own_uid_, own_gid_, false,
                 [this, self, _service, _instance, _eventgroup,
@@ -4286,7 +4286,7 @@ routing_manager_impl::send_unsubscription(client_t _offering_client,
             );
         }
     } else {
-        for (const auto its_client : _removed) {
+        for (const auto& its_client : _removed) {
             if (!stub_->send_unsubscribe(find_local(_offering_client), its_client,
                     _service, _instance, _eventgroup, ANY_EVENT, _id)) {
                 try {
@@ -4347,7 +4347,7 @@ bool routing_manager_impl::insert_event_statistics(service_t _service, instance_
             // check list for entry with least counter value
             uint32_t its_min_count(0xFFFFFFFF);
             auto its_tuple_to_discard = std::make_tuple(0xFFFF, 0xFFFF, 0xFFFF);
-            for (const auto it : message_statistics_) {
+            for (const auto& it : message_statistics_) {
                 if (it.second.counter_ < its_min_count) {
                     its_min_count = it.second.counter_;
                     its_tuple_to_discard = it.first;
@@ -4389,7 +4389,7 @@ void routing_manager_impl::statistics_log_timer_cbk(boost::system::error_code co
         std::stringstream its_log;
         {
             std::lock_guard<std::mutex> its_lock(message_statistics_mutex_);
-            for (const auto s : message_statistics_) {
+            for (const auto& s : message_statistics_) {
                 if (s.second.counter_ / (its_interval / 1000) >= its_min_freq) {
                     uint16_t its_subscribed(0);
                     std::shared_ptr<event> its_event = find_event(std::get<0>(s.first), std::get<1>(s.first), std::get<2>(s.first));

--- a/implementation/routing/src/routing_manager_proxy.cpp
+++ b/implementation/routing/src/routing_manager_proxy.cpp
@@ -125,7 +125,7 @@ void routing_manager_proxy::stop() {
         sender_ = nullptr;
     }
 
-    for (const auto client : ep_mgr_->get_connected_clients()) {
+    for (const auto& client : ep_mgr_->get_connected_clients()) {
         if (client != VSOMEIP_ROUTING_CLIENT) {
             remove_local(client, true);
         }
@@ -1733,7 +1733,7 @@ void routing_manager_proxy::on_routing_info(const byte_t *_data,
                 for (const client_t client : known_clients_) {
                     auto its_client = pending_incoming_subscripitons_.find(client);
                     if (its_client != pending_incoming_subscripitons_.end()) {
-                        for (const auto subscription : its_client->second) {
+                        for (const auto& subscription : its_client->second) {
                             subscription_actions.push_front(
                                 { subscription.service_, subscription.instance_,
                                         subscription.eventgroup_, client,
@@ -1850,7 +1850,7 @@ void routing_manager_proxy::reconnect(const std::unordered_set<client_t> &_clien
 
 
     // Remove all local connections/endpoints
-    for (const auto its_client : _clients) {
+    for (const auto& its_client : _clients) {
         if (its_client != VSOMEIP_ROUTING_CLIENT) {
             remove_local(its_client, true);
         }

--- a/implementation/routing/src/routing_manager_stub.cpp
+++ b/implementation/routing/src/routing_manager_stub.cpp
@@ -2257,7 +2257,7 @@ routing_manager_stub::send_requester_policies(const std::unordered_set<client_t>
     pending_security_update_id_t its_policy_id;
 
     // serialize the policies and send them...
-    for (const auto p : _policies) {
+    for (const auto& p : _policies) {
         std::vector<byte_t> its_policy_data;
         if (p->serialize(its_policy_data)) {
             std::vector<byte_t> its_message;
@@ -2279,7 +2279,7 @@ routing_manager_stub::send_requester_policies(const std::unordered_set<client_t>
 
             its_message.insert(its_message.end(), its_policy_data.begin(), its_policy_data.end());
 
-            for (const auto c : _clients) {
+            for (const auto& c : _clients) {
                 std::shared_ptr<endpoint> its_endpoint = host_->find_local(c);
                 if (its_endpoint)
                     its_endpoint->send(&its_message[0], static_cast<uint32_t>(its_message.size()));

--- a/implementation/runtime/src/application_impl.cpp
+++ b/implementation/runtime/src/application_impl.cpp
@@ -2157,7 +2157,7 @@ bool application_impl::check_for_active_subscription(service_t _service,
                         std::shared_ptr<event> its_event = routing_->find_event(
                                 _service, _instance, _event);
                         if (its_event) {
-                            for (const auto eg : its_event->get_eventgroups()) {
+                            for (const auto& eg : its_event->get_eventgroups()) {
                                 auto found_eventgroup = found_any_event->second.find(eg);
                                 if (found_eventgroup != found_any_event->second.end()) {
                                     // set the flag for initial event received to true

--- a/implementation/security/src/policy.cpp
+++ b/implementation/security/src/policy.cpp
@@ -175,7 +175,7 @@ policy::deserialize_ids(const byte_t * &_data, uint32_t &_size,
         if (its_result == false)
             return (false);
 
-        for (const auto i : its_instances)
+        for (const auto& i : its_instances)
             its_ids += std::make_pair(i, its_methods);
 
         its_array_length -= (its_current_size - _size);
@@ -305,7 +305,7 @@ policy::serialize(std::vector<byte_t> &_data) const {
     uint32_t its_requests_size(0);
     serialize_u32(its_requests_size, _data);
 
-    for (const auto its_request : requests_) {
+    for (const auto& its_request : requests_) {
         for (auto its_service = its_request.first.lower();
                 its_service <= its_request.first.upper();
                 its_service++) {
@@ -316,7 +316,7 @@ policy::serialize(std::vector<byte_t> &_data) const {
             uint32_t its_instances_size(0);
             serialize_u32(its_instances_size, _data);
 
-            for (const auto i : its_request.second) {
+            for (const auto& i : its_request.second) {
                 boost::icl::interval_set<instance_t> its_instances;
                 its_instances.insert(i.first);
                 serialize_interval_set(its_instances, _data);
@@ -378,7 +378,7 @@ policy::serialize_interval_set(
     uint32_t its_interval_set_size(0);
     serialize_u32(its_interval_set_size, _data);
 
-    for (const auto i : _intervals)
+    for (const auto& i : _intervals)
         serialize_interval(i, _data);
 
     its_interval_set_size = static_cast<uint32_t>(_data.size()

--- a/implementation/security/src/security_impl.cpp
+++ b/implementation/security/src/security_impl.cpp
@@ -470,7 +470,7 @@ security_impl::update_security_policy(uint32_t _uid, uint32_t _gid,
     }
 
     if (its_matching_policy) {
-        for (const auto r : _policy->requests_) {
+        for (const auto& r : _policy->requests_) {
             service_t its_lower, its_upper;
             get_bounds(r.first, its_lower, its_upper);
             for (auto s = its_lower; s <= its_upper; s++) {
@@ -479,7 +479,7 @@ security_impl::update_security_policy(uint32_t _uid, uint32_t _gid,
                 its_matching_policy->requests_ += std::make_pair(its_service, r.second);
             }
         }
-        for (const auto o : _policy->offers_) {
+        for (const auto& o : _policy->offers_) {
             service_t its_lower, its_upper;
             get_bounds(o.first, its_lower, its_upper);
             for (auto s = its_lower; s <= its_upper; s++) {
@@ -758,7 +758,7 @@ security_impl::load_policy(const boost::property_tree::ptree &_tree) {
                 policy->allow_who_ = true;
             }
             if (has_uid_range && has_gid_range) {
-                for (const auto u : its_uid_interval_set)
+                for (const auto& u : its_uid_interval_set)
                     policy->credentials_ += std::make_pair(u, its_gid_interval_set);
                 policy->allow_who_ = true;
             }
@@ -819,7 +819,7 @@ security_impl::load_policy_body(std::shared_ptr<policy> &_policy,
                             its_instance_interval_set.insert(all_instances);
                             its_method_interval_set.insert(all_methods);
                         }
-                        for (const auto i : its_instance_interval_set) {
+                        for (const auto& i : its_instance_interval_set) {
                             its_instance_method_intervals
                                 += std::make_pair(i, its_method_interval_set);
                         }
@@ -838,7 +838,7 @@ security_impl::load_policy_body(std::shared_ptr<policy> &_policy,
                             }
                             if (its_method_interval_set.empty())
                                 its_method_interval_set.insert(all_methods);
-                            for (const auto i : its_instance_interval_set) {
+                            for (const auto& i : its_instance_interval_set) {
                                 its_instance_method_intervals
                                     += std::make_pair(i, its_method_interval_set);
                             }
@@ -853,7 +853,7 @@ security_impl::load_policy_body(std::shared_ptr<policy> &_policy,
 
                             // try to only load instance ranges with any method to be allowed
                             load_interval_set(k->second, its_legacy_instance_interval_set);
-                            for (const auto i : its_legacy_instance_interval_set) {
+                            for (const auto& i : its_legacy_instance_interval_set) {
                                 its_instance_method_intervals
                                     += std::make_pair(i, its_legacy_method_interval_set);
                             }
@@ -929,7 +929,7 @@ security_impl::load_credential(
             }
         }
 
-        for (const auto its_uid_interval : its_uid_interval_set) {
+        for (const auto& its_uid_interval : its_uid_interval_set) {
             _credentials
                 += std::make_pair(its_uid_interval, its_gid_interval_set);
         }
@@ -1081,8 +1081,8 @@ security_impl::get_requester_policies(const std::shared_ptr<policy> _policy,
     }
 
     std::lock_guard<std::mutex> its_lock(_policy->mutex_);
-    for (const auto o : _policy->offers_) {
-        for (const auto p : its_policies) {
+    for (const auto& o : _policy->offers_) {
+        for (const auto& p : its_policies) {
             if (p == _policy)
                 continue;
 
@@ -1091,7 +1091,7 @@ security_impl::get_requester_policies(const std::shared_ptr<policy> _policy,
             auto its_policy = std::make_shared<policy>();
             its_policy->credentials_ = p->credentials_;
 
-            for (const auto r : p->requests_) {
+            for (const auto& r : p->requests_) {
                 // o represents an offer by a service interval and its instances
                 // (a set of intervals)
                 // r represents a request by a service interval and its instances
@@ -1109,9 +1109,9 @@ security_impl::get_requester_policies(const std::shared_ptr<policy> _policy,
                     auto its_service_min = std::max(its_o_lower, its_r_lower);
                     auto its_service_max = std::min(its_r_upper, its_o_upper);
 
-                    for (const auto i : o.second) {
-                        for (const auto j : r.second) {
-                            for (const auto k : j.second) {
+                    for (const auto& i : o.second) {
+                        for (const auto& j : r.second) {
+                            for (const auto& k : j.second) {
                                 instance_t its_i_lower, its_i_upper, its_k_lower, its_k_upper;
                                 get_bounds(i, its_i_lower, its_i_upper);
                                 get_bounds(k, its_k_lower, its_k_upper);
@@ -1151,7 +1151,7 @@ security_impl::get_clients(uid_t _uid, gid_t _gid,
         std::unordered_set<client_t> &_clients) const {
 
     std::lock_guard<std::mutex> its_lock(ids_mutex_);
-    for (const auto i : ids_) {
+    for (const auto& i : ids_) {
         if (i.second.first == _uid && i.second.second == _gid)
             _clients.insert(i.first);
     }

--- a/implementation/service_discovery/src/eventgroupentry_impl.cpp
+++ b/implementation/service_discovery/src/eventgroupentry_impl.cpp
@@ -118,8 +118,8 @@ bool eventgroupentry_impl::matches(const eventgroupentry_impl& _other,
         std::vector<std::shared_ptr<ip_option_impl>> its_options_current;
         std::vector<std::shared_ptr<ip_option_impl>> its_options_other;
         const std::size_t its_options_size = _options.size();
-        for (const auto option_run : {0,1}) {
-            for (const auto option_index : options_[option_run]) {
+        for (const auto& option_run : {0,1}) {
+            for (const auto& option_index : options_[option_run]) {
                 if (its_options_size > option_index) {
                     switch (_options[option_index]->get_type()) {
                         case option_type_e::IP4_ENDPOINT:
@@ -137,7 +137,7 @@ bool eventgroupentry_impl::matches(const eventgroupentry_impl& _other,
                     }
                 }
             }
-            for (const auto option_index : _other.options_[option_run]) {
+            for (const auto& option_index : _other.options_[option_run]) {
                 if (its_options_size > option_index) {
                     switch (_options[option_index]->get_type()) {
                         case option_type_e::IP4_ENDPOINT:
@@ -212,8 +212,8 @@ std::shared_ptr<endpoint_definition> eventgroupentry_impl::get_target(
 
 std::shared_ptr<selective_option_impl>
 eventgroupentry_impl::get_selective_option() const {
-    for (const auto i : {0, 1}) {
-        for (const auto j : options_[i]) {
+    for (const auto& i : {0, 1}) {
+        for (const auto& j : options_[i]) {
             auto its_option = std::dynamic_pointer_cast<
                     selective_option_impl>(owner_->get_option(j));
             if (its_option)

--- a/implementation/service_discovery/src/service_discovery_impl.cpp
+++ b/implementation/service_discovery/src/service_discovery_impl.cpp
@@ -248,8 +248,8 @@ service_discovery_impl::subscribe(
                 if (!its_subscription->is_selective() && is_selective) {
                     its_subscription->set_selective(true);
                     its_subscription->remove_client(VSOMEIP_ROUTING_CLIENT);
-                    for (const auto e : _info->get_events()) {
-                        for (const auto c : e->get_subscribers(_eventgroup)) {
+                    for (const auto& e : _info->get_events()) {
+                        for (const auto& c : e->get_subscribers(_eventgroup)) {
                             its_subscription->add_client(c);
                         }
                     }
@@ -769,7 +769,7 @@ service_discovery_impl::create_eventgroup_entry(
             its_entry->set_ttl(_subscription->get_ttl());
             its_data.entry_ = its_entry;
 
-            for (const auto its_client : _subscription->get_clients()) {
+            for (const auto& its_client : _subscription->get_clients()) {
                 if (_subscription->get_state(its_client)
                         == subscription_state_e::ST_RESUBSCRIBING_NOT_ACKNOWLEDGED) {
                     its_other = std::make_shared<eventgroupentry_impl>();
@@ -821,7 +821,7 @@ service_discovery_impl::create_eventgroup_entry(
                 its_data.entry_ = its_entry;
             }
 
-            for (const auto its_client : _subscription->get_clients()) {
+            for (const auto& its_client : _subscription->get_clients()) {
                 if (_subscription->get_state(its_client)
                         == subscription_state_e::ST_RESUBSCRIBING_NOT_ACKNOWLEDGED) {
                     if (!its_other) {
@@ -1473,7 +1473,7 @@ service_discovery_impl::process_offerservice_serviceentry(
                         if (its_data.entry_) {
                             add_entry_data(_resubscribes, its_data);
                         }
-                        for (const auto its_client : its_subscription->get_clients()) {
+                        for (const auto& its_client : its_subscription->get_clients()) {
                             its_subscription->set_state(its_client,
                                     subscription_state_e::ST_NOT_ACKNOWLEDGED);
                         }
@@ -1616,7 +1616,7 @@ service_discovery_impl::on_endpoint_connected(
 
                                     its_subscription->set_endpoint(its_reliable, true);
                                     its_subscription->set_endpoint(its_unreliable, false);
-                                    for (const auto its_client : its_subscription->get_clients())
+                                    for (const auto& its_client : its_subscription->get_clients())
                                         its_subscription->set_state(its_client,
                                                 subscription_state_e::ST_NOT_ACKNOWLEDGED);
 
@@ -2377,7 +2377,7 @@ service_discovery_impl::handle_eventgroup_subscription_nack(
             auto found_eventgroup = found_instance->second.find(_eventgroup);
             if (found_eventgroup != found_instance->second.end()) {
                 auto its_subscription = found_eventgroup->second;
-                for (const auto its_client : _clients) {
+                for (const auto& its_client : _clients) {
                     host_->on_subscribe_nack(its_client,
                             _service, _instance, _eventgroup, ANY_EVENT,
                             PENDING_SUBSCRIPTION_ID); // TODO: This is a dummy call...
@@ -2412,7 +2412,7 @@ service_discovery_impl::handle_eventgroup_subscription_ack(
         if (found_instance != found_service->second.end()) {
             auto found_eventgroup = found_instance->second.find(_eventgroup);
             if (found_eventgroup != found_instance->second.end()) {
-                for (const auto its_client : _clients) {
+                for (const auto& its_client : _clients) {
                     if (found_eventgroup->second->get_state(its_client)
                             == subscription_state_e::ST_NOT_ACKNOWLEDGED) {
                         found_eventgroup->second->set_state(its_client,

--- a/implementation/service_discovery/src/subscription.cpp
+++ b/implementation/service_discovery/src/subscription.cpp
@@ -100,7 +100,7 @@ std::set<client_t> subscription::get_clients() const {
     std::set<client_t> its_clients;
     {
         std::lock_guard<std::mutex> its_lock(clients_mutex_);
-        for (const auto its_item : clients_)
+        for (const auto& its_item : clients_)
             its_clients.insert(its_item.first);
     }
     return its_clients;

--- a/test/client_id_tests/client_id_test_utility.cpp
+++ b/test/client_id_tests/client_id_test_utility.cpp
@@ -312,7 +312,7 @@ TEST_F(client_id_utility_test, exhaust_client_id_range_sequential) {
         EXPECT_EQ(VSOMEIP_CLIENT_UNSET, vsomeip::utility::request_client_id(
                         configuration_, APPLICATION_NAME_NOT_PREDEFINED + "max",
                         VSOMEIP_CLIENT_UNSET));
-        for (const auto c : its_clients) {
+        for (const auto& c : its_clients) {
             utility::release_client_id(c);
         }
     }
@@ -396,7 +396,7 @@ TEST_F(client_id_utility_test, exhaust_client_id_range_fragmented) {
                         VSOMEIP_CLIENT_UNSET));
 
         // release all
-        for (const auto c : its_clients) {
+        for (const auto& c : its_clients) {
             utility::release_client_id(c);
         }
         its_clients.clear();

--- a/test/npdu_tests/npdu_test_service.cpp
+++ b/test/npdu_tests/npdu_test_service.cpp
@@ -92,7 +92,7 @@ void npdu_test_service::stop()
     VSOMEIP_INFO << "Stopping...";
     if (!undershot_debounce_times_.empty()) {
         std::chrono::microseconds sum(0);
-        for (const auto t : undershot_debounce_times_) {
+        for (const auto& t : undershot_debounce_times_) {
             sum += t;
         }
         double average = static_cast<double>(sum.count())/static_cast<double>(undershot_debounce_times_.size());

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -3,7 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required (VERSION 2.8...3.23.2)
 
 # vsomeip_ctrl
 add_executable(vsomeip_ctrl EXCLUDE_FROM_ALL vsomeip_ctrl.cpp)


### PR DESCRIPTION
Since the variables are marked const, we may also take them by ref. Which means we just want to see the variables.

This  helps to generate minimal code.

and I also touched on CMakeLists.txt to tell  CMake that the project does not need compatibility with older versions.