### PR TITLE
Add support for QNX 7.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -109,4 +109,4 @@ test/security_tests/security_test_local_config.json
 /test/event_tests/event_test_master.json
 /test/event_tests/event_test_slave_tcp.json
 /test/event_tests/event_test_slave_udp.json
-
+!build_qnx/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,7 +159,11 @@ find_package(Threads REQUIRED)
 
 # Boost
 find_package( Boost 1.55 COMPONENTS system thread filesystem REQUIRED )
-include_directories(SYSTEM ${Boost_INCLUDE_DIR} )
+if(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
+    include_directories(${Boost_INCLUDE_DIR} )
+else()
+    include_directories(SYSTEM ${Boost_INCLUDE_DIR} )
+endif()
 
 if(Boost_FOUND)
   if(Boost_LIBRARY_DIR)
@@ -245,6 +249,8 @@ if (MSVC)
     set(USE_RT "")
     link_directories(${Boost_LIBRARY_DIR_DEBUG})
     ADD_DEFINITIONS( -DBOOST_ALL_DYN_LINK )
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
+    set(USE_RT "")
 else()
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OS_CXX_FLAGS} -g ${OPTIMIZE} -std=c++14 ${NO_DEPRECATED} ${EXPORTSYMBOLS}")
     set(USE_RT "rt")
@@ -347,6 +353,9 @@ endif ()
 
 target_link_libraries(${VSOMEIP_NAME}-e2e ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${SystemD_LIBRARIES})
 
+if(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
+    target_link_libraries(${VSOMEIP_NAME}-e2e socket)
+endif()
 ################################################################################
 # Compatibility library
 ################################################################################
@@ -395,7 +404,11 @@ set(EXAMPLE_CONFIG_FILES
 ################################################################################
 # Configuration parameters
 ################################################################################
-set (VSOMEIP_BASE_PATH "/tmp")
+if(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
+    set (VSOMEIP_BASE_PATH "/var")
+else()
+    set (VSOMEIP_BASE_PATH "/tmp")
+endif()
 if (BASE_PATH)
 set (VSOMEIP_BASE_PATH ${BASE_PATH})
 endif ()
@@ -741,3 +754,15 @@ add_dependencies(build_tests build_benchmark_tests)
 # add test directory
 
 add_subdirectory( test EXCLUDE_FROM_ALL )
+
+if (${CMAKE_SYSTEM_NAME} MATCHES "QNX")
+    install(DIRECTORY ${PROJECT_BINARY_DIR}/test/
+        DESTINATION bin/vsomeip_tests/test
+        PATTERN "CMakeFiles" EXCLUDE
+        PATTERN "*.cmake" EXCLUDE
+        PATTERN "Makefile" EXCLUDE
+    )
+
+    install(FILES ${PROJECT_BINARY_DIR}/examples/routingmanagerd/routingmanagerd
+        DESTINATION bin/vsomeip_tests/examples/routingmanagerd)
+endif()

--- a/build_qnx/Makefile
+++ b/build_qnx/Makefile
@@ -1,0 +1,8 @@
+LIST=OS
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/common.mk
+++ b/build_qnx/common.mk
@@ -1,0 +1,108 @@
+ifndef QCONFIG
+QCONFIG=qconfig.mk
+endif
+include $(QCONFIG)
+
+#where to install vsomeip:
+#$(INSTALL_ROOT_$(OS)) is pointing to $QNX_TARGET
+#by default, unless it was manually re-routed to
+#a staging area by setting both INSTALL_ROOT_nto
+#and USE_INSTALL_ROOT
+VSOMEIP_INSTALL_ROOT ?= $(INSTALL_ROOT_$(OS))
+
+#where to find the vsomeip external dependencies, such as Boost
+VSOMEIP_EXTERNAL_DEPS_INSTALL ?= $(USE_ROOT_$(OS))
+
+# Get version information from CMakeLists.txt
+VSOMEIP_MAJOR_VERSION = $(word 3, $(shell bash -c "grep VSOMEIP_MAJOR_VERSION $(PROJECT_ROOT)/../CMakeLists.txt | head -1 | head -c-2"))
+VSOMEIP_MINOR_VERSION = $(word 3, $(shell bash -c "grep VSOMEIP_MINOR_VERSION $(PROJECT_ROOT)/../CMakeLists.txt | head -1 | head -c-2"))
+VSOMEIP_PATCH_VERSION = $(word 3, $(shell bash -c "grep VSOMEIP_PATCH_VERSION $(PROJECT_ROOT)/../CMakeLists.txt | head -1 | head -c-2"))
+
+#choose Release or Debug
+CMAKE_BUILD_TYPE ?= Release
+
+#set the following to TRUE if you want to compile the vsomeip tests.
+#If you do, make sure to set GTEST_ROOT to point to the google test library sources
+GENERATE_TESTS ?= TRUE
+TEST_IP_MASTER ?= XXX.XXX.XXX.XXX
+TEST_IP_SLAVE ?= XXX.XXX.XXX.XXX
+
+#set the following to FALSE if generating .pinfo files is causing problems
+GENERATE_PINFO_FILES ?= TRUE
+
+#override 'all' target to bypass the default QNX build system
+ALL_DEPENDENCIES = vsomeip_all
+.PHONY: vsomeip_all
+
+FLAGS   += -g -D_QNX_SOURCE
+LDFLAGS += -Wl,--build-id=md5 -lang-c++ -lsocket
+
+CMAKE_ARGS = -DCMAKE_TOOLCHAIN_FILE=$(PROJECT_ROOT)/qnx.nto.toolchain.cmake \
+             -DCMAKE_INSTALL_PREFIX=$(VSOMEIP_INSTALL_ROOT)/$(CPUVARDIR)/usr \
+             -DCMAKE_CXX_STANDARD=14 \
+             -DCMAKE_NO_SYSTEM_FROM_IMPORTED=TRUE \
+             -DVSOMEIP_EXTERNAL_DEPS_INSTALL=$(VSOMEIP_EXTERNAL_DEPS_INSTALL) \
+             -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE) \
+             -DCMAKE_MODULE_PATH=$(PROJECT_ROOT) \
+             -DEXTRA_CMAKE_C_FLAGS="$(FLAGS)" \
+             -DEXTRA_CMAKE_CXX_FLAGS="$(FLAGS)" \
+             -DEXTRA_CMAKE_LINKER_FLAGS="$(LDFLAGS)" \
+             -DINSTALL_INCLUDE_DIR=$(VSOMEIP_INSTALL_ROOT)/usr/include \
+             -DCPUVARDIR=$(CPUVARDIR) \
+             -DGCC_VER=${GCC_VER} \
+             -DVSOMEIP_INSTALL_ROUTINGMANAGERD=ON
+
+ifeq ($(GENERATE_TESTS), TRUE)
+CMAKE_ARGS += -DENABLE_SIGNAL_HANDLING=1 \
+              -DTEST_IP_MASTER=$(TEST_IP_MASTER) \
+              -DTEST_IP_SLAVE=$(TEST_IP_SLAVE)
+endif
+
+MAKE_ARGS ?= -j $(firstword $(JLEVEL) 4)
+
+define PINFO
+endef
+PINFO_STATE=Experimental
+USEFILE=
+
+include $(MKFILES_ROOT)/qtargets.mk
+
+ifneq ($(wildcard $(foreach dir,$(LIBVPATH),$(dir)/libregex.so)),)
+	LDFLAGS += -lregex
+endif
+
+
+ifndef NO_TARGET_OVERRIDE
+vsomeip_all:
+	@mkdir -p build
+	@cd build && cmake $(CMAKE_ARGS) ../../../../../
+	@cd build && make all $(MAKE_ARGS)
+	@cd build && make build_tests $(MAKE_ARGS)
+
+install: vsomeip_all
+	@cd build && make install $(MAKE_ARGS)
+	@cd build && make build_tests install $(MAKE_ARGS)
+
+clean iclean spotless:
+	@rm -fr build
+	
+endif
+
+#everything down below deals with the generation of the PINFO
+#information for shared objects that is used by the QNX build
+#infrastructure to embed metadata in the .so files, for example
+#data and time, version number, description, etc. Metadata can
+#be retrieved on the target by typing 'use -i <path to vsomeip .so file>'.
+#this is optional: setting GENERATE_PINFO_FILES to FALSE will disable
+#the insertion of metadata in .so files.
+ifeq ($(GENERATE_PINFO_FILES), TRUE)
+#the following rules are called by the cmake generated makefiles,
+#in order to generate the .pinfo files for the shared libraries
+%.so.$(VSOMEIP_MAJOR_VERSION).$(VSOMEIP_MINOR_VERSION).$(VSOMEIP_PATCH_VERSION):
+	$(ADD_PINFO)
+	$(ADD_USAGE)
+
+%vsomeipd:
+	$(ADD_PINFO)
+	$(ADD_USAGE)
+endif

--- a/build_qnx/nto/Makefile
+++ b/build_qnx/nto/Makefile
@@ -1,0 +1,8 @@
+LIST=CPU
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/nto/aarch64/Makefile
+++ b/build_qnx/nto/aarch64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/nto/aarch64/le/Makefile
+++ b/build_qnx/nto/aarch64/le/Makefile
@@ -1,0 +1,5 @@
+include ../../../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=aarch64
+FLAGS      += $(VFLAG_le) $(CCVFLAG_le)
+LDFLAGS    += $(VFLAG_le) $(LDVFLAG_le)

--- a/build_qnx/nto/x86_64/Makefile
+++ b/build_qnx/nto/x86_64/Makefile
@@ -1,0 +1,8 @@
+LIST=VARIANT
+ifndef QRECURSE
+QRECURSE=recurse.mk
+ifdef QCONFIG
+QRDIR=$(dir $(QCONFIG))
+endif
+endif
+include $(QRDIR)$(QRECURSE)

--- a/build_qnx/nto/x86_64/o/Makefile
+++ b/build_qnx/nto/x86_64/o/Makefile
@@ -1,0 +1,3 @@
+include ../../../common.mk
+
+CMAKE_ARGS += -DCMAKE_SYSTEM_PROCESSOR=x86_64

--- a/build_qnx/qnx.nto.toolchain.cmake
+++ b/build_qnx/qnx.nto.toolchain.cmake
@@ -1,0 +1,43 @@
+if("$ENV{QNX_HOST}" STREQUAL "")
+    message(FATAL_ERROR "QNX_HOST environment variable not found. Please set the variable to your host's build tools")
+endif()
+if("$ENV{QNX_TARGET}" STREQUAL "")
+    message(FATAL_ERROR "QNX_TARGET environment variable not found. Please set the variable to the qnx target location")
+endif()
+
+if(CMAKE_HOST_WIN32)
+    set(HOST_EXECUTABLE_SUFFIX ".exe")
+    #convert windows paths to cmake paths
+    file(TO_CMAKE_PATH "$ENV{QNX_HOST}" QNX_HOST)
+    file(TO_CMAKE_PATH "$ENV{QNX_TARGET}" QNX_TARGET)
+else()
+    set(QNX_HOST "$ENV{QNX_HOST}")
+    set(QNX_TARGET "$ENV{QNX_TARGET}")
+endif()
+
+message(STATUS "using QNX_HOST ${QNX_HOST}")
+message(STATUS "using QNX_TARGET ${QNX_TARGET}")
+
+set(CMAKE_SYSTEM_NAME QNX)
+set(CMAKE_C_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_CXX_COMPILER ${QNX_HOST}/usr/bin/qcc)
+set(CMAKE_AR "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ar${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "archiver")
+set(CMAKE_RANLIB "${QNX_HOST}/usr/bin/nto${CMAKE_SYSTEM_PROCESSOR}-ranlib${HOST_EXECUTABLE_SUFFIX}" CACHE PATH "ranlib")
+
+if ("${GCC_VER}" STREQUAL "")
+    set(GCC_VERSION "" CACHE STRING "gcc_ver")
+else()
+    set(GCC_VERSION "${GCC_VER}," CACHE STRING "gcc_ver")
+endif()
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -V${GCC_VERSION}gcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_C_FLAGS}" CACHE STRING "c_flags")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -V${GCC_VERSION}gcc_nto${CMAKE_SYSTEM_PROCESSOR} ${EXTRA_CMAKE_CXX_FLAGS}" CACHE STRING "cxx_flags")
+
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "exe_linker_flags")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${EXTRA_CMAKE_LINKER_FLAGS}" CACHE STRING "so_linker_flags")
+
+set(CMAKE_FIND_ROOT_PATH ${VSOMEIP_EXTERNAL_DEPS_INSTALL};${VSOMEIP_EXTERNAL_DEPS_INSTALL}/${CPUVARDIR};${QNX_TARGET};${QNX_TARGET}/${CPUVARDIR})
+
+set(CMAKE_SKIP_RPATH TRUE CACHE BOOL "If set, runtime paths are not added when using shared libraries.")
+set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)

--- a/examples/routingmanagerd/CMakeLists.txt
+++ b/examples/routingmanagerd/CMakeLists.txt
@@ -6,6 +6,9 @@
 # Daemon
 add_executable(routingmanagerd routingmanagerd.cpp)
 target_link_libraries(routingmanagerd ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${DL_LIBRARY} ${DLT_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+if(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
+    target_link_libraries(routingmanagerd socket)
+endif()
 add_dependencies(routingmanagerd ${VSOMEIP_NAME})
 
 option(VSOMEIP_INSTALL_ROUTINGMANAGERD "Whether or not to install the routing manager daemon.")

--- a/implementation/configuration/include/internal.hpp.in
+++ b/implementation/configuration/include/internal.hpp.in
@@ -114,7 +114,7 @@
 #define VSOMEIP_MINIMUM_CHECK_TTL_TIMEOUT       100
 #define VSOMEIP_SETSOCKOPT_TIMEOUT_US           500000  // microseconds
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 #include <pthread.h>
 #endif
 

--- a/implementation/configuration/src/configuration_impl.cpp
+++ b/implementation/configuration/src/configuration_impl.cpp
@@ -274,7 +274,7 @@ bool configuration_impl::load(const std::string &_name) {
     }
     if (its_folder != "") {
         its_input.insert(its_folder);
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
         // load security configuration files from UID_GID sub folder if existing
         std::stringstream its_security_config_folder;
         its_security_config_folder << its_folder << "/" << getuid() << "_" << getgid();
@@ -1101,13 +1101,13 @@ void configuration_impl::add_plugin(std::map<plugin_type_e, std::set<std::string
 #endif
 
     if (_plugin_data.type_ == "application_plugin") {
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
         its_library += ".";
         its_library += (VSOMEIP_APPLICATION_PLUGIN_VERSION + '0');
 #endif
         _plugins[plugin_type_e::APPLICATION_PLUGIN].insert(its_library);
     } else if (_plugin_data.type_ == "configuration_plugin") {
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
         its_library += ".";
         its_library += (VSOMEIP_PRE_CONFIGURATION_PLUGIN_VERSION + '0');
 #endif

--- a/implementation/endpoints/include/local_server_endpoint_impl_receive_op.hpp
+++ b/implementation/endpoints/include/local_server_endpoint_impl_receive_op.hpp
@@ -7,7 +7,7 @@
 #define VSOMEIP_V3_LOCAL_SERVER_ENDPOINT_IMPL_RECEIVE_OP_HPP_
 
 #if VSOMEIP_BOOST_VERSION >= 106600
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 
 #include <boost/asio/local/stream_protocol.hpp>
 

--- a/implementation/endpoints/include/local_uds_server_endpoint_impl.hpp
+++ b/implementation/endpoints/include/local_uds_server_endpoint_impl.hpp
@@ -107,7 +107,7 @@ private:
         void set_bound_client_host(const std::string &_bound_client_host);
         std::string get_bound_client_host() const;
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
         void set_bound_sec_client(const vsomeip_sec_client_t &_sec_client);
 #endif
 
@@ -124,7 +124,7 @@ private:
                 boost::system::error_code const &_error, std::size_t _bytes);
         void receive_cbk(boost::system::error_code const &_error,
                          std::size_t _bytes
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
                          , std::uint32_t const &_uid, std::uint32_t const &_gid
 #endif
         );

--- a/implementation/endpoints/include/udp_server_endpoint_impl_receive_op.hpp
+++ b/implementation/endpoints/include/udp_server_endpoint_impl_receive_op.hpp
@@ -7,7 +7,7 @@
 #define VSOMEIP_V3_UDP_SERVER_ENDPOINT_IMPL_RECEIVE_OP_HPP_
 
 #if VSOMEIP_BOOST_VERSION >= 106600
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 
 #include <iomanip>
 

--- a/implementation/endpoints/src/client_endpoint_impl.cpp
+++ b/implementation/endpoints/src/client_endpoint_impl.cpp
@@ -641,7 +641,7 @@ void client_endpoint_impl<Protocol>::shutdown_and_close_socket_unlocked(bool _re
 
     local_port_ = 0;
     if (socket_->is_open()) {
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
         if (-1 == fcntl(socket_->native_handle(), F_GETFD)) {
             VSOMEIP_ERROR << "cei::shutdown_and_close_socket_unlocked: socket/handle closed already '"
                     << std::string(std::strerror(errno))
@@ -830,7 +830,7 @@ void client_endpoint_impl<Protocol>::start_dispatch_timer(
         its_offset = std::chrono::nanoseconds::zero();
     }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     dispatch_timer_.expires_from_now(its_offset);
 #else
     dispatch_timer_.expires_from_now(
@@ -857,7 +857,7 @@ void client_endpoint_impl<Protocol>::update_last_departure() {
 }
 
 // Instantiate template
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 template class client_endpoint_impl<boost::asio::local::stream_protocol>;
 #endif
 template class client_endpoint_impl<boost::asio::ip::tcp>;

--- a/implementation/endpoints/src/endpoint_impl.cpp
+++ b/implementation/endpoints/src/endpoint_impl.cpp
@@ -153,6 +153,13 @@ template class endpoint_impl<boost::asio::local::stream_protocol>;
 #endif
 #endif
 
+#ifdef __QNX__
+#if VSOMEIP_BOOST_VERSION < 106600
+template class endpoint_impl<boost::asio::local::stream_protocol_ext>;
+#endif
+template class endpoint_impl<boost::asio::local::stream_protocol>;
+#endif
+
 template class endpoint_impl<boost::asio::ip::tcp>;
 template class endpoint_impl<boost::asio::ip::udp>;
 

--- a/implementation/endpoints/src/endpoint_manager_base.cpp
+++ b/implementation/endpoints/src/endpoint_manager_base.cpp
@@ -12,7 +12,7 @@
 #include "../include/local_tcp_client_endpoint_impl.hpp"
 #include "../include/local_tcp_server_endpoint_impl.hpp"
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 #include "../include/local_uds_client_endpoint_impl.hpp"
 #include "../include/local_uds_server_endpoint_impl.hpp"
 #endif
@@ -88,7 +88,7 @@ std::shared_ptr<endpoint> endpoint_manager_base::create_local_server(
              << std::hex << rm_->get_client();
     const client_t its_client = rm_->get_client();
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     if (is_local_routing_) {
         if (-1 == ::unlink(its_path.str().c_str()) && errno != ENOENT) {
             VSOMEIP_ERROR << "endpoint_manager_base::init_receiver unlink failed ("
@@ -251,7 +251,7 @@ endpoint_manager_base::create_local_unlocked(client_t _client) {
              << std::hex << _client;
     std::shared_ptr<endpoint> its_endpoint;
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     if (is_local_routing_) {
         VSOMEIP_INFO << "Client [" << std::hex << rm_->get_client() << "] is connecting to ["
             << std::hex << _client << "] at " << its_path.str();

--- a/implementation/endpoints/src/endpoint_manager_impl.cpp
+++ b/implementation/endpoints/src/endpoint_manager_impl.cpp
@@ -8,7 +8,7 @@
 #include <vsomeip/internal/logger.hpp>
 
 #include "../include/local_tcp_server_endpoint_impl.hpp"
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 #include "../include/local_uds_server_endpoint_impl.hpp"
 #endif
 #include "../include/udp_client_endpoint_impl.hpp"
@@ -645,7 +645,7 @@ endpoint_manager_impl::create_routing_root(
         num_fd = sd_listen_fds(0);
 #endif
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
         if (num_fd > 1) {
             VSOMEIP_ERROR <<  "Too many file descriptors received by systemd socket activation! num_fd: " << num_fd;
         } else if (num_fd == 1) {

--- a/implementation/endpoints/src/local_tcp_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/local_tcp_server_endpoint_impl.cpp
@@ -370,7 +370,7 @@ void local_tcp_server_endpoint_impl::connection::start() {
 void local_tcp_server_endpoint_impl::connection::stop() {
     std::lock_guard<std::mutex> its_lock(socket_mutex_);
     if (socket_.is_open()) {
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
         if (-1 == fcntl(socket_.native_handle(), F_GETFD)) {
             VSOMEIP_ERROR << "lse: socket/handle closed already '" << std::string(std::strerror(errno))
                           << "' (" << errno << ") " << get_path_local();

--- a/implementation/endpoints/src/local_uds_client_endpoint_impl.cpp
+++ b/implementation/endpoints/src/local_uds_client_endpoint_impl.cpp
@@ -11,7 +11,9 @@
 #include <vsomeip/defines.hpp>
 #include <vsomeip/internal/logger.hpp>
 
+#ifndef __QNX__
 #include "../include/credentials.hpp"
+#endif
 #include "../include/endpoint_host.hpp"
 #include "../include/local_uds_client_endpoint_impl.hpp"
 #include "../include/local_uds_server_endpoint_impl.hpp"
@@ -125,6 +127,7 @@ void local_uds_client_endpoint_impl::connect() {
             socket_->connect(remote_, its_connect_error);
 
             // Credentials
+#ifndef __QNX__
             if (!its_connect_error) {
                 auto its_host = endpoint_host_.lock();
                 if (its_host) {
@@ -137,6 +140,7 @@ void local_uds_client_endpoint_impl::connect() {
                         << its_connect_error.message() << " / " << std::dec
                         << its_connect_error.value() << ")";
             }
+#endif
         } else {
             VSOMEIP_WARNING << "local_client_endpoint::connect: Error opening socket: "
                     << its_error.message() << " (" << std::dec << its_error.value()

--- a/implementation/endpoints/src/local_uds_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/local_uds_server_endpoint_impl.cpp
@@ -12,7 +12,9 @@
 
 #include <vsomeip/internal/logger.hpp>
 
+#ifndef __QNX__
 #include "../include/credentials.hpp"
+#endif
 #include "../include/endpoint_host.hpp"
 #include "../include/local_uds_server_endpoint_impl.hpp"
 #include "../include/local_server_endpoint_impl_receive_op.hpp"
@@ -63,11 +65,13 @@ local_uds_server_endpoint_impl::local_uds_server_endpoint_impl(
         VSOMEIP_ERROR << __func__
             << ": listen failed (" << ec.message() << ")";
 
+#ifndef __QNX__
     if (chmod(_local.path().c_str(),
             static_cast<mode_t>(_configuration->get_permissions_uds())) == -1) {
         VSOMEIP_ERROR << __func__ << ": chmod: " << strerror(errno);
     }
     credentials::activate_credentials(acceptor_.native_handle());
+#endif
 }
 
 local_uds_server_endpoint_impl::local_uds_server_endpoint_impl(
@@ -92,11 +96,13 @@ local_uds_server_endpoint_impl::local_uds_server_endpoint_impl(
        VSOMEIP_ERROR << __func__
            << ": assign failed (" << ec.message() << ")";
 
+#ifndef __QNX__
     if (chmod(_local.path().c_str(),
             static_cast<mode_t>(_configuration->get_permissions_uds())) == -1) {
        VSOMEIP_ERROR << __func__ << ": chmod: " << strerror(errno);
     }
     credentials::activate_credentials(acceptor_.native_handle());
+#endif
 }
 
 local_uds_server_endpoint_impl::~local_uds_server_endpoint_impl() {
@@ -274,6 +280,7 @@ void local_uds_server_endpoint_impl::accept_cbk(
     }
 
     if (!_error) {
+#ifndef __QNX__
         auto its_host = endpoint_host_.lock();
         client_t its_client = 0;
         std::string its_client_host;
@@ -369,6 +376,7 @@ void local_uds_server_endpoint_impl::accept_cbk(
             _connection->set_bound_client_host(its_client_host);
         }
 
+#endif
         _connection->start();
     }
 }

--- a/implementation/endpoints/src/server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/server_endpoint_impl.cpp
@@ -808,7 +808,7 @@ void server_endpoint_impl<Protocol>::start_dispatch_timer(
         its_offset = std::chrono::nanoseconds::zero();
     }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     its_data.dispatch_timer_->expires_from_now(its_offset);
 #else
     its_data.dispatch_timer_->expires_from_now(
@@ -842,6 +842,10 @@ template class server_endpoint_impl<boost::asio::local::stream_protocol>;
 #if VSOMEIP_BOOST_VERSION < 106600
 template class server_endpoint_impl<boost::asio::local::stream_protocol_ext>;
 #endif
+#endif
+
+#ifdef __QNX__
+template class server_endpoint_impl<boost::asio::local::stream_protocol_ext>;
 #endif
 
 template class server_endpoint_impl<boost::asio::ip::tcp>;

--- a/implementation/endpoints/src/tcp_client_endpoint_impl.cpp
+++ b/implementation/endpoints/src/tcp_client_endpoint_impl.cpp
@@ -174,7 +174,7 @@ void tcp_client_endpoint_impl::connect() {
                     << " remote:" << get_address_port_remote();
         }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
         // If specified, bind to device
         std::string its_device(configuration_->get_device());
         if (its_device != "") {

--- a/implementation/endpoints/src/tcp_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/tcp_server_endpoint_impl.cpp
@@ -50,7 +50,7 @@ tcp_server_endpoint_impl::tcp_server_endpoint_impl(
         VSOMEIP_ERROR << __func__
             << ": set reuse address option failed (" << ec.message() << ")";
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     // If specified, bind to device
     std::string its_device(configuration_->get_device());
     if (its_device != "") {

--- a/implementation/endpoints/src/tp.cpp
+++ b/implementation/endpoints/src/tp.cpp
@@ -16,7 +16,7 @@
 #include "../../configuration/include/internal.hpp"
 #endif // ANDROID
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 #include <arpa/inet.h>
 #else
 #include <Winsock2.h>

--- a/implementation/endpoints/src/tp_message.cpp
+++ b/implementation/endpoints/src/tp_message.cpp
@@ -18,7 +18,7 @@
 #include "../../configuration/include/internal.hpp"
 #endif // ANDROID
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 #include <arpa/inet.h>
 #else
 #include <Winsock2.h>

--- a/implementation/endpoints/src/udp_client_endpoint_impl.cpp
+++ b/implementation/endpoints/src/udp_client_endpoint_impl.cpp
@@ -112,7 +112,7 @@ void udp_client_endpoint_impl::connect() {
             local_.port(0);
         }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
         // If specified, bind to device
         std::string its_device(configuration_->get_device());
         if (its_device != "") {

--- a/implementation/endpoints/src/udp_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/udp_server_endpoint_impl.cpp
@@ -66,7 +66,7 @@ udp_server_endpoint_impl::udp_server_endpoint_impl(
         VSOMEIP_ERROR << __func__
             << ": set reuse address option failed (" << ec.message() << ")";
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     // If specified, bind to device
     std::string its_device(configuration_->get_device());
     if (its_device != "") {

--- a/implementation/logger/src/logger_impl.cpp
+++ b/implementation/logger/src/logger_impl.cpp
@@ -88,7 +88,7 @@ static std::mutex the_logger_mutex__;
 
 std::shared_ptr<logger_impl>
 logger_impl::get() {
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     std::lock_guard<std::mutex> its_lock(the_logger_mutex__);
 #endif
     if (the_logger_ptr__ == nullptr) {
@@ -103,7 +103,7 @@ logger_impl::get() {
     return nullptr;
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 static void logger_impl_teardown(void) __attribute__((destructor));
 static void logger_impl_teardown(void)
 {

--- a/implementation/plugin/src/plugin_manager_impl.cpp
+++ b/implementation/plugin/src/plugin_manager_impl.cpp
@@ -209,7 +209,11 @@ void * plugin_manager_impl::load_symbol(void * _handle, const std::string &_symb
             error_message = dlerror();
 #endif
 
+#ifdef __QNX__
+            VSOMEIP_ERROR << "Cannot load symbol " << std::quoted(_symbol_name.c_str()) << " because: " << error_message;
+#else
             VSOMEIP_ERROR << "Cannot load symbol " << std::quoted(_symbol_name) << " because: " << error_message;
+#endif
 
 #ifdef _WIN32
             // Required to release memory allocated by FormatMessageA()

--- a/implementation/routing/include/routing_manager_client.hpp
+++ b/implementation/routing/include/routing_manager_client.hpp
@@ -219,7 +219,7 @@ private:
 
     void on_suspend();
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     void on_net_state_change(bool _is_interface, const std::string &_name, bool _is_available);
 #endif
 

--- a/implementation/routing/include/routing_manager_stub.hpp
+++ b/implementation/routing/include/routing_manager_stub.hpp
@@ -36,7 +36,7 @@
 namespace vsomeip_v3 {
 
 class configuration;
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 class netlink_connector;
 #endif // __linux__ || ANDROID
 class routing_manager_stub_host;
@@ -232,7 +232,7 @@ private:
     void add_pending_security_update_timer(
             pending_security_update_id_t _id);
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     void on_net_state_change(bool _is_interface, const std::string &_name, bool _is_available);
 #endif
 
@@ -294,7 +294,7 @@ private:
     > requester_policies_;
 
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     // netlink connector for internal network
     // (replacement for Unix Domain Sockets if configured)
     std::shared_ptr<netlink_connector> local_link_connector_;

--- a/implementation/routing/src/routing_manager_client.cpp
+++ b/implementation/routing/src/routing_manager_client.cpp
@@ -3,7 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 #include <unistd.h>
 #endif
 
@@ -130,7 +130,7 @@ void routing_manager_client::init() {
 
 void routing_manager_client::start() {
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     if (configuration_->is_local_routing()) {
 #else
     {
@@ -1779,7 +1779,7 @@ void routing_manager_client::on_routing_info(
                 if (its_client == get_client()) {
                     VSOMEIP_INFO << std::hex << "Application/Client " << get_client()
                                 << " (" << host_->get_name() << ") is registered.";
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
                     if (!its_security->check_credentials(get_client(), get_sec_client())) {
                         VSOMEIP_ERROR << "vSomeIP Security: Client 0x" << std::hex << get_client()
                                 << " : routing_manager_client::on_routing_info: RIE_ADD_CLIENT: isn't allowed"
@@ -2040,7 +2040,7 @@ void routing_manager_client::reconnect(const std::map<client_t, std::string> &_c
     VSOMEIP_INFO << std::hex << "Application/Client " << get_client()
             << ": Reconnecting to routing manager.";
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     if (!its_security->check_credentials(get_client(), get_sec_client())) {
         VSOMEIP_ERROR << "vSomeIP Security: Client 0x" << std::hex << get_client()
                 << " :  routing_manager_client::reconnect: isn't allowed"
@@ -2418,7 +2418,7 @@ void routing_manager_client::send_pending_commands() {
 }
 
 void routing_manager_client::init_receiver() {
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     auto its_security = policy_manager_impl::get();
     if (!its_security)
         return;

--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -10,7 +10,7 @@
 #include <forward_list>
 #include <thread>
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 #include <unistd.h>
 #include <cstdio>
 #include <time.h>
@@ -252,7 +252,7 @@ void routing_manager_impl::start() {
         version_log_timer_.async_wait(std::bind(&routing_manager_impl::log_version_timer_cbk,
                 this, std::placeholders::_1));
     }
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     if (configuration_->log_memory()) {
         std::lock_guard<std::mutex> its_lock(memory_log_timer_mutex_);
         boost::system::error_code ec;
@@ -3916,7 +3916,7 @@ void routing_manager_impl::on_net_interface_or_route_state_changed(
 }
 
 void routing_manager_impl::start_ip_routing() {
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__QNX__) 
     if_state_running_ = true;
 #endif
 
@@ -4367,7 +4367,7 @@ void routing_manager_impl::memory_log_timer_cbk(
         return;
     }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     static const std::uint32_t its_pagesize = static_cast<std::uint32_t>(getpagesize() / 1024);
 
     std::FILE *its_file = std::fopen("/proc/self/statm", "r");

--- a/implementation/runtime/src/application_impl.cpp
+++ b/implementation/runtime/src/application_impl.cpp
@@ -394,7 +394,7 @@ void application_impl::start() {
         VSOMEIP_INFO << "Starting vsomeip application \"" << name_ << "\" ("
                 << std::hex << std::setw(4) << std::setfill('0') << client_
                 << ") using "  << std::dec << io_thread_count << " threads"
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
                 << " I/O nice " << io_thread_nice_level
 #endif
         ;
@@ -1745,7 +1745,7 @@ routing_manager * application_impl::get_routing_manager() const {
 }
 
 void application_impl::main_dispatch() {
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     {
         std::stringstream s;
         s << std::hex << std::setw(4) << std::setfill('0')
@@ -2100,7 +2100,7 @@ void application_impl::shutdown() {
             << " TID: " << std::dec << static_cast<int>(syscall(SYS_gettid))
 #endif
     ;
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     boost::asio::detail::posix_signal_blocker blocker;
     {
         std::stringstream s;

--- a/implementation/security/src/policy_manager_impl.cpp
+++ b/implementation/security/src/policy_manager_impl.cpp
@@ -1266,7 +1266,7 @@ policy_manager_impl::get_security_config_folder(const std::string &its_folder) c
     std::stringstream its_security_config_folder;
     its_security_config_folder << its_folder;
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     its_security_config_folder << "/" << getuid() << "_" << getgid();
 #endif
 
@@ -1439,7 +1439,7 @@ static std::mutex the_policy_manager_mutex__;
 
 std::shared_ptr<policy_manager_impl>
 policy_manager_impl::get() {
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     std::lock_guard<std::mutex> its_lock(the_policy_manager_mutex__);
 #endif
     if(the_policy_manager_ptr__ == nullptr) {
@@ -1454,7 +1454,7 @@ policy_manager_impl::get() {
     return nullptr;
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 static void security_teardown(void) __attribute__((destructor));
 static void security_teardown(void)
 {

--- a/implementation/utility/src/wrappers_qnx.cpp
+++ b/implementation/utility/src/wrappers_qnx.cpp
@@ -1,0 +1,161 @@
+// Copyright (C) 2020-2021 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifdef __QNX__
+
+#include <sys/socket.h>
+#include <sys/types.h>
+
+#include <fcntl.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <pthread.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/dcmd_ip.h>
+#include <sys/netmgr.h>
+#include <sys/sockmsg.h>
+#include <unistd.h>
+
+typedef enum accept_msg_t {
+	ACCEPT1=1,
+	ACCEPT4,
+} accept_msg_t;
+
+struct _io_sock_accept {
+	struct _io_openfd msg;
+	accept_msg_t type;
+	int flags;
+	socklen_t anamelen;
+};
+
+typedef union {
+	struct _io_sock_accept i;
+}   io_sock_accept_t;
+
+static int
+__accept (int s, struct sockaddr *addr, socklen_t *addrlen, accept_msg_t msg_type, int flags)
+{
+	/* This is basically _sopenfd specifying a return buffer for dst address */
+	int fd2;
+	int ret, niov;
+	io_sock_accept_t msg;
+	struct _io_openfd *open;
+	struct _server_info info;
+	iov_t iov[2];
+	socklen_t len;
+
+	if ((addrlen) && (*addrlen > 0) && (!addr)) {
+		/* Prevent addr dereference */
+		errno = EINVAL;
+		return -1;
+	}
+
+	if (s == -1 || ConnectServerInfo(0, s, &info) != s) {
+		errno = EBADF;
+		return -1;
+	}
+
+	fd2 = ConnectAttach(info.nd, info.pid, info.chid, 0, _NTO_COF_CLOEXEC | _NTO_COF_INSECURE);
+	if (fd2 == -1) {
+		return -1;
+	}
+
+	open = &msg.i.msg;
+	memset(open, 0x00, sizeof *open);
+	open->type = _IO_OPENFD;
+	open->combine_len = sizeof open;
+	open->ioflag = 0;
+	open->sflag = 0;
+	open->xtype = _IO_OPENFD_ACCEPT;
+	open->info.pid = getpid();
+	open->info.chid = info.chid;
+	open->info.scoid = info.scoid;
+	open->info.coid = s;
+
+	msg.i.type = msg_type;
+	msg.i.flags = flags;
+	if (addr && addrlen && (*addrlen > 0)) {
+		/* Only send len > 0 if addr is set (accept1() assumption) */
+		len = *addrlen;
+	} else {
+		len = 0;
+	}
+	msg.i.anamelen = len;
+
+	niov = 0;
+	SETIOV(iov + niov, &msg.i, sizeof(msg.i));
+	niov++;
+
+	if (len > 0) {
+		/* Only send buffer space required */
+		SETIOV(iov + niov, addr, len);
+		niov++;
+	}
+
+	ret = MsgSendv(fd2, iov, niov, iov, niov);
+	if (ret == -1) {
+		if(errno == ENOSYS) {
+			errno = ENOTSOCK;
+		}
+		ConnectDetach(fd2);
+		return -1;
+	}
+
+	if (addr && addrlen && (*addrlen > 0)) {
+		*addrlen = msg.i.anamelen;
+	}
+
+	ConnectFlags_r(0, fd2, FD_CLOEXEC, (flags & SOCK_CLOEXEC) ? 1 : 0);
+
+	return fd2;
+}
+
+int
+accept4 (int s, struct sockaddr *addr, socklen_t *addrlen, int flags) {
+	return __accept(s, addr, addrlen, ACCEPT4, flags);
+}
+
+/*
+ * These definitions MUST remain in the global namespace.
+ */
+extern "C"
+{
+    /*
+     * The real socket(2), renamed by GCC.
+     */
+    int __real_socket(int domain, int type, int protocol) noexcept;
+
+    /*
+     * Overrides socket(2) to set SOCK_CLOEXEC by default.
+     */
+    int __wrap_socket(int domain, int type, int protocol) noexcept
+    {
+        return __real_socket(domain, type | SOCK_CLOEXEC, protocol);
+    }
+
+    /*
+     * Overrides accept(2) to set SOCK_CLOEXEC by default.
+     */
+    int __wrap_accept(int sockfd, struct sockaddr *addr, socklen_t *addrlen)
+    {
+        return accept4(sockfd, addr, addrlen, SOCK_CLOEXEC);
+    }
+
+    /*
+     * The real open(2), renamed by GCC.
+     */
+    int __real_open(const char *pathname, int flags, mode_t mode);
+
+    /*
+     * Overrides open(2) to set O_CLOEXEC by default.
+     */
+    int __wrap_open(const char *pathname, int flags, mode_t mode)
+    {
+        return __real_open(pathname, flags | O_CLOEXEC, mode);
+    }
+}
+
+#endif

--- a/interface/compat/vsomeip/primitive_types.hpp
+++ b/interface/compat/vsomeip/primitive_types.hpp
@@ -9,7 +9,7 @@
 #include <array>
 #include <cstdint>
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 #include <sys/types.h>
 #endif
 

--- a/interface/vsomeip/primitive_types.hpp
+++ b/interface/vsomeip/primitive_types.hpp
@@ -10,7 +10,7 @@
 #include <cstdint>
 #include <string>
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 #include <sys/types.h>
 #endif
 
@@ -56,7 +56,7 @@ typedef std::uint32_t pending_remote_offer_id_t;
 
 typedef std::uint32_t pending_security_update_id_t;
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__QNX__)
     typedef std::uint32_t uid_t;
     typedef std::uint32_t gid_t;
 #else

--- a/interface/vsomeip/vsomeip_sec.h
+++ b/interface/vsomeip/vsomeip_sec.h
@@ -26,8 +26,13 @@ typedef uint32_t gid_t;
 #endif
 
 typedef struct {
+#ifdef __QNX__
+    uint32_t user;
+    uint32_t group;
+#else
     uid_t user;
     gid_t group;
+#endif
 } vsomeip_sec_uds_client_credentials_t;
 
 typedef struct {

--- a/test/internal_routing_disabled_acceptance_test/CMakeLists.txt
+++ b/test/internal_routing_disabled_acceptance_test/CMakeLists.txt
@@ -20,6 +20,10 @@ add_executable(${PROJECT_NAME} applet.cpp client.cpp server.cpp main.cpp)
 target_include_directories(${PROJECT_NAME} PRIVATE ${gtest_SOURCE_DIR}/include)
 target_link_libraries(${PROJECT_NAME} PRIVATE gtest Threads::Threads vsomeip3 ${Boost_LIBRARIES})
 
+if (${CMAKE_SYSTEM_NAME} MATCHES "QNX")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE _QNX_SOURCE)
+endif()
+
 enable_testing()
 add_test(NAME ${PROJECT_NAME} COMMAND $<TARGET_FILE:${PROJECT_NAME}>)
 add_dependencies(build_network_tests ${PROJECT_NAME})

--- a/test/network_tests/CMakeLists.txt
+++ b/test/network_tests/CMakeLists.txt
@@ -122,6 +122,9 @@ if(NOT ${TESTS_BAT})
         ${DL_LIBRARY}
         ${TEST_LINK_LIBRARIES}
     )
+    if(QNX)
+        target_compile_definitions(${TEST_APPLICATION_SINGLE_PROCESS_NAME} PRIVATE _QNX_SOURCE)
+    endif()
 
     set(TEST_APPLICATION_AVAILABILITY_NAME ${TEST_APPLICATION}_availability)
     add_executable(${TEST_APPLICATION_AVAILABILITY_NAME} application_tests/${TEST_APPLICATION_AVAILABILITY_NAME}.cpp)
@@ -394,7 +397,11 @@ if(NOT ${TESTS_BAT})
     )
 
     # Copy bashscript to start client and server $BUILDDIR/test
-    set(TEST_LOCAL_ROUTING_STARTER local_routing_test_starter.sh)
+    if (${CMAKE_SYSTEM_NAME} MATCHES "QNX")
+        set(TEST_LOCAL_ROUTING_STARTER local_routing_test_starter_qnx.sh)
+    else()
+        set(TEST_LOCAL_ROUTING_STARTER local_routing_test_starter.sh)
+    endif()
     configure_file(
         ${NETWORK_TEST_SRC_DIR}/routing_tests/conf/${TEST_LOCAL_ROUTING_STARTER}.in
         ${NETWORK_TEST_SRC_DIR}/routing_tests/${TEST_LOCAL_ROUTING_STARTER}
@@ -1431,7 +1438,11 @@ if(NOT ${TESTS_BAT})
     )
 
     # copy starter scripts into builddir
-    set(TEST_CLIENT_ID_MASTER_STARTER ${TEST_CLIENT_ID_NAME}_master_starter.sh)
+    if (${CMAKE_SYSTEM_NAME} MATCHES "QNX")
+        set(TEST_CLIENT_ID_MASTER_STARTER ${TEST_CLIENT_ID_NAME}_master_starter_qnx.sh)
+    else()
+        set(TEST_CLIENT_ID_MASTER_STARTER ${TEST_CLIENT_ID_NAME}_master_starter.sh)
+    endif()
     copy_to_builddir(${NETWORK_TEST_SRC_DIR}/client_id_tests/${TEST_CLIENT_ID_MASTER_STARTER}
         ${NETWORK_TEST_BIN_DIR}/${TEST_CLIENT_ID_MASTER_STARTER}
         ${TEST_CLIENT_ID_SERVICE}
@@ -1780,7 +1791,11 @@ if(NOT ${TESTS_BAT})
     )
 
     # copy starter scripts into builddir
-    set(TEST_SUBSCRIBE_NOTIFY_MASTER_STARTER ${TEST_SUBSCRIBE_NOTIFY_NAME}_master_starter.sh)
+    if (${CMAKE_SYSTEM_NAME} MATCHES "QNX")
+        set(TEST_SUBSCRIBE_NOTIFY_MASTER_STARTER ${TEST_SUBSCRIBE_NOTIFY_NAME}_master_starter_qnx.sh)
+    else()
+        set(TEST_SUBSCRIBE_NOTIFY_MASTER_STARTER ${TEST_SUBSCRIBE_NOTIFY_NAME}_master_starter.sh)
+    endif()
     copy_to_builddir(${NETWORK_TEST_SRC_DIR}/subscribe_notify_tests/${TEST_SUBSCRIBE_NOTIFY_MASTER_STARTER}
         ${NETWORK_TEST_BIN_DIR}/${TEST_SUBSCRIBE_NOTIFY_MASTER_STARTER}
         ${TEST_SUBSCRIBE_NOTIFY_SERVICE}
@@ -2278,7 +2293,11 @@ if(NOT ${TESTS_BAT})
     )
 
     # copy starter scripts into builddir
-    set(TEST_SUBSCRIBE_NOTIFY_ONE_MASTER_STARTER ${TEST_SUBSCRIBE_NOTIFY_ONE_NAME}_master_starter.sh)
+    if (${CMAKE_SYSTEM_NAME} MATCHES "QNX")
+        set(TEST_SUBSCRIBE_NOTIFY_ONE_MASTER_STARTER ${TEST_SUBSCRIBE_NOTIFY_ONE_NAME}_master_starter_qnx.sh)
+    else()
+        set(TEST_SUBSCRIBE_NOTIFY_ONE_MASTER_STARTER ${TEST_SUBSCRIBE_NOTIFY_ONE_NAME}_master_starter.sh)
+    endif()
     copy_to_builddir(${NETWORK_TEST_SRC_DIR}/subscribe_notify_one_tests/${TEST_SUBSCRIBE_NOTIFY_ONE_MASTER_STARTER}
         ${NETWORK_TEST_BIN_DIR}/${TEST_SUBSCRIBE_NOTIFY_ONE_MASTER_STARTER}
         ${TEST_SUBSCRIBE_NOTIFY_ONE_SERVICE}
@@ -2664,7 +2683,11 @@ if(NOT ${TESTS_BAT})
     )
 
     # copy starter scripts into builddir
-    set(TEST_INITIAL_EVENT_MASTER_STARTER ${TEST_INITIAL_EVENT_NAME}_master_starter.sh)
+    if (${CMAKE_SYSTEM_NAME} MATCHES "QNX")
+        set(TEST_INITIAL_EVENT_MASTER_STARTER ${TEST_INITIAL_EVENT_NAME}_master_starter_qnx.sh)
+    else()
+        set(TEST_INITIAL_EVENT_MASTER_STARTER ${TEST_INITIAL_EVENT_NAME}_master_starter.sh)
+    endif()
     copy_to_builddir(${NETWORK_TEST_SRC_DIR}/initial_event_tests/${TEST_INITIAL_EVENT_MASTER_STARTER}
         ${NETWORK_TEST_BIN_DIR}/${TEST_INITIAL_EVENT_MASTER_STARTER}
         ${TEST_INITIAL_EVENT_SERVICE}
@@ -2737,7 +2760,11 @@ if(NOT ${TESTS_BAT})
     )
 
     # copy starter scripts into builddir
-    set(TEST_OFFER_LOCAL_STARTER ${TEST_OFFER_NAME}_local_starter.sh)
+    if (${CMAKE_SYSTEM_NAME} MATCHES "QNX")
+        set(TEST_OFFER_LOCAL_STARTER ${TEST_OFFER_NAME}_local_starter_qnx.sh)    
+    else()
+        set(TEST_OFFER_LOCAL_STARTER ${TEST_OFFER_NAME}_local_starter.sh)
+    endif()
     copy_to_builddir(${NETWORK_TEST_SRC_DIR}/offer_tests/${TEST_OFFER_LOCAL_STARTER}
         ${NETWORK_TEST_BIN_DIR}/${TEST_OFFER_LOCAL_STARTER}
         ${TEST_OFFER_SERVICE}
@@ -2798,7 +2825,11 @@ if(NOT ${TESTS_BAT})
     )
 
     # Copy starter scripts for external test to $BUILDDIR/test
-    set(TEST_OFFER_EXTERNAL_MASTER_STARTER ${TEST_OFFER_NAME}_external_master_starter.sh)
+    if (${CMAKE_SYSTEM_NAME} MATCHES "QNX")
+        set(TEST_OFFER_EXTERNAL_MASTER_STARTER ${TEST_OFFER_NAME}_external_master_starter_qnx.sh)
+    else()
+        set(TEST_OFFER_EXTERNAL_MASTER_STARTER ${TEST_OFFER_NAME}_external_master_starter.sh)
+    endif()
     configure_file(
         ${NETWORK_TEST_SRC_DIR}/offer_tests/conf/${TEST_OFFER_EXTERNAL_MASTER_STARTER}.in
         ${NETWORK_TEST_SRC_DIR}/offer_tests/${TEST_OFFER_EXTERNAL_MASTER_STARTER}
@@ -3207,7 +3238,7 @@ endif()
 ##############################################################################
 # npdu-test
 ##############################################################################
-if(NOT ${TESTS_BAT})
+if(NOT ${TESTS_BAT} AND NOT ${CMAKE_SYSTEM_NAME} MATCHES "QNX")
     set(TEST_NPDU_NAME npdu_test)
 
     set(TEST_NPDU_DAEMON npdu_test_rmd)
@@ -3690,6 +3721,7 @@ if(NOT ${TESTS_BAT})
     endif()
     add_dependencies(${TEST_EVENT_SERVICE} gtest)
     add_dependencies(${TEST_EVENT_CLIENT} gtest)
+    if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "QNX")
     add_dependencies(${TEST_NPDU_SERVICE_ONE} gtest)
     add_dependencies(${TEST_NPDU_SERVICE_TWO} gtest)
     add_dependencies(${TEST_NPDU_SERVICE_THREE} gtest)
@@ -3700,6 +3732,7 @@ if(NOT ${TESTS_BAT})
     add_dependencies(${TEST_NPDU_CLIENT_FOUR} gtest)
     add_dependencies(${TEST_NPDU_DAEMON_CLIENT} gtest)
     add_dependencies(${TEST_NPDU_DAEMON_SERVICE} gtest)
+    endif()
     add_dependencies(${TEST_SOMEIPTP_CLIENT} gtest)
     add_dependencies(${TEST_SOMEIPTP_SERVICE} gtest)
     if(${TEST_SECOND_ADDRESS})
@@ -3774,6 +3807,7 @@ if(NOT ${TESTS_BAT})
     endif()
     add_dependencies(build_network_tests ${TEST_EVENT_SERVICE})
     add_dependencies(build_network_tests ${TEST_EVENT_CLIENT})
+    if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "QNX")
     add_dependencies(build_network_tests ${TEST_NPDU_SERVICE_ONE})
     add_dependencies(build_network_tests ${TEST_NPDU_SERVICE_TWO})
     add_dependencies(build_network_tests ${TEST_NPDU_SERVICE_THREE})
@@ -3784,6 +3818,7 @@ if(NOT ${TESTS_BAT})
     add_dependencies(build_network_tests ${TEST_NPDU_CLIENT_FOUR})
     add_dependencies(build_network_tests ${TEST_NPDU_DAEMON_CLIENT})
     add_dependencies(build_network_tests ${TEST_NPDU_DAEMON_SERVICE})
+    endif()
     add_dependencies(build_network_tests ${TEST_SOMEIPTP_CLIENT})
     add_dependencies(build_network_tests ${TEST_SOMEIPTP_SERVICE})
     if(${TEST_SECOND_ADDRESS})

--- a/test/network_tests/application_tests/application_test.cpp
+++ b/test/network_tests/application_tests/application_test.cpp
@@ -466,7 +466,7 @@ TEST_F(someip_application_exception_test, catch_exception_in_invoked_handler) {
 
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/application_tests/application_test_availability.cpp
+++ b/test/network_tests/application_tests/application_test_availability.cpp
@@ -30,7 +30,7 @@ TEST(someip_application_test_availability, register_availability_handlers)
     its_daemon.stop();
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/application_tests/application_test_single_process.cpp
+++ b/test/network_tests/application_tests/application_test_single_process.cpp
@@ -38,7 +38,7 @@ TEST(someip_application_test_single_process, notify_increasing_counter)
 }
 
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/big_payload_tests/big_payload_test_client.cpp
+++ b/test/network_tests/big_payload_tests/big_payload_test_client.cpp
@@ -279,7 +279,7 @@ TEST(someip_big_payload_test, send_ten_messages_to_service)
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/big_payload_tests/big_payload_test_service.cpp
+++ b/test/network_tests/big_payload_tests/big_payload_test_service.cpp
@@ -251,7 +251,7 @@ TEST(someip_big_payload_test, receive_ten_messages_and_send_reply)
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/client_id_tests/client_id_test_master_starter_qnx.sh
+++ b/test/network_tests/client_id_tests/client_id_test_master_starter_qnx.sh
@@ -1,0 +1,80 @@
+#!/bin/sh
+# Copyright (C) 2015-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Purpose: This script is needed to start the services with
+# one command. This is necessary as ctest - which is used to run the
+# tests - isn't able to start multiple binaries for one testcase. Therefore
+# the testcase simply executes this script. This script then runs the services
+# and checks that all exit successfully.
+
+if [ $# -lt 1 ]
+then
+    echo "Please pass a json file to this script."
+    echo "For example: $0 client_id_test_diff_client_ids_diff_ports_master.json"
+    exit 1
+fi
+
+MASTER_JSON_FILE=$1
+CLIENT_JSON_FILE="<corresponding-slave-json-for-$MASTER_JSON_FILE>"
+
+FAIL=0
+
+# Start the services
+export VSOMEIP_APPLICATION_NAME=client_id_test_service_one
+export VSOMEIP_CONFIGURATION=$1
+./client_id_test_service 1 &
+CLIENT_ID_PIDS[1]=$!
+
+export VSOMEIP_APPLICATION_NAME=client_id_test_service_two
+export VSOMEIP_CONFIGURATION=$1
+./client_id_test_service 2 &
+CLIENT_ID_PIDS[2]=$!
+
+export VSOMEIP_APPLICATION_NAME=client_id_test_service_three
+export VSOMEIP_CONFIGURATION=$1
+./client_id_test_service 3 &
+CLIENT_ID_PIDS[3]=$!
+
+sleep 1
+
+if [ ! -z "$USE_LXC_TEST" ]; then
+    echo "starting client id test on slave LXC"
+    ssh  -tt -i $SANDBOX_ROOT_DIR/commonapi_main/lxc-config/.ssh/mgc_lxc/rsa_key_file.pub -o StrictHostKeyChecking=no root@$LXC_TEST_SLAVE_IP "bash -ci \"set -m; cd \\\$SANDBOX_TARGET_DIR/vsomeip_lib/test/network_tests; ./client_id_test_slave_starter.sh $CLIENT_JSON_FILE\"" &
+elif [ ! -z "$USE_DOCKER" ]; then
+    docker exec $DOCKER_IMAGE sh -c "cd $DOCKER_TESTS && ./client_id_test_slave_starter.sh $CLIENT_JSON_FILE" &
+else
+cat <<End-of-message
+*******************************************************************************
+*******************************************************************************
+** Please now run:
+** client_id_test_slave_starter.sh $CLIENT_JSON_FILE
+** from an external host to successfully complete this test.
+**
+** You probably will need to adapt the 'unicast' settings in
+** client_id_test_diff_client_ids_diff_ports_master.json and
+** client_id_test_diff_client_ids_diff_ports_slave.json to your personal setup.
+*******************************************************************************
+*******************************************************************************
+End-of-message
+fi
+
+# Wait until client and service are finished
+for client_pid in "${CLIENT_ID_PIDS[@]}"
+do
+    if [ -n "$client_pid" ]; then
+        # Fail gets incremented if either client or service exit
+        # with a non-zero exit code
+        wait "$client_pid" || ((FAIL+=1))
+    fi
+done
+
+# Check if both exited successfully
+if [ $FAIL -eq 0 ]
+then
+    exit 0
+else
+    exit 1
+fi

--- a/test/network_tests/client_id_tests/client_id_test_service.cpp
+++ b/test/network_tests/client_id_tests/client_id_test_service.cpp
@@ -277,7 +277,7 @@ TEST(someip_client_id_test, send_ten_messages_to_service)
             client_id_test::service_infos[static_cast<size_t>(service_number)]);
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/client_id_tests/client_id_test_utility.cpp
+++ b/test/network_tests/client_id_tests/client_id_test_utility.cpp
@@ -600,7 +600,7 @@ TEST_F(client_id_utility_test, request_released_client_id_after_maximum_client_i
     its_client_ids.clear();
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/test/network_tests/configuration_tests/configuration-test.cpp
+++ b/test/network_tests/configuration_tests/configuration-test.cpp
@@ -159,7 +159,7 @@ void check_file(const std::string &_config_file,
 
 
     // 0. Set environment variable to config file and load it
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
     setenv("VSOMEIP_CONFIGURATION", _config_file.c_str(), 1);
 #else
     _putenv_s("VSOMEIP_CONFIGURATION", _config_file.c_str()
@@ -526,7 +526,7 @@ void check_file(const std::string &_config_file,
     EXPECT_EQ(15001u + 16, its_configuration->get_max_message_size_reliable("10.10.10.11", 7778));
 
     // security
-#ifndef VSOMEIP_DISABLE_SECURITY
+#if !defined(VSOMEIP_DISABLE_SECURITY) && !defined(__QNX__)
     vsomeip_sec_client_t its_x123_x456 = utility::create_uds_client(0x123, 0x456);
     EXPECT_TRUE(its_configuration->check_routing_credentials(0x7788, &its_x123_x456));
 

--- a/test/network_tests/cpu_load_tests/cpu_load_test_client.cpp
+++ b/test/network_tests/cpu_load_tests/cpu_load_test_client.cpp
@@ -319,7 +319,7 @@ TEST(someip_load_test, DISABLED_send_messages_and_measure_cpu_load)
     cpu_load_test_client test_client_(protocol, number_of_calls, payload_size, call_service_sync, shutdown_service);
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     int i = 0;

--- a/test/network_tests/cpu_load_tests/cpu_load_test_service.cpp
+++ b/test/network_tests/cpu_load_tests/cpu_load_test_service.cpp
@@ -200,7 +200,7 @@ TEST(someip_payload_test, DISABLED_send_response_for_every_request)
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/e2e_tests/e2e_profile_04_test_service.cpp
+++ b/test/network_tests/e2e_tests/e2e_profile_04_test_service.cpp
@@ -200,7 +200,7 @@ TEST(someip_e2e_profile_04_test, basic_subscribe_request_response) {
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv) {
 
 

--- a/test/network_tests/e2e_tests/e2e_test_service.cpp
+++ b/test/network_tests/e2e_tests/e2e_test_service.cpp
@@ -208,7 +208,7 @@ TEST(someip_e2e_test, basic_subscribe_request_response) {
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv) {
 
     /*

--- a/test/network_tests/event_tests/event_test_client.cpp
+++ b/test/network_tests/event_tests/event_test_client.cpp
@@ -253,7 +253,7 @@ TEST(someip_event_test, subscribe_or_call_method_at_service)
     event_test_client its_sample(event_test::service, passed_mode, use_tcp);
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/event_tests/event_test_service.cpp
+++ b/test/network_tests/event_tests/event_test_service.cpp
@@ -185,7 +185,7 @@ TEST(someip_event_test, send_events)
 }
 
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/header_factory_tests/header_factory_test.cpp
+++ b/test/network_tests/header_factory_tests/header_factory_test.cpp
@@ -110,7 +110,7 @@ TEST_F(someip_header_factory_test, create_notification_test)
     ASSERT_EQ(notification_->get_return_code(), vsomeip::return_code_e::E_OK);
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/header_factory_tests/header_factory_test_client.cpp
+++ b/test/network_tests/header_factory_tests/header_factory_test_client.cpp
@@ -161,7 +161,7 @@ TEST(someip_header_factory_test, send_message_ten_times_test)
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/header_factory_tests/header_factory_test_service.cpp
+++ b/test/network_tests/header_factory_tests/header_factory_test_service.cpp
@@ -161,7 +161,7 @@ TEST(someip_header_factory_test, reveice_message_ten_times_test)
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/initial_event_tests/initial_event_test_availability_checker.cpp
+++ b/test/network_tests/initial_event_tests/initial_event_test_availability_checker.cpp
@@ -139,7 +139,7 @@ TEST(someip_initial_event_test, wait_for_availability_and_exit)
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/initial_event_tests/initial_event_test_client.cpp
+++ b/test/network_tests/initial_event_tests/initial_event_test_client.cpp
@@ -564,7 +564,7 @@ TEST(someip_initial_event_test, wait_for_initial_events_of_all_services)
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     // Block all signals

--- a/test/network_tests/initial_event_tests/initial_event_test_master_starter_qnx.sh
+++ b/test/network_tests/initial_event_tests/initial_event_test_master_starter_qnx.sh
@@ -1,0 +1,163 @@
+#!/bin/sh
+# Copyright (C) 2015-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Purpose: This script is needed to start the services with
+# one command. This is necessary as ctest - which is used to run the
+# tests - isn't able to start multiple binaries for one testcase. Therefore
+# the testcase simply executes this script. This script then runs the services
+# and checks that all exit successfully.
+
+if [ $# -lt 1 ]
+then
+    echo "Please pass a json file to this script."
+    echo "For example: $0 initial_event_test_diff_client_ids_diff_ports_master.json"
+    echo "To use the same service id but different instances on the node pass SAME_SERVICE_ID as third parameter"
+    echo "To ensure the first client only subscribes to one event pass SUBSCRIBE_ONLY_ONE as third/fourth parameter"
+    exit 1
+fi
+
+PASSED_JSON_FILE=$1
+# Remove processed options from $@
+shift 1
+REMAINING_OPTIONS="$@"
+
+print_starter_message () {
+
+if [ ! -z "$USE_LXC_TEST" ]; then
+    echo "starting initial event test on slave LXC with params $CLIENT_JSON_FILE $REMAINING_OPTIONS"
+    ssh -tt -i $SANDBOX_ROOT_DIR/commonapi_main/lxc-config/.ssh/mgc_lxc/rsa_key_file.pub -o StrictHostKeyChecking=no root@$LXC_TEST_SLAVE_IP "bash -ci \"set -m; cd \\\$SANDBOX_TARGET_DIR/vsomeip_lib/test/network_tests; ./initial_event_test_slave_starter.sh $CLIENT_JSON_FILE $REMAINING_OPTIONS\"" &
+elif [ ! -z "$USE_DOCKER" ]; then
+    docker exec $DOCKER_IMAGE sh -c "cd $DOCKER_TESTS && ./initial_event_test_slave_starter.sh $CLIENT_JSON_FILE $REMAINING_OPTIONS" &
+else
+cat <<End-of-message
+*******************************************************************************
+*******************************************************************************
+** Please now run:
+** initial_event_test_slave_starter.sh $CLIENT_JSON_FILE $REMAINING_OPTIONS
+** from an external host to successfully complete this test.
+**
+** You probably will need to adapt the 'unicast' settings in
+** initial_event_test_diff_client_ids_diff_ports_master.json and
+** initial_event_test_diff_client_ids_diff_ports_slave.json to your personal setup.
+*******************************************************************************
+*******************************************************************************
+End-of-message
+fi
+}
+
+# replace master with slave to be able display the correct json file to be used
+# with the slave script
+MASTER_JSON_FILE=$PASSED_JSON_FILE
+CLIENT_JSON_FILE="<corresponding-slave-json-for-$MASTER_JSON_FILE>"
+
+FAIL=0
+
+# Start the services
+export VSOMEIP_CONFIGURATION=$PASSED_JSON_FILE
+
+export VSOMEIP_APPLICATION_NAME=initial_event_test_service_one
+./initial_event_test_service 1 $REMAINING_OPTIONS &
+PID_SERVICE_ONE=$!
+
+export VSOMEIP_APPLICATION_NAME=initial_event_test_service_two
+./initial_event_test_service 2 $REMAINING_OPTIONS &
+PID_SERVICE_TWO=$!
+
+export VSOMEIP_APPLICATION_NAME=initial_event_test_service_three
+./initial_event_test_service 3 $REMAINING_OPTIONS &
+PID_SERVICE_THREE=$!
+
+sleep 3
+
+unset VSOMEIP_APPLICATION_NAME
+
+# Start first client which subscribes remotely
+./initial_event_test_client 9000 DONT_EXIT $REMAINING_OPTIONS &
+FIRST_PID=$!
+
+# Start availability checker in order to wait until the services on the remote
+# were started as well
+./initial_event_test_availability_checker 1234 $REMAINING_OPTIONS &
+PID_AVAILABILITY_CHECKER=$!
+
+sleep 1
+
+print_starter_message
+
+# remove SUBSCRIBE_ONLY_ONCE parameter from $REMAINING_OPTIONS to ensure the
+# following clients subscribe normaly
+REMAINING_OPTIONS=${REMAINING_OPTIONS%SUBSCRIBE_ONLY_ONE}
+REMAINING_OPTIONS=${REMAINING_OPTIONS#SUBSCRIBE_ONLY_ONE}
+
+
+# wait until the services on the remote node were started as well
+echo "WAITING FOR SERVICE AVAILABILITY"
+wait $PID_AVAILABILITY_CHECKER
+echo "ALL SERVICES ARE AVAILABLE NOW"
+
+sleep 2
+
+./initial_event_test_client 9001 STRICT_CHECKING $REMAINING_OPTIONS &
+CLIENT_PID_ONE=$!
+./initial_event_test_client 9002 STRICT_CHECKING $REMAINING_OPTIONS &
+CLIENT_PID_TWO=$!
+./initial_event_test_client 9003 STRICT_CHECKING $REMAINING_OPTIONS &
+CLIENT_PID_THREE=$!
+./initial_event_test_client 9004 STRICT_CHECKING $REMAINING_OPTIONS &
+CLIENT_PID_FOUR=$!
+./initial_event_test_client 9005 STRICT_CHECKING $REMAINING_OPTIONS &
+CLIENT_PID_FIVE=$!
+./initial_event_test_client 9006 STRICT_CHECKING $REMAINING_OPTIONS &
+CLIENT_PID_SIX=$!
+./initial_event_test_client 9007 STRICT_CHECKING $REMAINING_OPTIONS &
+CLIENT_PID_SEVEN=$!
+./initial_event_test_client 9008 STRICT_CHECKING $REMAINING_OPTIONS &
+CLIENT_PID_EIGHT=$!
+./initial_event_test_client 9009 STRICT_CHECKING $REMAINING_OPTIONS &
+CLIENT_PID_NINE=$!
+./initial_event_test_client 9010 STRICT_CHECKING $REMAINING_OPTIONS &
+CLIENT_PID_TEN=$!
+./initial_event_test_client 9011 STRICT_CHECKING $REMAINING_OPTIONS &
+CLIENT_PID_ELEVEN=$!
+
+# Wait until all clients are finished
+# Fail gets incremented if a client exits with a non-zero exit code
+wait $CLIENT_PID_ONE || FAIL=$(($FAIL+1))
+wait $CLIENT_PID_TWO || FAIL=$(($FAIL+1))
+wait $CLIENT_PID_THREE || FAIL=$(($FAIL+1))
+wait $CLIENT_PID_FOUR || FAIL=$(($FAIL+1))
+wait $CLIENT_PID_FIVE || FAIL=$(($FAIL+1))
+wait $CLIENT_PID_SIX || FAIL=$(($FAIL+1))
+wait $CLIENT_PID_SEVEN || FAIL=$(($FAIL+1))
+wait $CLIENT_PID_EIGHT || FAIL=$(($FAIL+1))
+wait $CLIENT_PID_NINE || FAIL=$(($FAIL+1))
+wait $CLIENT_PID_TEN || FAIL=$(($FAIL+1))
+wait $CLIENT_PID_ELEVEN || FAIL=$(($FAIL+1))
+
+# wait until all clients exited on slave side
+./initial_event_test_stop_service MASTER &
+PID_STOP_SERVICE=$!
+wait $PID_STOP_SERVICE
+
+# shutdown the first client
+kill $FIRST_PID
+wait $FIRST_PID || FAIL=$(($FAIL+1))
+
+# shutdown the services
+kill $PID_SERVICE_THREE
+kill $PID_SERVICE_TWO
+kill $PID_SERVICE_ONE
+
+sleep 1
+echo ""
+
+# Check if they exited successfully
+if [ $FAIL -eq 0 ]
+then
+    exit 0
+else
+    exit 1
+fi

--- a/test/network_tests/initial_event_tests/initial_event_test_service.cpp
+++ b/test/network_tests/initial_event_tests/initial_event_test_service.cpp
@@ -129,7 +129,7 @@ TEST(someip_initial_event_test, set_field_once)
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/initial_event_tests/initial_event_test_stop_service.cpp
+++ b/test/network_tests/initial_event_tests/initial_event_test_stop_service.cpp
@@ -267,7 +267,7 @@ TEST(someip_initial_event_test, wait_for_stop_method_to_be_called)
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/malicious_data_tests/malicious_data_test_msg_sender.cpp
+++ b/test/network_tests/malicious_data_tests/malicious_data_test_msg_sender.cpp
@@ -1570,7 +1570,7 @@ TEST_F(malicious_data, wrong_header_fields_udp)
     udp_socket.close(ec);
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     if(argc < 3) {

--- a/test/network_tests/malicious_data_tests/malicious_data_test_service.cpp
+++ b/test/network_tests/malicious_data_tests/malicious_data_test_service.cpp
@@ -164,7 +164,7 @@ TEST(someip_malicious_data_test, block_subscription_handler)
 }
 
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/npdu_tests/npdu_test_client.cpp
+++ b/test/network_tests/npdu_tests/npdu_test_client.cpp
@@ -530,7 +530,7 @@ TEST(someip_npdu_test, send_different_payloads)
 }
 
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     std::string tcp_enable("--TCP");

--- a/test/network_tests/npdu_tests/npdu_test_service.cpp
+++ b/test/network_tests/npdu_tests/npdu_test_service.cpp
@@ -286,7 +286,7 @@ TEST(someip_npdu_test, offer_service_and_check_debounce_times)
     test_service.join_shutdown_thread();
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     int i = 1;

--- a/test/network_tests/offer_tests/conf/offer_test_external_master_starter_qnx.sh.in
+++ b/test/network_tests/offer_tests/conf/offer_test_external_master_starter_qnx.sh.in
@@ -1,0 +1,150 @@
+#!/bin/bash
+# Copyright (C) 2015-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Purpose: This script is needed to start the services with
+# one command. This is necessary as ctest - which is used to run the
+# tests - isn't able to start multiple binaries for one testcase. Therefore
+# the testcase simply executes this script. This script then runs the services
+# and checks that all exit successfully.
+
+FAIL=0
+# Rejecting offer for which there is already a remote offer:
+# * start daemon
+# * start application which offers service
+# * start daemon remotely
+# * start same application which offers the same service again remotely
+#   -> should be rejected as there is already a service instance
+#   running in the network
+
+export VSOMEIP_CONFIGURATION=offer_test_external_master.json
+# start daemon
+../../examples/routingmanagerd/./routingmanagerd &
+PID_VSOMEIPD=$!
+# Start the services
+./offer_test_service 2 &
+PID_SERVICE_TWO=$!
+echo "SERVICE_TWO pid $PID_SERVICE_TWO"
+
+./offer_test_client SUBSCRIBE &
+CLIENT_PID_ONE=$!
+echo "client pid ${CLIENT_PIDS}"
+
+sleep 1
+
+if [ ! -z "$USE_LXC_TEST" ]; then
+    echo "Waiting for 5s"
+    sleep 5
+    echo "starting offer test on slave LXC offer_test_external_slave_starter.sh"
+    ssh -tt -i $SANDBOX_ROOT_DIR/commonapi_main/lxc-config/.ssh/mgc_lxc/rsa_key_file.pub -o StrictHostKeyChecking=no root@$LXC_TEST_SLAVE_IP "bash -ci \"set -m; cd \\\$SANDBOX_TARGET_DIR/vsomeip_lib/test/network_tests; ./offer_test_external_slave_starter.sh\"" &
+    echo "remote ssh pid: $!"
+elif [ ! -z "$USE_DOCKER" ]; then
+    echo "Waiting for 5s"
+    sleep 5
+    docker exec $DOCKER_IMAGE sh -c "cd $DOCKER_TESTS && sleep 10; ./offer_test_external_slave_starter.sh" &
+else
+cat <<End-of-message
+*******************************************************************************
+*******************************************************************************
+** Please now run:
+** offer_test_external_slave_starter.sh
+** from an external host to successfully complete this test.
+**
+** You probably will need to adapt the 'unicast' settings in
+** offer_test_external_master.json and
+** offer_test_external_slave.json to your personal setup.
+*******************************************************************************
+*******************************************************************************
+End-of-message
+fi
+
+# Wait until all clients and services are finished
+# Fail gets incremented if a client exits with a non-zero exit code
+echo "waiting for $job"
+wait $CLIENT_PID_ONE || FAIL=$(($FAIL+1))
+wait $PID_SERVICE_TWO || FAIL=$(($FAIL+1))
+
+# kill the services
+kill $PID_VSOMEIPD
+sleep 1
+
+# wait for slave to finish
+for job in $(jobs -p)
+do
+    # Fail gets incremented if either client or service exit
+    # with a non-zero exit code
+    echo "[Master] waiting for job $job"
+    wait $job || ((FAIL+=1))
+done
+
+# Rejecting remote offer for which there is already a local offer
+# * start application which offers service
+# * send sd message trying to offer the same service instance as already
+#   offered locally from a remote host
+
+export VSOMEIP_CONFIGURATION=offer_test_external_master.json
+# start daemon
+../../examples/routingmanagerd/./routingmanagerd &
+PID_VSOMEIPD=$!
+# Start the services
+./offer_test_service 2 &
+PID_SERVICE_TWO=$!
+
+./offer_test_client SUBSCRIBE &
+CLIENT_PID_ONE=$!
+echo "client pid ${CLIENT_PID_ONE}"
+
+sleep 1
+
+if [ ! -z "$USE_LXC_TEST" ]; then
+    echo "Waiting for 5s"
+    sleep 5
+    echo "starting offer test on slave LXC offer_test_external_sd_msg_sender"
+    ssh -tt -i $SANDBOX_ROOT_DIR/commonapi_main/lxc-config/.ssh/mgc_lxc/rsa_key_file.pub -o StrictHostKeyChecking=no root@$LXC_TEST_SLAVE_IP "bash -ci \"set -m; cd \\\$SANDBOX_TARGET_DIR/vsomeip_lib/test/network_tests; ./offer_test_external_sd_msg_sender $LXC_TEST_MASTER_IP\"" &
+    echo "remote ssh job id: $!"
+elif [ ! -z "$USE_DOCKER" ]; then
+    echo "Waiting for 5s"
+    sleep 5
+    docker exec $DOCKER_IMAGE sh -c "cd $DOCKER_TESTS && sleep 10; ./offer_test_external_sd_msg_sender $DOCKER_IP" &
+else
+cat <<End-of-message
+*******************************************************************************
+*******************************************************************************
+** Please now run:
+** offer_test_external_sd_msg_sender @TEST_IP_MASTER@
+** (pass the correct ip address of your test master)
+** from an external host to successfully complete this test.
+**
+*******************************************************************************
+*******************************************************************************
+End-of-message
+fi
+
+# Wait until all clients and services are finished
+# Fail gets incremented if a client exits with a non-zero exit code
+echo "waiting for $job"
+wait $CLIENT_PID_ONE || FAIL=$(($FAIL+1))
+wait $PID_SERVICE_TWO || FAIL=$(($FAIL+1))
+
+# kill the services
+kill $PID_VSOMEIPD
+sleep 1
+
+# wait for slave to finish
+for job in $(jobs -p)
+do
+    # Fail gets incremented if either client or service exit
+    # with a non-zero exit code
+    echo "[Master] waiting for job $job"
+    wait $job || ((FAIL+=1))
+done
+
+# Check if everything went well
+if [ $FAIL -eq 0 ]
+then
+    exit 0
+else
+    exit 1
+fi

--- a/test/network_tests/offer_tests/offer_test_big_sd_msg_client.cpp
+++ b/test/network_tests/offer_tests/offer_test_big_sd_msg_client.cpp
@@ -229,7 +229,7 @@ TEST(someip_offer_test_big_sd_msg, subscribe_or_call_method_at_service)
     offer_test_big_sd_msg_client its_sample(offer_test::service);
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/offer_tests/offer_test_big_sd_msg_service.cpp
+++ b/test/network_tests/offer_tests/offer_test_big_sd_msg_service.cpp
@@ -163,7 +163,7 @@ TEST(someip_offer_test_big_sd_msg, notify_increasing_counter)
 }
 
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/offer_tests/offer_test_client.cpp
+++ b/test/network_tests/offer_tests/offer_test_client.cpp
@@ -255,7 +255,7 @@ TEST(someip_offer_test, subscribe_or_call_method_at_service)
     offer_test_client its_sample(offer_test::service, passed_mode);
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/offer_tests/offer_test_external_sd_msg_sender.cpp
+++ b/test/network_tests/offer_tests/offer_test_external_sd_msg_sender.cpp
@@ -64,7 +64,7 @@ TEST(someip_offer_test, send_offer_service_sd_message)
 }
 
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     if(argc < 2) {

--- a/test/network_tests/offer_tests/offer_test_local_starter_qnx.sh
+++ b/test/network_tests/offer_tests/offer_test_local_starter_qnx.sh
@@ -1,0 +1,278 @@
+#!/bin/sh
+# Copyright (C) 2015-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Purpose: This script is needed to start the services with
+# one command. This is necessary as ctest - which is used to run the
+# tests - isn't able to start multiple binaries for one testcase. Therefore
+# the testcase simply executes this script. This script then runs the services
+# and checks that all exit successfully.
+
+FAIL=0
+
+cat <<End-of-message
+*******************************************************************************
+*******************************************************************************
+** Running first test
+*******************************************************************************
+*******************************************************************************
+End-of-message
+
+# Rejecting offer of service instance whose hosting application is still
+# alive:
+# * start application which offers service
+# * start two clients which continuously exchanges messages with the service
+# * start application which offers the same service again -> should be
+#   rejected and an error message should be printed.
+# * Message exchange with client application should not be interrupted.
+
+export VSOMEIP_CONFIGURATION=offer_test_local.json
+# Start the services
+./offer_test_service 1 &
+PID_SERVICE_ONE=$!
+./offer_test_client SUBSCRIBE &
+CLIENT_PID_ONE=$!
+./offer_test_client SUBSCRIBE &
+CLIENT_PID_TWO=$!
+
+./offer_test_service 2 &
+PID_SERVICE_TWO=$!
+
+# Wait until all clients are finished
+# Fail gets incremented if a client exits with a non-zero exit code
+wait $CLIENT_PID_ONE || FAIL=$(($FAIL+1))
+wait $CLIENT_PID_TWO || FAIL=$(($FAIL+1))
+
+# kill the services
+kill $PID_SERVICE_TWO
+kill $PID_SERVICE_ONE
+sleep 1
+
+
+cat <<End-of-message
+*******************************************************************************
+*******************************************************************************
+** Running second test
+*******************************************************************************
+*******************************************************************************
+End-of-message
+
+# Rejecting offer of service instance whose hosting application is still
+# alive with daemon:
+# * start daemon (needed as he has to ping the offering client)
+# * start application which offers service
+# * start two clients which continuously exchanges messages with the service
+# * start application which offers the same service again -> should be
+#   rejected and an error message should be printed.
+# * Message exchange with client application should not be interrupted.
+
+export VSOMEIP_CONFIGURATION=offer_test_local.json
+# start daemon
+../../examples/routingmanagerd/./routingmanagerd &
+PID_VSOMEIPD=$!
+
+# Start the services
+./offer_test_service 2 &
+PID_SERVICE_TWO=$!
+./offer_test_client SUBSCRIBE &
+CLIENT_PID_ONE=$!
+./offer_test_client SUBSCRIBE &
+CLIENT_PID_TWO=$!
+
+./offer_test_service 3 &
+PID_SERVICE_THREE=$!
+
+# Wait until all clients are finished
+# Fail gets incremented if a client exits with a non-zero exit code
+wait $CLIENT_PID_ONE || FAIL=$(($FAIL+1))
+wait $CLIENT_PID_TWO || FAIL=$(($FAIL+1))
+
+# kill the services
+kill $PID_SERVICE_THREE
+kill $PID_SERVICE_TWO
+sleep 1
+kill $PID_VSOMEIPD
+sleep 1
+
+
+cat <<End-of-message
+*******************************************************************************
+*******************************************************************************
+** Running third test
+*******************************************************************************
+*******************************************************************************
+End-of-message
+
+# Accepting offer of service instance whose hosting application crashed
+# with (send SIGKILL)
+# * start daemon
+# * start application which offers service
+# * start client which exchanges messages with the service
+# * kill application with SIGKILL
+# * start application which offers the same service again -> should be
+#   accepted.
+# * start another client which exchanges messages with the service
+# * Client should now communicate with new offerer.
+
+export VSOMEIP_CONFIGURATION=offer_test_local.json
+# start daemon
+../../examples/routingmanagerd/./routingmanagerd &
+PID_VSOMEIPD=$!
+# Start the service
+./offer_test_service 2 &
+PID_SERVICE_TWO=$!
+
+# Start a client
+./offer_test_client METHODCALL &
+CLIENT_PID_ONE=$!
+
+# Kill the service
+sleep 1
+kill -KILL $PID_SERVICE_TWO
+
+# reoffer the service
+./offer_test_service 3 &
+PID_SERVICE_THREE=$!
+
+# Start another client
+./offer_test_client METHODCALL &
+CLIENT_PID_TWO=$!
+
+# Wait until all clients are finished
+# Fail gets incremented if a client exits with a non-zero exit code
+wait $CLIENT_PID_ONE || FAIL=$(($FAIL+1))
+wait $CLIENT_PID_TWO || FAIL=$(($FAIL+1))
+
+# kill the services
+kill $PID_SERVICE_THREE
+kill $PID_VSOMEIPD
+sleep 1
+
+cat <<End-of-message
+*******************************************************************************
+*******************************************************************************
+** Running fourth test
+*******************************************************************************
+*******************************************************************************
+End-of-message
+
+# Accepting offer of service instance whose hosting application became
+# unresponsive (SIGSTOP)
+# * start daemon
+# * start application which offers service
+# * Send a SIGSTOP to the service to make it unresponsive
+# * start application which offers the same service again -> should be
+#   marked as PENDING_OFFER and a ping should be sent to the paused
+#   application.
+# * After the timeout passed the new offer should be accepted.
+# * start client which exchanges messages with the service
+# * Client should now communicate with new offerer.
+
+export VSOMEIP_CONFIGURATION=offer_test_local.json
+# start daemon
+../../examples/routingmanagerd/./routingmanagerd &
+PID_VSOMEIPD=$!
+# Start the service
+./offer_test_service 2 &
+PID_SERVICE_TWO=$!
+
+# Start a client
+./offer_test_client METHODCALL &
+CLIENT_PID_ONE=$!
+
+# Pause the service
+sleep 1
+kill -STOP $PID_SERVICE_TWO
+
+# reoffer the service
+./offer_test_service 3 &
+PID_SERVICE_THREE=$!
+
+# Start another client
+./offer_test_client METHODCALL &
+CLIENT_PID_TWO=$!
+
+# Wait until all clients are finished
+# Fail gets incremented if a client exits with a non-zero exit code
+wait $CLIENT_PID_ONE || FAIL=$(($FAIL+1))
+wait $CLIENT_PID_TWO || FAIL=$(($FAIL+1))
+
+# kill the services
+kill -CONT $PID_SERVICE_TWO
+kill $PID_SERVICE_TWO
+kill $PID_SERVICE_THREE
+kill $PID_VSOMEIPD
+sleep 1
+
+cat <<End-of-message
+*******************************************************************************
+*******************************************************************************
+** Running fifth test
+*******************************************************************************
+*******************************************************************************
+End-of-message
+
+# Rejecting offers for which there is already a pending offer
+# * start daemon
+# * start application which offers service
+# * Send a SIGSTOP to the service to make it unresponsive
+# * start application which offers the same service again -> should be
+#   marked as PENDING_OFFER and a ping should be sent to the paused
+#   application.
+# * start application which offers the same service again -> should be
+#   rejected as there is already a PENDING_OFFER pending.
+# * After the timeout passed the new offer should be accepted.
+# * start client which exchanges messages with the service
+# * Client should now communicate with new offerer.
+
+export VSOMEIP_CONFIGURATION=offer_test_local.json
+# start daemon
+../../examples/routingmanagerd/./routingmanagerd &
+PID_VSOMEIPD=$!
+# Start the service
+./offer_test_service 2 &
+PID_SERVICE_TWO=$!
+
+# Start a client
+./offer_test_client METHODCALL &
+CLIENT_PID_ONE=$!
+
+# Pause the service
+sleep 1
+kill -STOP $PID_SERVICE_TWO
+
+# reoffer the service
+./offer_test_service 3 &
+PID_SERVICE_THREE=$!
+
+# reoffer the service again to provoke rejecting as there is
+# already a pending offer
+./offer_test_service 4 &
+PID_SERVICE_FOUR=$!
+
+# Start another client
+./offer_test_client METHODCALL &
+CLIENT_PID_TWO=$!
+
+# Wait until all clients are finished
+# Fail gets incremented if a client exits with a non-zero exit code
+wait $CLIENT_PID_ONE || FAIL=$(($FAIL+1))
+wait $CLIENT_PID_TWO || FAIL=$(($FAIL+1))
+
+# kill the services
+kill -CONT $PID_SERVICE_TWO
+kill $PID_SERVICE_TWO
+kill $PID_SERVICE_THREE
+kill $PID_SERVICE_FOUR
+kill $PID_VSOMEIPD
+
+
+# Check if everything went well
+if [ $FAIL -eq 0 ]
+then
+    exit 0
+else
+    exit 1
+fi

--- a/test/network_tests/offer_tests/offer_test_service.cpp
+++ b/test/network_tests/offer_tests/offer_test_service.cpp
@@ -156,7 +156,7 @@ TEST(someip_offer_test, notify_increasing_counter)
 }
 
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/offer_tests/offer_test_service_external.cpp
+++ b/test/network_tests/offer_tests/offer_test_service_external.cpp
@@ -140,7 +140,7 @@ TEST(someip_offer_test, notify_increasing_counter)
 }
 
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/offered_services_info_test/offered_services_info_test_client.cpp
+++ b/test/network_tests/offered_services_info_test/offered_services_info_test_client.cpp
@@ -300,7 +300,7 @@ TEST(someip_offered_services_info_test, check_offered_services)
     offered_services_info_test_client its_sample(offer_test::service, offer_test::remote_service, passed_mode);
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/offered_services_info_test/offered_services_info_test_service.cpp
+++ b/test/network_tests/offered_services_info_test/offered_services_info_test_service.cpp
@@ -249,7 +249,7 @@ TEST(someip_offered_services_info_test, check_offered_services_as_rm_impl)
     offer_test_service its_sample(offer_test::service, offer_test::remote_service);
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/payload_tests/payload_test_client.cpp
+++ b/test/network_tests/payload_tests/payload_test_client.cpp
@@ -319,7 +319,7 @@ TEST(someip_payload_test, send_different_payloads)
 }
 
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     std::string tcp_enable("--tcp");

--- a/test/network_tests/payload_tests/payload_test_service.cpp
+++ b/test/network_tests/payload_tests/payload_test_service.cpp
@@ -158,7 +158,7 @@ TEST(someip_payload_test, send_response_for_every_request)
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     std::string help("--help");

--- a/test/network_tests/payload_tests/stopwatch.cpp
+++ b/test/network_tests/payload_tests/stopwatch.cpp
@@ -29,7 +29,11 @@ stop_watch::usec_t stop_watch::get_total_elapsed_seconds() const {
 stop_watch::usec_t stop_watch::now() {
     struct timespec ts;
 
+#ifdef __QNX__
+    const int ret = clock_gettime(CLOCK_MONOTONIC, &ts);
+#else
     const int ret = clock_gettime(CLOCK_MONOTONIC_RAW, &ts);
+#endif
     assert(!ret);
     static_cast<void>(ret); // prevent warning in release build
 

--- a/test/network_tests/pending_subscription_tests/pending_subscription_test_sd_msg_sender.cpp
+++ b/test/network_tests/pending_subscription_tests/pending_subscription_test_sd_msg_sender.cpp
@@ -1701,7 +1701,7 @@ TEST_F(pending_subscription, send_request_to_sd_port)
     udp_socket.close(ec);
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     if(argc < 4) {

--- a/test/network_tests/pending_subscription_tests/pending_subscription_test_service.cpp
+++ b/test/network_tests/pending_subscription_tests/pending_subscription_test_service.cpp
@@ -354,7 +354,7 @@ TEST(someip_pending_subscription_test, block_subscription_handler)
 }
 
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/restart_routing_tests/restart_routing_test_service.cpp
+++ b/test/network_tests/restart_routing_tests/restart_routing_test_service.cpp
@@ -125,7 +125,7 @@ TEST(someip_restart_routing_test, send_response_for_every_request) {
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();

--- a/test/network_tests/routing_tests/conf/local_routing_test_starter_qnx.sh.in
+++ b/test/network_tests/routing_tests/conf/local_routing_test_starter_qnx.sh.in
@@ -1,0 +1,76 @@
+#!/bin/sh
+# Copyright (C) 2015-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Purpose: This script is needed to start the client and service with
+# one command. This is necessary as ctest - which is used to run the
+# tests - isn't able to start two binaries for one testcase. Therefore
+# the testcase simply executes this script. This script then runs client
+# and service and checks that both exit sucessfully.
+
+FAIL=0
+
+# Parameter 1: the pid to check
+check_tcp_udp_sockets_are_closed ()
+{
+    # Check that the service does not listen on any TCP/UDP socket
+    # or has any active connection via a TCP/UDP socket
+    # awk is used to avoid the case when a inode number is the same as a PID. The awk
+    # program filters the netstat output down to the protocol (1st field) and
+    # the PID/Program name (last field) fields.
+    SERVICE_SOCKETS_LISTENING=$(netstat -tulpen 2> /dev/null | awk '{print $1 "\t"  $NF}' | grep $1 | wc -l)
+    if [ $SERVICE_SOCKETS_LISTENING -ne 0 ]
+    then
+        ((FAIL+=1))
+    fi
+
+    SERVICE_SOCKETS_CONNECTED=$(netstat -tupen 2> /dev/null | awk '{print $1 "\t"  $NF}' | grep $1 | wc -l)
+    if [ $SERVICE_SOCKETS_CONNECTED -ne 0 ]
+    then
+        ((FAIL+=1))
+    fi
+}
+
+export VSOMEIP_CONFIGURATION=local_routing_test_service.json
+# start daemon
+../../examples/routingmanagerd/./routingmanagerd &
+PID_VSOMEIPD=$!
+
+# Start the service
+export VSOMEIP_APPLICATION_NAME=local_routing_test_service
+./local_routing_test_service &
+SERIVCE_PID=$!
+WAIT_PID_ONE=$!
+sleep 1;
+
+check_tcp_udp_sockets_are_closed  $SERIVCE_PID
+
+# Start the client
+export VSOMEIP_APPLICATION_NAME=local_routing_test_client
+export VSOMEIP_CONFIGURATION=local_routing_test_client.json
+./local_routing_test_client &
+CLIENT_PID=$!
+WAIT_PID_TWO=$!
+
+check_tcp_udp_sockets_are_closed  $SERIVCE_PID
+check_tcp_udp_sockets_are_closed  $CLIENT_PID
+
+# Wait until client and service are finished
+# Fail gets incremented if either client or service exit
+# with a non-zero exit code
+wait $WAIT_PID_ONE || ((FAIL+=1))
+wait $WAIT_PID_TWO || ((FAIL+=1))
+
+kill $PID_VSOMEIPD
+sleep 1
+
+# Check if client and server both exited successfully and the service didnt't
+# have any open
+if [ $FAIL -eq 0 ]
+then
+    exit 0
+else
+    exit 1
+fi

--- a/test/network_tests/routing_tests/external_local_routing_test_service.cpp
+++ b/test/network_tests/routing_tests/external_local_routing_test_service.cpp
@@ -176,7 +176,7 @@ TEST(someip_external_local_routing_test, receive_ten_messages_over_local_and_ext
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/routing_tests/local_routing_test_client.cpp
+++ b/test/network_tests/routing_tests/local_routing_test_client.cpp
@@ -158,7 +158,7 @@ TEST(someip_local_routing_test, send_ten_messages_to_service_and_receive_reply)
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/routing_tests/local_routing_test_service.cpp
+++ b/test/network_tests/routing_tests/local_routing_test_service.cpp
@@ -155,7 +155,7 @@ TEST(someip_local_routing_test, receive_ten_messages_over_local_uds_socket)
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/second_address_tests/second_address_test_client.cpp
+++ b/test/network_tests/second_address_tests/second_address_test_client.cpp
@@ -332,7 +332,7 @@ TEST(someip_event_test, communicate_using_second_address)
     second_address_test_client its_sample(second_address_test::service, use_tcp);
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/second_address_tests/second_address_test_service.cpp
+++ b/test/network_tests/second_address_tests/second_address_test_service.cpp
@@ -243,7 +243,7 @@ TEST(someip_second_address_test, test_communication_with_client)
     second_address_test_service its_sample(second_address_test::service);
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/security_tests/security_test_service.cpp
+++ b/test/network_tests/security_tests/security_test_service.cpp
@@ -171,7 +171,7 @@ TEST(someip_security_test, basic_subscribe_request_response) {
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv) {
 
     std::string test_remote("--remote");

--- a/test/network_tests/someip_tp_tests/someip_tp_test_msg_sender.cpp
+++ b/test/network_tests/someip_tp_tests/someip_tp_test_msg_sender.cpp
@@ -1357,7 +1357,7 @@ TEST_P(someip_tp, send_in_mode)
     udp_server_socket.close(ec);
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv) {
     ::testing::InitGoogleTest(&argc, argv);
     if(argc < 3) {

--- a/test/network_tests/someip_tp_tests/someip_tp_test_service.cpp
+++ b/test/network_tests/someip_tp_tests/someip_tp_test_service.cpp
@@ -382,7 +382,7 @@ TEST(someip_someip_tp_test, echo_requests)
 }
 
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/subscribe_notify_one_tests/subscribe_notify_one_test_master_starter_qnx.sh
+++ b/test/network_tests/subscribe_notify_one_tests/subscribe_notify_one_test_master_starter_qnx.sh
@@ -1,0 +1,79 @@
+#!/bin/sh
+# Copyright (C) 2015-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Purpose: This script is needed to start the services with
+# one command. This is necessary as ctest - which is used to run the
+# tests - isn't able to start multiple binaries for one testcase. Therefore
+# the testcase simply executes this script. This script then runs the services
+# and checks that all exit successfully.
+
+if [ $# -lt 2 ]
+then
+    echo "Please pass a json file and event reliability type to this script."
+    echo "For example: $0 subscribe_notify_one_test_diff_client_ids_diff_ports_master_udp.json UDP"
+    exit 1
+fi
+
+# replace master with slave to be able display the correct json file to be used
+# with the slave script
+RELIABILITY_TYPE=$1
+MASTER_JSON_FILE=$2
+CLIENT_JSON_FILE="<corresponding-slave-json-for-$MASTER_JSON_FILE>"
+
+FAIL=0
+
+# Start the services
+export VSOMEIP_APPLICATION_NAME=subscribe_notify_one_test_service_one
+export VSOMEIP_CONFIGURATION=$MASTER_JSON_FILE
+./subscribe_notify_one_test_service 1 $RELIABILITY_TYPE &
+
+export VSOMEIP_APPLICATION_NAME=subscribe_notify_one_test_service_two
+export VSOMEIP_CONFIGURATION=$MASTER_JSON_FILE
+./subscribe_notify_one_test_service 2 $RELIABILITY_TYPE &
+
+export VSOMEIP_APPLICATION_NAME=subscribe_notify_one_test_service_three
+export VSOMEIP_CONFIGURATION=$MASTER_JSON_FILE
+./subscribe_notify_one_test_service 3 $RELIABILITY_TYPE &
+
+sleep 3
+
+if [ ! -z "$USE_LXC_TEST" ]; then
+    echo "starting subscribe_notify_one_test_slave_starter.sh on slave LXC with parameters $CLIENT_JSON_FILE"
+    ssh -tt -i $SANDBOX_ROOT_DIR/commonapi_main/lxc-config/.ssh/mgc_lxc/rsa_key_file.pub -o StrictHostKeyChecking=no root@$LXC_TEST_SLAVE_IP "bash -ci \"set -m; cd \\\$SANDBOX_TARGET_DIR/vsomeip_lib/test/network_tests; ./subscribe_notify_one_test_slave_starter.sh $RELIABILITY_TYPE $CLIENT_JSON_FILE\"" &
+    echo "remote ssh job id: $!"
+elif [ ! -z "$USE_DOCKER" ]; then
+    docker exec $DOCKER_IMAGE sh -c "cd $DOCKER_TESTS && ./subscribe_notify_one_test_slave_starter.sh $RELIABILITY_TYPE $CLIENT_JSON_FILE" &
+else
+    cat <<End-of-message
+*******************************************************************************
+*******************************************************************************
+** Please now run:
+** subscribe_notify_one_test_slave_starter.sh $RELIABILITY_TYPE $CLIENT_JSON_FILE
+** from an external host to successfully complete this test.
+**
+** You probably will need to adapt the 'unicast' settings in
+** subscribe_notify_one_test_diff_client_ids_diff_ports_master.json and
+** subscribe_notify_one_test_diff_client_ids_diff_ports_slave.json to your personal setup.
+*******************************************************************************
+*******************************************************************************
+End-of-message
+fi
+
+# Wait until client and service are finished
+for job in $(jobs -p)
+do
+    # Fail gets incremented if either client or service exit
+    # with a non-zero exit code
+    wait $job || ((FAIL+=1))
+done
+
+# Check if both exited successfully
+if [ $FAIL -eq 0 ]
+then
+    exit 0
+else
+    exit 1
+fi

--- a/test/network_tests/subscribe_notify_one_tests/subscribe_notify_one_test_service.cpp
+++ b/test/network_tests/subscribe_notify_one_tests/subscribe_notify_one_test_service.cpp
@@ -470,7 +470,7 @@ TEST(someip_subscribe_notify_one_test, send_ten_notifications_to_service)
             reliability_type);
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/subscribe_notify_tests/subscribe_notify_test_master_starter_qnx.sh
+++ b/test/network_tests/subscribe_notify_tests/subscribe_notify_test_master_starter_qnx.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+# Copyright (C) 2015-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+# Purpose: This script is needed to start the services with
+# one command. This is necessary as ctest - which is used to run the
+# tests - isn't able to start multiple binaries for one testcase. Therefore
+# the testcase simply executes this script. This script then runs the services
+# and checks that all exit successfully.
+
+if [ $# -lt 1 ]
+then
+    echo "Please pass a json file and event reliability type to this script."
+    echo "For example: $0 UDP subscribe_notify_test_diff_client_ids_diff_ports_master.json"
+    echo "To use the same service id but different instances on the node pass SAME_SERVICE_ID as third parameter"
+    exit 1
+fi
+
+# replace master with slave to be able display the correct json file to be used
+# with the slave script
+RELIABILITY_TYPE=$1
+MASTER_JSON_FILE=$2
+SAME_SERVICE_ID=$3
+CLIENT_JSON_FILE="<corresponding-slave-json-for-$MASTER_JSON_FILE>"
+
+FAIL=0
+
+# Start the services
+export VSOMEIP_APPLICATION_NAME=subscribe_notify_test_service_one
+export VSOMEIP_CONFIGURATION=$MASTER_JSON_FILE
+./subscribe_notify_test_service 1 $RELIABILITY_TYPE $3 &
+
+export VSOMEIP_APPLICATION_NAME=subscribe_notify_test_service_two
+export VSOMEIP_CONFIGURATION=$MASTER_JSON_FILE
+./subscribe_notify_test_service 2 $RELIABILITY_TYPE $3 &
+
+export VSOMEIP_APPLICATION_NAME=subscribe_notify_test_service_three
+export VSOMEIP_CONFIGURATION=$MASTER_JSON_FILE
+./subscribe_notify_test_service 3 $RELIABILITY_TYPE $3 &
+
+sleep 3
+
+if [ ! -z "$USE_LXC_TEST" ]; then
+    echo "starting subscribe_notify_test_slave_starter.sh on slave LXC with parameters $CLIENT_JSON_FILE $2"
+    ssh -tt -i $SANDBOX_ROOT_DIR/commonapi_main/lxc-config/.ssh/mgc_lxc/rsa_key_file.pub -o StrictHostKeyChecking=no root@$LXC_TEST_SLAVE_IP "bash -ci \"set -m; cd \\\$SANDBOX_TARGET_DIR/vsomeip_lib/test/network_tests; ./subscribe_notify_test_slave_starter.sh $RELIABILITY_TYPE $CLIENT_JSON_FILE $3\"" &
+    echo "remote ssh job id: $!"
+elif [ ! -z "$USE_DOCKER" ]; then
+    docker exec $DOCKER_IMAGE sh -c "cd $DOCKER_TESTS && ./subscribe_notify_test_slave_starter.sh $RELIABILITY_TYPE $CLIENT_JSON_FILE $3" &
+else
+    cat <<End-of-message
+*******************************************************************************
+*******************************************************************************
+** Please now run:
+** subscribe_notify_test_slave_starter.sh $RELIABILITY_TYPE $CLIENT_JSON_FILE $3
+** from an external host to successfully complete this test.
+**
+** You probably will need to adapt the 'unicast' settings in
+** $MASTER_JSON_FILE and
+** $CLIENT_JSON_FILE to your personal setup.
+*******************************************************************************
+*******************************************************************************
+End-of-message
+fi
+
+if [ ! -z "$USE_DOCKER" ]; then
+  FAIL=0
+fi
+
+# Wait until client and service are finished
+for job in $(jobs -p)
+do
+    # Fail gets incremented if either client or service exit
+    # with a non-zero exit code
+    wait $job || ((FAIL+=1))
+done
+
+# Check if both exited successfully
+if [ $FAIL -eq 0 ]
+then
+    exit 0
+else
+    exit 1
+fi

--- a/test/network_tests/subscribe_notify_tests/subscribe_notify_test_one_event_two_eventgroups_client.cpp
+++ b/test/network_tests/subscribe_notify_tests/subscribe_notify_test_one_event_two_eventgroups_client.cpp
@@ -368,7 +368,7 @@ TEST(someip_subscribe_notify_test_one_event_two_eventgroups, subscribe_to_servic
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/subscribe_notify_tests/subscribe_notify_test_one_event_two_eventgroups_service.cpp
+++ b/test/network_tests/subscribe_notify_tests/subscribe_notify_test_one_event_two_eventgroups_service.cpp
@@ -219,7 +219,7 @@ TEST(someip_subscribe_notify_test_one_event_two_eventgroups, wait_for_attribute_
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/subscribe_notify_tests/subscribe_notify_test_service.cpp
+++ b/test/network_tests/subscribe_notify_tests/subscribe_notify_test_service.cpp
@@ -477,7 +477,7 @@ TEST(someip_subscribe_notify_test, send_ten_notifications_to_service)
     }
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv)
 {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/suspend_resume_tests/suspend_resume_test_client.cpp
+++ b/test/network_tests/suspend_resume_tests/suspend_resume_test_client.cpp
@@ -229,7 +229,7 @@ TEST(suspend_resume_test, fast)
     its_client.run_test();
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv) {
 
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/network_tests/suspend_resume_tests/suspend_resume_test_service.cpp
+++ b/test/network_tests/suspend_resume_tests/suspend_resume_test_service.cpp
@@ -201,7 +201,7 @@ TEST(suspend_resume_test, fast)
     its_service.run_test();
 }
 
-#if defined(__linux__) || defined(ANDROID)
+#if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
 int main(int argc, char** argv) {
 
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/unit_tests/security_tests/ut_is_policy_update_allowed.cpp
+++ b/test/unit_tests/security_tests/ut_is_policy_update_allowed.cpp
@@ -20,6 +20,7 @@ vsomeip_v3::service_t valid_service { 0xf913 };
 vsomeip_v3::service_t invalid_service { 0x41 };
 }
 
+#ifndef __QNX__
 TEST(is_policy_update_allowed, check_whitelist_disabled)
 {
     // Test object.
@@ -169,6 +170,7 @@ TEST(is_policy_update_allowed, check_whitelist_enabled)
     EXPECT_FALSE(security->is_policy_update_allowed(valid_uid, policy))
             << "Failed to deny policy update with valid user id and invalid request!";
 }
+#endif
 
 TEST(is_policy_update_allowed, null_policy)
 {


### PR DESCRIPTION
Add support for QNX 7.1.

Build instruction:
```bash
# source the QNX environment script
source <path-to-qnxsdp-env.sh>/qnxsdp-env.sh

# Create a workspace
mkdir ~/vsomeip_workspace
WORKSPACE=~/vsomeip_workspace

# Build and install boost
cd $WORKSPACE
git clone https://gitlab.com/qnx/libs/boost.git && cd boost
git checkout QNX_7.1_v1.63.0
git submodule update --init --recursive
cd tools/build
git apply ../../boost_tools_build_qnx.patch
cd -
mkdir -p ./boost/utility
cp -r ./libs/utility/include/boost/utility/detail ./boost/utility
JLEVEL=8 make install

# Get googletest
cd $WORKSPACE
git clone https://gitlab.com/qnx/libs/googletest.git
export GTEST_ROOT=$WORKSPACE/googletest

# Build and install vsomeip
git clone https://github.com/chachoi/vsomeip.git && cd vsomeip/build_qnx

# Before building, look at $WORKSPACE/vsomeip/build_qnx/common.mk
# set TEST_IP_MASTER to the target ip address
# set TEST_IP_SLAVE to the host PC ip address for tests
JLEVEL=8 make install
```

[Test instruction](https://gitlab.com/qnx/libs/vsomeip/-/wikis/Test-vsomeip)