### PR TITLE
mr accrdingly to mpl

### DIFF
--- a/interface/vsomeip/application.hpp
+++ b/interface/vsomeip/application.hpp
@@ -18,6 +18,13 @@
 #include <vsomeip/constants.hpp>
 #include <vsomeip/handler.hpp>
 
+namespace boost {
+namespace asio {
+    class io_context;
+    typedef io_context io_service;
+}
+}
+
 namespace vsomeip_v3 {
 
 class configuration_public;
@@ -920,6 +927,8 @@ public:
     virtual void remove_security_policy_configuration(uint32_t _uid,
                                                       uint32_t _gid,
                                                       security_update_handler_t _handler) = 0;
+                                                      
+    virtual boost::asio::io_service & get_io() = 0;
 };
 
 /** @} */


### PR DESCRIPTION
1) add thread id to logs
2) add an explicit tag to android logs as null tag leads to full process name, which oversizes logs itself. Android logs are filtered by id, so the process name is useless 
3) expose io outside, so we can add our own file descriptors to one common event loop, making vsomeip to be an async server of the whole application