### PR TITLE
Fix service instance any 3.1

### DIFF
--- a/implementation/routing/include/routing_manager_base.hpp
+++ b/implementation/routing/include/routing_manager_base.hpp
@@ -131,6 +131,7 @@ public:
     std::set<client_t> find_local_clients(service_t _service, instance_t _instance);
 
     std::shared_ptr<serviceinfo> find_service(service_t _service, instance_t _instance) const;
+    std::vector<std::shared_ptr<serviceinfo>> find_any_service(service_t _service) const;
 
     client_t find_local_client(service_t _service, instance_t _instance) const;
     client_t find_local_client_unlocked(service_t _service, instance_t _instance) const;

--- a/implementation/routing/src/routing_manager_base.cpp
+++ b/implementation/routing/src/routing_manager_base.cpp
@@ -163,6 +163,19 @@ void routing_manager_base::request_service(client_t _client,
                     << std::dec << _minor;
         }
     }
+    if (_instance == ANY_INSTANCE) {
+        auto its_infos = find_any_service(_service);
+        for (auto its_info : its_infos) {
+            if ((_major == its_info->get_major()
+                || DEFAULT_MAJOR == its_info->get_major()
+                || ANY_MAJOR == _major)
+                && (_minor <= its_info->get_minor()
+                        || DEFAULT_MINOR == its_info->get_minor()
+                        || _minor == ANY_MINOR)) {
+                its_info->add_client(_client);
+            }
+        }
+    }
 }
 
 void routing_manager_base::release_service(client_t _client,
@@ -909,6 +922,19 @@ std::shared_ptr<serviceinfo> routing_manager_base::find_service(
         }
     }
     return (its_info);
+}
+
+std::vector<std::shared_ptr<serviceinfo>> routing_manager_base::find_any_service(
+        service_t _service) const {
+    std::vector<std::shared_ptr<serviceinfo>> its_infos;
+    std::lock_guard<std::mutex> its_lock(services_mutex_);
+    auto found_service = services_.find(_service);
+    if (found_service != services_.end()) {
+        for (auto i : found_service->second) {
+            its_infos.push_back(i.second);
+        }
+    }
+    return (its_infos);
 }
 
 void routing_manager_base::clear_service_info(service_t _service, instance_t _instance,

--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -537,6 +537,24 @@ void routing_manager_impl::request_service(client_t _client, service_t _service,
             }
         }
     }
+    if (_instance == ANY_INSTANCE) {
+        auto its_infos = find_any_service(_service);
+        for (auto its_info : its_infos) {
+            if ((_major == its_info->get_major()
+                    || DEFAULT_MAJOR == its_info->get_major()
+                    || ANY_MAJOR == _major)
+                    && (_minor <= its_info->get_minor()
+                            || DEFAULT_MINOR == its_info->get_minor()
+                            || _minor == ANY_MINOR)) {
+                if(!its_info->is_local()) {
+                    requested_service_add(_client, _service, its_info->get_instance(), _major, _minor);
+                    its_info->add_client(_client);
+                    ep_mgr_impl_->find_or_create_remote_client(
+                            _service, its_info->get_instance());
+                }
+            }
+        }
+    }
 
     if (_client == get_client()) {
         stub_->create_local_receiver();
@@ -2285,6 +2303,10 @@ void routing_manager_impl::add_routing_info(
                 auto found_service = client_id.second.find(_service);
                 if (found_service != client_id.second.end()) {
                     auto found_instance = found_service->second.find(_instance);
+                    if (found_instance == found_service->second.end()) {
+                        // check if any instance was requested
+                        found_instance = found_service->second.find(ANY_INSTANCE);
+                    }
                     if (found_instance != found_service->second.end()) {
                         for (const auto &major_minor_pair : found_instance->second) {
                             if ((major_minor_pair.first == _major
@@ -2321,6 +2343,10 @@ void routing_manager_impl::add_routing_info(
             auto found_service = client_id.second.find(_service);
             if (found_service != client_id.second.end()) {
                 auto found_instance = found_service->second.find(_instance);
+                if (found_instance == found_service->second.end()) {
+                    // check if any instance was requested
+                    found_instance = found_service->second.find(ANY_INSTANCE);
+                }
                 if (found_instance != found_service->second.end()) {
                     for (const auto &major_minor_pair : found_instance->second) {
                         if ((major_minor_pair.first == _major
@@ -2379,8 +2405,12 @@ void routing_manager_impl::add_routing_info(
                 for (const auto &client_id : requested_services_) {
                     const auto found_service = client_id.second.find(_service);
                     if (found_service != client_id.second.end()) {
-                        const auto found_instance = found_service->second.find(
+                        auto found_instance = found_service->second.find(
                                 _instance);
+                        if (found_instance == found_service->second.end()) {
+                            // check if any instance was requested
+                            found_instance = found_service->second.find(ANY_INSTANCE);
+                        }
                         if (found_instance != found_service->second.end()) {
                             for (const auto &major_minor_pair : found_instance->second) {
                                 if ((major_minor_pair.first == _major
@@ -2421,6 +2451,10 @@ void routing_manager_impl::add_routing_info(
             auto found_service = client_id.second.find(_service);
             if (found_service != client_id.second.end()) {
                 auto found_instance = found_service->second.find(_instance);
+                if (found_instance == found_service->second.end()) {
+                    // check if any instance was requested
+                    found_instance = found_service->second.find(ANY_INSTANCE);
+                }
                 if (found_instance != found_service->second.end()) {
                     for (const auto &major_minor_pair : found_instance->second) {
                         if ((major_minor_pair.first == _major

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3153,6 +3153,95 @@ if(NOT ${TESTS_BAT})
 endif()
 
 ##############################################################################
+# any instance tests
+##############################################################################
+if(NOT ${TESTS_BAT})
+    set(TEST_ANY_INSTANCE_NAME any_instance_test)
+    set(TEST_ANY_INSTANCE_SERVICE ${TEST_ANY_INSTANCE_NAME}_service)
+    add_executable(${TEST_ANY_INSTANCE_SERVICE} any_instance_tests/${TEST_ANY_INSTANCE_NAME}_service.cpp)
+    target_link_libraries(${TEST_ANY_INSTANCE_SERVICE}
+        vsomeip3
+        ${Boost_LIBRARIES}
+        ${DL_LIBRARY}
+        ${TEST_LINK_LIBRARIES}
+    )
+
+    set(TEST_ANY_INSTANCE_CLIENT ${TEST_ANY_INSTANCE_NAME}_client)
+    add_executable(${TEST_ANY_INSTANCE_CLIENT} any_instance_tests/${TEST_ANY_INSTANCE_NAME}_client.cpp)
+    target_link_libraries(${TEST_ANY_INSTANCE_CLIENT}
+        vsomeip3
+        ${Boost_LIBRARIES}
+        ${DL_LIBRARY}
+        ${TEST_LINK_LIBRARIES}
+    )
+
+    set(TEST_ANY_INSTANCE_AVAILABILITY_CHECKER ${TEST_ANY_INSTANCE_NAME}_client_availability_checker)
+    add_executable(${TEST_ANY_INSTANCE_AVAILABILITY_CHECKER} any_instance_tests/${TEST_ANY_INSTANCE_NAME}_client_availability_checker.cpp)
+    target_link_libraries(${TEST_ANY_INSTANCE_AVAILABILITY_CHECKER}
+        vsomeip3
+        ${Boost_LIBRARIES}
+        ${DL_LIBRARY}
+        ${TEST_LINK_LIBRARIES}
+    )
+
+    set(TEST_ANY_INSTANCE_MASTER_CONFIG_FILE ${TEST_ANY_INSTANCE_NAME}_master.json)
+    configure_file(
+        ${PROJECT_SOURCE_DIR}/test/any_instance_tests/conf/${TEST_ANY_INSTANCE_MASTER_CONFIG_FILE}.in
+        ${PROJECT_SOURCE_DIR}/test/any_instance_tests/${TEST_ANY_INSTANCE_MASTER_CONFIG_FILE}
+        @ONLY)
+    copy_to_builddir(
+        ${PROJECT_SOURCE_DIR}/test/any_instance_tests/${TEST_ANY_INSTANCE_MASTER_CONFIG_FILE}
+        ${PROJECT_BINARY_DIR}/test/${TEST_ANY_INSTANCE_MASTER_CONFIG_FILE}
+        ${TEST_ANY_INSTANCE_SERVICE}
+    )
+
+    set(TEST_ANY_INSTANCE_MASTER_TCP_CONFIG_FILE ${TEST_ANY_INSTANCE_NAME}_master_tcp.json)
+    configure_file(
+        ${PROJECT_SOURCE_DIR}/test/any_instance_tests/conf/${TEST_ANY_INSTANCE_MASTER_TCP_CONFIG_FILE}.in
+        ${PROJECT_SOURCE_DIR}/test/any_instance_tests/${TEST_ANY_INSTANCE_MASTER_TCP_CONFIG_FILE}
+        @ONLY)
+    copy_to_builddir(
+        ${PROJECT_SOURCE_DIR}/test/any_instance_tests/${TEST_ANY_INSTANCE_MASTER_TCP_CONFIG_FILE}
+        ${PROJECT_BINARY_DIR}/test/${TEST_ANY_INSTANCE_MASTER_TCP_CONFIG_FILE}
+        ${TEST_ANY_INSTANCE_SERVICE}
+    )
+
+    set(TEST_ANY_INSTANCE_MASTER_UDP_CONFIG_FILE ${TEST_ANY_INSTANCE_NAME}_master_udp.json)
+    configure_file(
+        ${PROJECT_SOURCE_DIR}/test/any_instance_tests/conf/${TEST_ANY_INSTANCE_MASTER_UDP_CONFIG_FILE}.in
+        ${PROJECT_SOURCE_DIR}/test/any_instance_tests/${TEST_ANY_INSTANCE_MASTER_UDP_CONFIG_FILE}
+        @ONLY)
+    copy_to_builddir(
+        ${PROJECT_SOURCE_DIR}/test/any_instance_tests/${TEST_ANY_INSTANCE_MASTER_UDP_CONFIG_FILE}
+        ${PROJECT_BINARY_DIR}/test/${TEST_ANY_INSTANCE_MASTER_UDP_CONFIG_FILE}
+        ${TEST_ANY_INSTANCE_SERVICE}
+    )
+
+    set(TEST_ANY_INSTANCE_SLAVE_CONFIG_FILE ${TEST_ANY_INSTANCE_NAME}_slave.json)
+    configure_file(
+        ${PROJECT_SOURCE_DIR}/test/any_instance_tests/conf/${TEST_ANY_INSTANCE_SLAVE_CONFIG_FILE}.in
+        ${PROJECT_SOURCE_DIR}/test/any_instance_tests/${TEST_ANY_INSTANCE_SLAVE_CONFIG_FILE}
+        @ONLY)
+    copy_to_builddir(
+        ${PROJECT_SOURCE_DIR}/test/any_instance_tests/${TEST_ANY_INSTANCE_SLAVE_CONFIG_FILE}
+        ${PROJECT_BINARY_DIR}/test/${TEST_ANY_INSTANCE_SLAVE_CONFIG_FILE}
+        ${TEST_ANY_INSTANCE_SERVICE}
+    )
+
+    # Copy starter scripts for external test to $BUILDDIR/test
+    set(TEST_ANY_INSTANCE_MASTER_STARTER ${TEST_ANY_INSTANCE_NAME}_master_starter.sh)
+    copy_to_builddir(${PROJECT_SOURCE_DIR}/test/any_instance_tests/${TEST_ANY_INSTANCE_MASTER_STARTER}
+        ${PROJECT_BINARY_DIR}/test/${TEST_ANY_INSTANCE_MASTER_STARTER}
+        ${TEST_ANY_INSTANCE_SERVICE}
+    )
+    set(TEST_ANY_INSTANCE_SLAVE_STARTER ${TEST_ANY_INSTANCE_NAME}_slave_starter.sh)
+    copy_to_builddir(${PROJECT_SOURCE_DIR}/test/any_instance_tests/${TEST_ANY_INSTANCE_SLAVE_STARTER}
+        ${PROJECT_BINARY_DIR}/test/${TEST_ANY_INSTANCE_SLAVE_STARTER}
+        ${TEST_ANY_INSTANCE_SERVICE}
+    )
+endif()
+
+##############################################################################
 # Add for every test a dependency to gtest
 ##############################################################################
 
@@ -3309,6 +3398,9 @@ if(NOT ${TESTS_BAT})
     endif()
     add_dependencies(build_tests ${TEST_SUSPEND_RESUME_CLIENT})
     add_dependencies(build_tests ${TEST_SUSPEND_RESUME_SERVICE})
+    add_dependencies(build_tests ${TEST_ANY_INSTANCE_SERVICE})
+    add_dependencies(build_tests ${TEST_ANY_INSTANCE_CLIENT})
+    add_dependencies(build_tests ${TEST_ANY_INSTANCE_AVAILABILITY_CHECKER})
 else()
     add_dependencies(build_tests ${TEST_LOCAL_ROUTING_SERVICE})
     add_dependencies(build_tests ${TEST_LOCAL_ROUTING_CLIENT})
@@ -3830,6 +3922,18 @@ if(NOT ${TESTS_BAT})
         COMMAND ${PROJECT_BINARY_DIR}/test/${TEST_SUSPEND_RESUME_MASTER_START_SCRIPT} SERVICE
     )
     set_tests_properties(${TEST_SUSPEND_RESUME_NAME}_initial PROPERTIES TIMEOUT 80)
+
+    add_test(NAME ${TEST_ANY_INSTANCE_NAME}
+        COMMAND ${PROJECT_BINARY_DIR}/test/${TEST_ANY_INSTANCE_MASTER_STARTER}
+    )
+
+    add_test(NAME ${TEST_ANY_INSTANCE_NAME}_tcp
+        COMMAND ${PROJECT_BINARY_DIR}/test/${TEST_ANY_INSTANCE_MASTER_STARTER} TCP
+    )
+
+    add_test(NAME ${TEST_ANY_INSTANCE_NAME}_udp
+        COMMAND ${PROJECT_BINARY_DIR}/test/${TEST_ANY_INSTANCE_MASTER_STARTER} UDP
+    )
 
 else()
     # Routing tests

--- a/test/any_instance_tests/any_instance_test_client.cpp
+++ b/test/any_instance_tests/any_instance_test_client.cpp
@@ -1,0 +1,253 @@
+// Copyright (C) 2014-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <thread>
+#include <vsomeip/internal/logger.hpp>
+#include <vsomeip/vsomeip.hpp>
+
+#ifdef ANDROID
+#include "../../configuration/include/internal_android.hpp"
+#else
+#include "../../configuration/include/internal.hpp"
+#endif // ANDROID
+
+#include "any_instance_test_globals.hpp"
+
+enum operation_mode_e { SUBSCRIBE,
+    METHODCALL };
+
+class any_instance_test_client {
+public:
+    any_instance_test_client(
+        std::array<any_instance_test::service_info, NUMBER_SERVICES>
+            _service_infos,
+        vsomeip::service_t _service_id,
+        struct any_instance_test::service_info _client,
+        bool _use_tcp)
+        : service_infos_(_service_infos)
+        , service_id_(_service_id)
+        , client_(_client)
+        , app_(vsomeip::runtime::get()->create_application(
+              "any_instance_client"))
+        , use_tcp_(_use_tcp)
+        , wait_until_registered_(true)
+        , wait_for_stop_(true)
+        , send_thread_(std::bind(&any_instance_test_client::send, this))
+        , offer_thread_(std::bind(&any_instance_test_client::run, this))
+    {
+        for (int i = 0; i < NUMBER_SERVICES; i++) {
+            service_available_[i] = false;
+        }
+        if (!app_->init()) {
+            ADD_FAILURE() << "Couldn't initialize application";
+            return;
+        }
+        app_->register_state_handler(std::bind(&any_instance_test_client::on_state,
+            this, std::placeholders::_1));
+
+        app_->register_message_handler(
+            vsomeip::ANY_SERVICE, vsomeip::ANY_INSTANCE, vsomeip::ANY_METHOD,
+            std::bind(&any_instance_test_client::on_message, this,
+                std::placeholders::_1));
+
+        // register availability for any instance of _service_id
+        app_->register_availability_handler(
+            _service_id, vsomeip::ANY_INSTANCE,
+            std::bind(&any_instance_test_client::on_availability, this,
+                std::placeholders::_1, std::placeholders::_2,
+                std::placeholders::_3));
+        app_->request_service(_service_id, vsomeip::ANY_INSTANCE);
+
+        app_->start();
+    }
+
+    ~any_instance_test_client()
+    {
+        send_thread_.join();
+        offer_thread_.join();
+    }
+
+    void on_state(vsomeip::state_type_e _state)
+    {
+        VSOMEIP_INFO << "Application " << app_->get_name() << " is "
+                     << (_state == vsomeip::state_type_e::ST_REGISTERED
+                                ? "registered."
+                                : "deregistered.");
+
+        if (_state == vsomeip::state_type_e::ST_REGISTERED) {
+            std::lock_guard<std::mutex> its_lock(mutex_);
+            wait_until_registered_ = false;
+            condition_.notify_one();
+        }
+    }
+
+    void on_availability(vsomeip::service_t _service,
+        vsomeip::instance_t _instance, bool _is_available)
+    {
+        VSOMEIP_INFO << "Service [" << std::setw(4) << std::setfill('0') << std::hex
+                     << _service << "." << _instance << "] is "
+                     << (_is_available ? "available" : "not available") << ".";
+        std::lock_guard<std::mutex> its_lock(mutex_);
+        for (int i = 0; i < NUMBER_SERVICES; i++) {
+            if (_instance == service_infos_[i].instance_id) {
+                service_available_[i] = _is_available;
+            }
+        }
+        condition_.notify_one();
+    }
+
+    void on_message(const std::shared_ptr<vsomeip::message>& _message)
+    {
+        if (_message->get_message_type() == vsomeip::message_type_e::MT_RESPONSE) {
+            on_response(_message);
+        }
+    }
+
+    void on_response(const std::shared_ptr<vsomeip::message>& _message)
+    {
+        std::unique_lock<std::mutex> its_lock(mutex_);
+        EXPECT_EQ(service_infos_[current_service_].service_id,
+            _message->get_service());
+        EXPECT_EQ(service_infos_[current_service_].method_id,
+            _message->get_method());
+        EXPECT_EQ(service_infos_[current_service_].instance_id,
+            _message->get_instance());
+        if (service_infos_[current_service_].service_id == _message->get_service() && service_infos_[current_service_].instance_id == _message->get_instance() && service_infos_[current_service_].instance_id == _message->get_instance()) {
+            response_received_ = true;
+        }
+        condition_.notify_one();
+    }
+
+    void offer() { app_->offer_service(client_.service_id, client_.instance_id); }
+
+    void run()
+    {
+        VSOMEIP_DEBUG << "[" << std::setw(4) << std::setfill('0') << std::hex
+                      << client_.service_id << "] Running";
+        {
+            std::unique_lock<std::mutex> its_lock(mutex_);
+            while (wait_until_registered_) {
+                condition_.wait(its_lock);
+            }
+
+            VSOMEIP_DEBUG << "[" << std::setw(4) << std::setfill('0') << std::hex
+                          << client_.service_id << "] Offering";
+            offer();
+            condition_.notify_one();
+        }
+
+        VSOMEIP_DEBUG << "Running";
+        while (wait_for_stop_) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        VSOMEIP_DEBUG << "Stop running";
+    }
+
+    void send()
+    {
+        {
+            std::unique_lock<std::mutex> its_lock(mutex_);
+            while (wait_until_registered_) {
+                condition_.wait(its_lock);
+            }
+
+            for (current_service_ = 0; current_service_ < NUMBER_SERVICES;
+                 current_service_++) {
+                VSOMEIP_INFO << "Waiting for availability of service "
+                             << current_service_;
+                while (service_available_[current_service_] == false) {
+                    condition_.wait(its_lock);
+                }
+                std::shared_ptr<vsomeip::message> its_req = vsomeip::runtime::get()->create_request();
+                its_req->set_service(service_infos_[current_service_].service_id);
+                its_req->set_instance(service_infos_[current_service_].instance_id);
+                its_req->set_method(service_infos_[current_service_].method_id);
+                its_req->set_reliable(use_tcp_);
+                response_received_ = false;
+                app_->send(its_req);
+                VSOMEIP_INFO << "Waiting for response of service " << current_service_;
+                while (response_received_ == false) {
+                    condition_.wait(its_lock);
+                }
+            }
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+        VSOMEIP_INFO << "going down.";
+        wait_for_stop_ = false;
+        app_->stop_offer_service(client_.service_id, client_.instance_id);
+        app_->clear_all_handler();
+        app_->stop();
+    }
+
+private:
+    std::array<any_instance_test::service_info, NUMBER_SERVICES> service_infos_;
+    vsomeip::service_t service_id_;
+    struct any_instance_test::service_info client_;
+    operation_mode_e operation_mode_;
+    std::shared_ptr<vsomeip::application> app_;
+    bool use_tcp_;
+
+    bool wait_until_registered_;
+    bool service_available_[NUMBER_SERVICES];
+    bool response_received_;
+    std::uint32_t current_service_;
+    std::mutex mutex_;
+    std::condition_variable condition_;
+
+    bool wait_for_stop_;
+    std::mutex stop_mutex_;
+    std::condition_variable stop_condition_;
+
+    // std::thread stop_thread_;
+    std::thread send_thread_;
+    std::thread offer_thread_;
+};
+
+static bool use_tcp;
+
+TEST(someip_any_instance_test, subscribe_or_call_method_at_service)
+{
+    any_instance_test_client its_sample(any_instance_test::service_infos,
+        any_instance_test::service_id,
+        any_instance_test::client,
+        use_tcp);
+}
+
+#ifndef _WIN32
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    if(argc < 2) {
+        std::cerr << "Please specify a method type of the service, like: " << argv[0] << " UDP" << std::endl;
+        std::cerr << "Valid method types include:" << std::endl;
+        std::cerr << "[UDP, TCP]" << std::endl;
+        return 1;
+    }
+
+    if(std::string("TCP") == std::string(argv[1])) {
+        use_tcp = true;
+    } else if(std::string("UDP") == std::string(argv[1])) {
+        use_tcp = false;
+    } else {
+        std::cerr << "Wrong method call type passed, exiting" << std::endl;
+        std::cerr << "Valid method call types include:" << std::endl;
+        std::cerr << "[UDP, TCP]" << std::endl;
+        return 1;
+    }
+
+    return RUN_ALL_TESTS();
+}
+#endif

--- a/test/any_instance_tests/any_instance_test_client_availability_checker.cpp
+++ b/test/any_instance_tests/any_instance_test_client_availability_checker.cpp
@@ -1,0 +1,122 @@
+// Copyright (C) 2014-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <chrono>
+#include <condition_variable>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <thread>
+#include <vsomeip/internal/logger.hpp>
+#include <vsomeip/vsomeip.hpp>
+
+#include "any_instance_test_globals.hpp"
+
+class any_instance_test_client_availability_checker {
+public:
+    any_instance_test_client_availability_checker(
+        struct any_instance_test::service_info _service_info)
+        : service_info_(_service_info)
+        , app_(vsomeip::runtime::get()->create_application("routingmanagerd"))
+        , wait_until_registered_(true)
+        , wait_for_stop_(true)
+        , stop_thread_(std::bind(
+              &any_instance_test_client_availability_checker::wait_for_stop,
+              this))
+    {
+        if (!app_->init()) {
+            ADD_FAILURE() << "Couldn't initialize application";
+            return;
+        }
+        app_->register_state_handler(
+            std::bind(&any_instance_test_client_availability_checker::on_state,
+                this, std::placeholders::_1));
+
+        // register availability for all other services and request their event.
+        app_->register_availability_handler(
+            service_info_.service_id, service_info_.instance_id,
+            std::bind(
+                &any_instance_test_client_availability_checker::on_availability,
+                this, std::placeholders::_1, std::placeholders::_2,
+                std::placeholders::_3));
+        app_->request_service(service_info_.service_id, service_info_.instance_id);
+
+        app_->start();
+    }
+
+    ~any_instance_test_client_availability_checker() { stop_thread_.join(); }
+
+    void on_state(vsomeip::state_type_e _state)
+    {
+        VSOMEIP_INFO << "Application " << app_->get_name() << " is "
+                     << (_state == vsomeip::state_type_e::ST_REGISTERED
+                                ? "registered."
+                                : "deregistered.");
+
+        if (_state == vsomeip::state_type_e::ST_REGISTERED) {
+            std::lock_guard<std::mutex> its_lock(mutex_);
+            wait_until_registered_ = false;
+            condition_.notify_one();
+        }
+    }
+
+    void on_availability(vsomeip::service_t _service,
+        vsomeip::instance_t _instance, bool _is_available)
+    {
+        VSOMEIP_INFO << "Service [" << std::setw(4) << std::setfill('0') << std::hex
+                     << _service << "." << _instance << "] is "
+                     << (_is_available ? "available" : "not available") << ".";
+        std::lock_guard<std::mutex> its_lock(mutex_);
+        if (_is_available) {
+            wait_for_stop_ = false;
+            stop_condition_.notify_one();
+        }
+    }
+
+    void wait_for_stop()
+    {
+        VSOMEIP_INFO
+            << "any_instance_test_service_availability_check wait_for_stop() ";
+        std::unique_lock<std::mutex> its_lock(stop_mutex_);
+        while (wait_for_stop_) {
+            stop_condition_.wait(its_lock);
+        }
+        VSOMEIP_INFO
+            << "any_instance_test_service_availability_check is going down ";
+        app_->clear_all_handler();
+        app_->stop();
+    }
+
+private:
+    struct any_instance_test::service_info service_info_;
+    std::shared_ptr<vsomeip::application> app_;
+
+    bool wait_until_registered_;
+    std::mutex mutex_;
+    std::condition_variable condition_;
+
+    bool wait_for_stop_;
+    std::mutex stop_mutex_;
+    std::condition_variable stop_condition_;
+    std::thread stop_thread_;
+};
+
+TEST(someip_any_instance_test, wait_for_availability_and_exit)
+{
+    any_instance_test_client_availability_checker its_sample(
+        any_instance_test::client);
+}
+
+#ifndef _WIN32
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+#endif

--- a/test/any_instance_tests/any_instance_test_globals.hpp
+++ b/test/any_instance_tests/any_instance_test_globals.hpp
@@ -1,0 +1,30 @@
+// Copyright (C) 2014-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef ANY_INSTANCE_GLOBALS_HPP_
+#define ANY_INSTANCE_GLOBALS_HPP_
+
+namespace any_instance_test {
+
+#define NUMBER_SERVICES 3
+
+struct service_info {
+    vsomeip::service_t service_id;
+    vsomeip::instance_t instance_id;
+    vsomeip::method_t method_id;
+};
+
+const vsomeip::service_t service_id = 0x1111;
+
+struct service_info client = { 0x9999, 0x1, 0x9999 };
+
+static constexpr std::array<service_info, NUMBER_SERVICES> service_infos = {{
+    { 0x1111, 0x1, 0x1111},
+    { 0x1111, 0x2, 0x1111},
+    { 0x1111, 0x3, 0x1111}
+}};
+}
+
+#endif /* ANY_INSTANCE_GLOBALS_HPP_ */

--- a/test/any_instance_tests/any_instance_test_master_starter.sh
+++ b/test/any_instance_tests/any_instance_test_master_starter.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+# Copyright (C) 2015-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Purpose: This script is needed to start the services with
+# one command. This is necessary as ctest - which is used to run the
+# tests - isn't able to start multiple binaries for one testcase. Therefore
+# the testcase simply executes this script. This script then runs the services
+# and checks that all exit successfully.
+
+FAIL=0
+# Find multiple instances that are already running
+
+# Array for service pids
+SERVICE_PIDS=()
+NUMBER_SERVICES=3
+if [[ $# -gt 0 && $1 == "TCP" ]]; then
+    export VSOMEIP_CONFIGURATION=any_instance_test_master_tcp.json
+    RELIABILITY_TYPES=($1)
+elif [[ $# -gt 0 && $1 == "UDP" ]]; then
+    export VSOMEIP_CONFIGURATION=any_instance_test_master_udp.json
+    RELIABILITY_TYPES=($1)
+else
+    # service provides TCP and UDP, client tests TCP, then UDP
+    export VSOMEIP_CONFIGURATION=any_instance_test_master.json
+    RELIABILITY_TYPES=(TCP UDP)
+fi
+for RELIABILITY_TYPE in ${RELIABILITY_TYPES[*]}
+do
+    # Start daemon
+    ../examples/routingmanagerd/./routingmanagerd &
+    PID_VSOMEIPD=$!
+    # Start the services
+    for i in $(seq 0 $((NUMBER_SERVICES - 1)))
+    do
+        ./any_instance_test_service $i &
+        SERVICE_PIDS+=($!)
+    done
+
+    # Start the client. It will send find_service calls that should be responded to
+    # by our service.
+
+    if [ ! -z "$USE_LXC_TEST" ]; then
+        echo "starting client test on slave LXC any_instance_test_slave_starter.sh"
+        ssh -tt -i $SANDBOX_ROOT_DIR/commonapi_main/lxc-config/.ssh/mgc_lxc/rsa_key_file.pub -o StrictHostKeyChecking=no root@$LXC_TEST_SLAVE_IP "bash -ci \"set -m; cd \\\$SANDBOX_TARGET_DIR/vsomeip_lib/test; ./any_instance_test_slave_starter.sh $RELIABILITY_TYPE\"" &
+    elif [ ! -z "$USE_DOCKER" ]; then
+        docker exec $DOCKER_IMAGE sh -c "cd $DOCKER_TESTS; ./any_instance_test_slave_starter.sh $RELIABILITY_TYPE" &
+    elif [ ! -z "$JENKINS" ]; then
+        ssh -tt -i $PRV_KEY -o StrictHostKeyChecking=no jenkins@$IP_SLAVE "bash -ci \"set -m; cd $WS_ROOT/build/test ; ./any_instance_test_slave_starter.sh $RELIABILITY_TYPE\" >> $WS_ROOT/slave_test_output 2>&1" &
+    else
+    cat <<End-of-message
+*******************************************************************************
+*******************************************************************************
+** Please now run:
+** any_instance_test_slave_starter.sh $RELIABILITY_TYPE
+** from an external host to successfully complete this test.
+**
+** You probably will need to adapt the 'unicast' settings in
+** any_instance_test_master.json and
+** any_instance_test_slave.json to your personal setup.
+*******************************************************************************
+*******************************************************************************
+End-of-message
+    fi
+
+    # Wait until all services are finished
+    for job in ${SERVICE_PIDS[*]}
+    do
+        # Fail gets incremented if a client exits with a non-zero exit code
+        echo "waiting for $job"
+        wait $job || FAIL=$(($FAIL+1))
+    done
+
+    # Kill the routing manager
+    kill $PID_VSOMEIPD
+    sleep 1
+
+    # Now run the client first and then start the service
+
+    if [ ! -z "$USE_LXC_TEST" ]; then
+        echo "starting client test on slave LXC any_instance_test_slave_starter.sh"
+        ssh -tt -i $SANDBOX_ROOT_DIR/commonapi_main/lxc-config/.ssh/mgc_lxc/rsa_key_file.pub -o StrictHostKeyChecking=no root@$LXC_TEST_SLAVE_IP "bash -ci \"set -m; cd \\\$SANDBOX_TARGET_DIR/vsomeip_lib/test; ./any_instance_test_slave_starter.sh\"" &
+    elif [ ! -z "$USE_DOCKER" ]; then
+        docker exec $DOCKER_IMAGE sh -c "cd $DOCKER_TESTS; ./any_instance_test_slave_starter.sh" &
+    elif [ ! -z "$JENKINS" ]; then
+        ssh -tt -i $PRV_KEY -o StrictHostKeyChecking=no jenkins@$IP_SLAVE "bash -ci \"set -m; cd $WS_ROOT/build/test ; ./any_instance_test_slave_starter.sh\" >> $WS_ROOT/slave_test_output 2>&1" &
+    else
+    cat <<End-of-message
+*******************************************************************************
+*******************************************************************************
+** Please now run:
+** any_instance_test_slave_starter.sh $RELIABILITY_TYPE
+** from an external host to successfully complete this test.
+**
+** You probably will need to adapt the 'unicast' settings in
+** any_instance_test_master.json and
+** any_instance_test_slave.json to your personal setup.
+*******************************************************************************
+*******************************************************************************
+End-of-message
+    fi
+
+    # Wait until the client on the remote node was started
+    echo "WAITING FOR CLIENT AVAILABILITY"
+
+    ./any_instance_test_client_availability_checker
+    PID_AVAILABILITY_CHECKER=$!
+
+    sleep 1
+
+    wait $PID_AVAILABILITY_CHECKER
+    echo "CLIENT IS AVAILABLE NOW"
+
+    # Wait until the client has send all find_service calls. we want it to find
+    # the service from the multicast discovery for the next test case
+    sleep 5
+
+    # Array for service pids
+    SERVICE_PIDS=()
+    NUMBER_SERVICES=3
+    export VSOMEIP_CONFIGURATION=any_instance_test_master.json
+    # Start daemon
+    ../examples/routingmanagerd/./routingmanagerd &
+    PID_VSOMEIPD=$!
+    # Start the services
+    for i in $(seq 0 $((NUMBER_SERVICES - 1)))
+    do
+        ./any_instance_test_service $i &
+        SERVICE_PIDS+=($!)
+    done
+
+    # Wait until all services are finished
+    for job in ${SERVICE_PIDS[*]}
+    do
+        # Fail gets incremented if a client exits with a non-zero exit code
+        echo "waiting for $job"
+        wait $job || FAIL=$(($FAIL+1))
+    done
+
+    # Kill the routing manager
+    kill $PID_VSOMEIPD
+    sleep 1
+done
+
+# Check if everything went well
+if [ $FAIL -eq 0 ]
+then
+    exit 0
+else
+    exit 1
+fi

--- a/test/any_instance_tests/any_instance_test_service.cpp
+++ b/test/any_instance_tests/any_instance_test_service.cpp
@@ -1,0 +1,146 @@
+// Copyright (C) 2014-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <condition_variable>
+#include <iomanip>
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <thread>
+#include <vsomeip/internal/logger.hpp>
+#include <vsomeip/vsomeip.hpp>
+
+#include "any_instance_test_globals.hpp"
+
+static unsigned long service_number;
+
+class any_instance_test_service {
+public:
+    any_instance_test_service(
+        struct any_instance_test::service_info _service_info)
+        : service_info_(_service_info)
+        , app_(vsomeip::runtime::get()->create_application())
+        , counter_(0)
+        , wait_until_registered_(true)
+        , shutdown_method_called_(false)
+        , offer_thread_(std::bind(&any_instance_test_service::run, this))
+    {
+        if (!app_->init()) {
+            ADD_FAILURE() << "Couldn't initialize application";
+            return;
+        }
+        app_->register_state_handler(std::bind(&any_instance_test_service::on_state,
+            this, std::placeholders::_1));
+
+        app_->register_message_handler(
+            service_info_.service_id, service_info_.instance_id,
+            service_info_.method_id,
+            std::bind(&any_instance_test_service::on_request, this,
+                std::placeholders::_1));
+
+        app_->start();
+    }
+
+    ~any_instance_test_service() { offer_thread_.join(); }
+
+    void offer()
+    {
+        app_->offer_service(service_info_.service_id, service_info_.instance_id);
+    }
+
+    void on_state(vsomeip::state_type_e _state)
+    {
+        VSOMEIP_INFO << "Application " << app_->get_name() << " is "
+                     << (_state == vsomeip::state_type_e::ST_REGISTERED
+                                ? "registered."
+                                : "deregistered.");
+
+        if (_state == vsomeip::state_type_e::ST_REGISTERED) {
+            std::lock_guard<std::mutex> its_lock(mutex_);
+            wait_until_registered_ = false;
+            condition_.notify_one();
+        }
+    }
+
+    void on_request(const std::shared_ptr<vsomeip::message>& _message)
+    {
+        app_->send(vsomeip::runtime::get()->create_response(_message));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        VSOMEIP_WARNING
+            << "************************************************************";
+        VSOMEIP_WARNING << "Shutdown method called -> going down!";
+        VSOMEIP_WARNING
+            << "************************************************************";
+        shutdown_method_called_ = true;
+        app_->stop_offer_service(service_info_.service_id,
+            service_info_.instance_id);
+        app_->clear_all_handler();
+        app_->stop();
+    }
+
+    void
+    on_shutdown_method_called(const std::shared_ptr<vsomeip::message>& _message)
+    {
+        (void)_message;
+    }
+
+    void run()
+    {
+        VSOMEIP_DEBUG << "[" << std::setw(4) << std::setfill('0') << std::hex
+                      << service_info_.service_id << "] Running";
+        std::unique_lock<std::mutex> its_lock(mutex_);
+        while (wait_until_registered_) {
+            condition_.wait(its_lock);
+        }
+
+        VSOMEIP_DEBUG << "[" << std::setw(4) << std::setfill('0') << std::hex
+                      << service_info_.service_id << "] Offering";
+        offer();
+
+        while (!shutdown_method_called_) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+    }
+
+private:
+    struct any_instance_test::service_info service_info_;
+    std::shared_ptr<vsomeip::application> app_;
+    std::uint32_t counter_;
+
+    bool wait_until_registered_;
+    std::mutex mutex_;
+    std::condition_variable condition_;
+    std::atomic<bool> shutdown_method_called_;
+    std::thread offer_thread_;
+};
+
+TEST(someip_any_instance_test, offer_any_service)
+{
+    any_instance_test_service its_sample(
+        any_instance_test::service_infos[service_number]);
+}
+
+#ifndef _WIN32
+int main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    if (argc < 2) {
+        std::cerr << "Please specify a service number, like: " << argv[0] << " 2"
+                  << std::endl;
+        return 1;
+    }
+    service_number = std::stoul(std::string(argv[1]), nullptr);
+    if (service_number > NUMBER_SERVICES) {
+        std::cerr << "Only services 0-" << NUMBER_SERVICES - 1 << " are configured"
+                  << std::endl;
+    }
+    return RUN_ALL_TESTS();
+}
+#endif

--- a/test/any_instance_tests/any_instance_test_slave_starter.sh
+++ b/test/any_instance_tests/any_instance_test_slave_starter.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# Copyright (C) 2015-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Purpose: This script is needed to start the services with
+# one command. This is necessary as ctest - which is used to run the
+# tests - isn't able to start multiple binaries for one testcase. Therefore
+# the testcase simply executes this script. This script then runs the services
+# and checks that all exit successfully.
+
+if [ $# -lt 1 ]
+then
+    echo "Please pass a reliability type to this script."
+    echo "For example: $0 UDP"
+    echo "             $0 TCP"
+    exit 1
+fi
+
+FAIL=0
+# Find multiple instances that are already running
+
+export VSOMEIP_CONFIGURATION=any_instance_test_slave.json
+# start client
+./any_instance_test_client $1 &
+PID_CLIENT=$!
+
+# Fail gets incremented if a client exits with a non-zero exit code
+wait $PID_CLIENT || FAIL=$(($FAIL+1))
+
+# Check if everything went well
+if [ $FAIL -eq 0 ]
+then
+    exit 0
+else
+    exit 1
+fi

--- a/test/any_instance_tests/conf/any_instance_test_master.json.in
+++ b/test/any_instance_tests/conf/any_instance_test_master.json.in
@@ -1,0 +1,81 @@
+{
+    "unicast":"@TEST_IP_MASTER@",
+    "logging":
+    {
+        "level":"info",
+        "console":"true",
+        "file":
+        {
+            "enable":"false",
+            "path":"/tmp/vsomeip.log"
+        },
+        "dlt":"false"
+    },
+    "applications":
+    [
+        {
+            "name":"any_instance_service_1",
+            "id":"0x1111"
+        },
+        {
+            "name":"any_instance_service_2",
+            "id":"0x2222"
+        },
+        {
+            "name":"any_instance_service_3",
+            "id":"0x3333"
+        }
+    ],
+    "services":
+    [
+        {
+            "service":"0x1111",
+            "instance":"0x0001",
+            "unreliable":"30001",
+            "reliable":
+            {
+                "port":"40001",
+                "enable-magic-cookies":"false"
+            }
+        },
+        {
+            "service":"0x1111",
+            "instance":"0x0002",
+            "unreliable":"30002",
+            "reliable":
+            {
+                "port":"40002",
+                "enable-magic-cookies":"false"
+            }
+        },
+        {
+            "service":"0x1111",
+            "instance":"0x0003",
+            "unreliable":"30003",
+            "reliable":
+            {
+                "port":"40003",
+                "enable-magic-cookies":"false"
+            }
+        },
+        {
+            "service":"0x8888",
+            "instance":"0x0001",
+            "unreliable":"8888"
+        }
+    ],
+    "routing":"routingmanagerd",
+    "service-discovery":
+    {
+        "enable":"true",
+        "multicast":"224.0.0.1",
+        "port":"30490",
+        "protocol":"udp",
+        "initial_delay_min" : "10",
+        "initial_delay_max" : "10",
+        "repetitions_base_delay" : "30",
+        "repetitions_max" : "3",
+        "cyclic_offer_delay" : "1000",
+        "ttl" : "3"
+    }
+}

--- a/test/any_instance_tests/conf/any_instance_test_master_tcp.json.in
+++ b/test/any_instance_tests/conf/any_instance_test_master_tcp.json.in
@@ -1,0 +1,78 @@
+{
+    "unicast":"@TEST_IP_MASTER@",
+    "logging":
+    {
+        "level":"info",
+        "console":"true",
+        "file":
+        {
+            "enable":"false",
+            "path":"/tmp/vsomeip.log"
+        },
+        "dlt":"false"
+    },
+    "applications":
+    [
+        {
+            "name":"any_instance_service_1",
+            "id":"0x1111"
+        },
+        {
+            "name":"any_instance_service_2",
+            "id":"0x2222"
+        },
+        {
+            "name":"any_instance_service_3",
+            "id":"0x3333"
+        }
+    ],
+    "services":
+    [
+        {
+            "service":"0x1111",
+            "instance":"0x0001",
+            "reliable":
+            {
+                "port":"40001",
+                "enable-magic-cookies":"false"
+            }
+        },
+        {
+            "service":"0x1111",
+            "instance":"0x0002",
+            "reliable":
+            {
+                "port":"40002",
+                "enable-magic-cookies":"false"
+            }
+        },
+        {
+            "service":"0x1111",
+            "instance":"0x0003",
+            "reliable":
+            {
+                "port":"40003",
+                "enable-magic-cookies":"false"
+            }
+        },
+        {
+            "service":"0x8888",
+            "instance":"0x0001",
+            "unreliable":"8888"
+        }
+    ],
+    "routing":"routingmanagerd",
+    "service-discovery":
+    {
+        "enable":"true",
+        "multicast":"224.0.0.1",
+        "port":"30490",
+        "protocol":"udp",
+        "initial_delay_min" : "10",
+        "initial_delay_max" : "10",
+        "repetitions_base_delay" : "30",
+        "repetitions_max" : "3",
+        "cyclic_offer_delay" : "1000",
+        "ttl" : "3"
+    }
+}

--- a/test/any_instance_tests/conf/any_instance_test_master_udp.json.in
+++ b/test/any_instance_tests/conf/any_instance_test_master_udp.json.in
@@ -1,0 +1,66 @@
+{
+    "unicast":"@TEST_IP_MASTER@",
+    "logging":
+    {
+        "level":"info",
+        "console":"true",
+        "file":
+        {
+            "enable":"false",
+            "path":"/tmp/vsomeip.log"
+        },
+        "dlt":"false"
+    },
+    "applications":
+    [
+        {
+            "name":"any_instance_service_1",
+            "id":"0x1111"
+        },
+        {
+            "name":"any_instance_service_2",
+            "id":"0x2222"
+        },
+        {
+            "name":"any_instance_service_3",
+            "id":"0x3333"
+        }
+    ],
+    "services":
+    [
+        {
+            "service":"0x1111",
+            "instance":"0x0001",
+            "unreliable":"30001"
+        },
+        {
+            "service":"0x1111",
+            "instance":"0x0002",
+            "unreliable":"30002"
+        },
+        {
+            "service":"0x1111",
+            "instance":"0x0003",
+            "unreliable":"30003"
+        },
+        {
+            "service":"0x8888",
+            "instance":"0x0001",
+            "unreliable":"8888"
+        }
+    ],
+    "routing":"routingmanagerd",
+    "service-discovery":
+    {
+        "enable":"true",
+        "multicast":"224.0.0.1",
+        "port":"30490",
+        "protocol":"udp",
+        "initial_delay_min" : "10",
+        "initial_delay_max" : "10",
+        "repetitions_base_delay" : "30",
+        "repetitions_max" : "3",
+        "cyclic_offer_delay" : "1000",
+        "ttl" : "3"
+    }
+}

--- a/test/any_instance_tests/conf/any_instance_test_slave.json.in
+++ b/test/any_instance_tests/conf/any_instance_test_slave.json.in
@@ -1,0 +1,44 @@
+{
+    "unicast":"@TEST_IP_SLAVE@",
+    "diagnosis" : "0x63",
+    "logging":
+    {
+        "level":"debug",
+        "console":"true",
+        "file":
+        {
+            "enable":"true",
+            "path":"/tmp/vsomeip.log"
+        },
+        "dlt":"false"
+    },
+    "applications":
+    [
+        {
+            "name":"any_instance_client",
+            "id":"0x4444"
+        }
+    ],
+    "services":
+    [
+        {
+            "service":"0x9999",
+            "instance":"0x0001",
+            "unreliable":"9999"
+        }
+    ],
+    "routing":"any_instance_client",
+    "service-discovery":
+    {
+        "enable":"true",
+        "multicast":"224.0.0.1",
+        "port":"30490",
+        "protocol":"udp",
+        "initial_delay_min" : "10",
+        "initial_delay_max" : "10",
+        "repetitions_base_delay" : "30",
+        "repetitions_max" : "3",
+        "cyclic_offer_delay" : "1000",
+        "ttl" : "3"
+    }
+}


### PR DESCRIPTION
This is a rework of #410. A test case is added to demonstrate the issue (first commit). The test case only succeeds with the second commit which fixes the issue.

In my local setup all test cases except for malicious_data_test_wrong_header_fields_udp, second_address_test_second_ip_address_service_udp, second_address_test_second_ip_address_client_udp and suspend_resume_test_initial pass, but those are not related to these changes and fail also without this patch.

The diff to the original #410 is that the implementation for any case now uses the correct overload of find_or_create_remote_client.
```diff
diff --git a/implementation/routing/src/routing_manager_impl.cpp b/implementation/routing/src/routing_manager_impl.cpp
index 0a2a73f..d608c4b 100644
--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -550,7 +550,7 @@ void routing_manager_impl::request_service(client_t _client, service_t _service,
                     requested_service_add(_client, _service, its_info->get_instance(), _major, _minor);
                     its_info->add_client(_client);
                     ep_mgr_impl_->find_or_create_remote_client(
-                            _service, its_info->get_instance(), true);
+                            _service, its_info->get_instance());
                 }
             }
         }
```

If you consider merging this into the 3.1 branch I can also rebase it for the 3.3 branch after that.