### PR TITLE
Fix service discovery for any instance

### DIFF
--- a/implementation/routing/include/routing_manager_base.hpp
+++ b/implementation/routing/include/routing_manager_base.hpp
@@ -129,6 +129,7 @@ public:
     std::set<client_t> find_local_clients(service_t _service, instance_t _instance);
 
     std::shared_ptr<serviceinfo> find_service(service_t _service, instance_t _instance) const;
+    std::vector<std::shared_ptr<serviceinfo>> find_any_service(service_t _service) const;
 
     client_t find_local_client(service_t _service, instance_t _instance) const;
 

--- a/implementation/routing/src/routing_manager_base.cpp
+++ b/implementation/routing/src/routing_manager_base.cpp
@@ -162,6 +162,19 @@ void routing_manager_base::request_service(client_t _client,
                     << std::dec << _minor;
         }
     }
+    if (_instance == ANY_INSTANCE) {
+        auto its_infos = find_any_service(_service);
+        for (auto its_info : its_infos) {
+            if ((_major == its_info->get_major()
+                || DEFAULT_MAJOR == its_info->get_major()
+                || ANY_MAJOR == _major)
+                && (_minor <= its_info->get_minor()
+                        || DEFAULT_MINOR == its_info->get_minor()
+                        || _minor == ANY_MINOR)) {
+                its_info->add_client(_client);
+            }
+        }
+    }
 }
 
 void routing_manager_base::release_service(client_t _client,
@@ -889,6 +902,19 @@ std::shared_ptr<serviceinfo> routing_manager_base::find_service(
         }
     }
     return (its_info);
+}
+
+std::vector<std::shared_ptr<serviceinfo>> routing_manager_base::find_any_service(
+        service_t _service) const {
+    std::vector<std::shared_ptr<serviceinfo>> its_infos;
+    std::lock_guard<std::mutex> its_lock(services_mutex_);
+    auto found_service = services_.find(_service);
+    if (found_service != services_.end()) {
+        for (auto i : found_service->second) {
+            its_infos.push_back(i.second);
+        }
+    }
+    return (its_infos);
 }
 
 void routing_manager_base::clear_service_info(service_t _service, instance_t _instance,


### PR DESCRIPTION
This patch fixes a bug in vsomeip for clients requesting remote service of any instance. Without the patch, only exact matches are considered, unless the service is already known from a previous exact match (e.g. of another client).

The first part fixes the processing of service offers in discovery. This enables nodes searching for ANY instance to find services not yet known. The second part fixes the request_service() method by returning all instances currently known. This is needed if the request is made for an already known service.