### PR TITLE
Prevent boost symbols from leaking into global namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,6 +301,10 @@ target_include_directories(${VSOMEIP_NAME} INTERFACE
 # the build.
 target_link_libraries(${VSOMEIP_NAME} PRIVATE ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${DLT_LIBRARIES} ${SystemD_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
+if(NOT WIN32)
+    target_link_options(${VSOMEIP_NAME} PRIVATE "LINKER:-as-needed")
+endif()
+
 ################################################################################
 # Service Discovery library
 ################################################################################

--- a/implementation/plugin/src/plugin_manager_impl.cpp
+++ b/implementation/plugin/src/plugin_manager_impl.cpp
@@ -178,7 +178,7 @@ void * plugin_manager_impl::load_library(const std::string &_path) {
 #ifdef _WIN32
     return LoadLibrary(_path.c_str());
 #else
-    return dlopen(_path.c_str(), RTLD_LAZY | RTLD_GLOBAL);
+    return dlopen(_path.c_str(), RTLD_LAZY | RTLD_LOCAL);
 #endif
 }
 


### PR DESCRIPTION
The plugin manager currently call's `dlopen` with the `RTLD_GLOBAL` flag, which make all the boost symbols from the filesystem shared library available for relocation and use by other parts of application outside of vsomeip.  This can cause ABI conflicts if a different version of boost is in use by other parts of the application, but those parts end up using the implementation from vsomeip's boost.  Since there doesn't appear to be any need for the `RTLD_GLOBAL` flag, replace it with `RTLD_LOCAL` to prevent the boost symbols from leaking into the global namespace.

In addition, also use the `--as-needed` flag for the primary vsomeip library. This library links against all the boost libraries but doesn't actually need them (at least not the filesystem one), so remove them in the linker stage so that boost symbols aren't brought through this path either.