### PR TITLE
vsomeip 3.3.5.1

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -55,7 +55,7 @@ cc_defaults {
 
 cc_defaults {
     name: "vsomeip_lib_defaults",
-    
+
     cflags: [
         "-DVSOMEIP_BOOST_VERSION=107100",
         "-DVSOMEIP_INTERNAL_SUPPRESS_DEPRECATED",
@@ -80,14 +80,15 @@ cc_library_shared {
 
     cflags: [
         "-DWITHOUT_SYSTEMD",
-        "-DVSOMEIP_COMPAT_VERSION=\"3.3.0\"",
+        "-DVSOMEIP_COMPAT_VERSION=\"3.3.5\"",
         "-DVSOMEIP_BASE_PATH=\"/vendor/run/someip/\"",
         "-DUSE_DLT",
     ],
 
     ldflags: [
         "-Wl,-wrap,socket",
-        "-Wl,-wrap,accept"
+        "-Wl,-wrap,accept",
+        "-Wl,-wrap,open"
     ],
 
     rtti: true,

--- a/Android.mk
+++ b/Android.mk
@@ -100,7 +100,7 @@ LOCAL_CFLAGS :=  \
     -frtti \
     -fexceptions \
     -DWITHOUT_SYSTEMD \
-    -DVSOMEIP_VERSION=\"3.3.0\" \
+    -DVSOMEIP_VERSION=\"3.3.5\" \
     -DVSOMEIP_BASE_PATH=\"/vendor/run/someip/\" \
     -Wno-unused-parameter \
     -Wno-non-virtual-dtor \
@@ -147,7 +147,7 @@ LOCAL_CFLAGS := \
     -frtti \
     -fexceptions \
     -DWITHOUT_SYSTEMD \
-    -DVSOMEIP_VERSION=\"3.3.0\" \
+    -DVSOMEIP_VERSION=\"3.3.5\" \
     -DVSOMEIP_BASE_PATH=\"/vendor/run/someip/\" \
     -Wno-unused-parameter \
     -Wno-non-virtual-dtor \
@@ -194,8 +194,8 @@ LOCAL_CFLAGS :=  \
     -frtti \
     -fexceptions \
     -DWITHOUT_SYSTEMD \
-    -DVSOMEIP_VERSION=\"3.3.0\" \
-    -DVSOMEIP_COMPAT_VERSION=\"3.3.0\" \
+    -DVSOMEIP_VERSION=\"3.3.5\" \
+    -DVSOMEIP_COMPAT_VERSION=\"3.3.5\" \
     -DVSOMEIP_BASE_PATH=\"/vendor/run/someip/\" \
     -Wno-unused-parameter \
     -Wno-non-virtual-dtor \
@@ -210,5 +210,7 @@ LOCAL_CFLAGS :=  \
     -Wno-header-guard \
     -Wno-overloaded-virtual \
     -Wl,-wrap,socket \
+    -Wl,-wrap,accept \
+    -Wl,-wrap,open \
 
 include $(BUILD_SHARED_LIBRARY)

--- a/CHANGES
+++ b/CHANGES
@@ -1,7 +1,22 @@
 Changes
 =======
 
-v3.3.0
+v3.3.5.1
+- Fix typo in application_impl.cpp
+- Update load_balancing_option_impl.cpp
+- Fix format specifier in memory_log_timer_cbk
+- Isolate boost
+- Remove redundant ostream manipulators
+- Fix for configuration option deserialize bug
+- Accept return codes within range 0x20 - 0x5E as valid
+
+v3.3.5
+- Do NOT use iterators in asynchronous operations.
+- Add event identifier to "REGISTER EVENT" log message at routing manager stub.
+- Fix for crash in flush function, server_endpoint_impl class
+- added FD_CLOEXEC flag in all open operations
+- Use "make_unique" and "make_shared" to construct "unique_ptr" and "shared_ptr"
+- Removed redundant pairs of parentheses
 - Do not erase while iterating.
 - Changed invalid call of deserialize to serialize
 - Fixed the the problem in policy::deserialize counts down the given policy size,
@@ -10,10 +25,13 @@ and after deserializing the policy it is 0.
 - Fix timestamp format of log message
 - Prevent crash when logging with DLT
 - load_security_update_whitelist Unit and Benchmark Tests
-- Added protection when a message is destroyed.
+- Added protection when a message is destroyed
+- Pu/connect timeout refactor
 - Rework the addition of services when in suspended mode
 - Remove const qualifier from function return types
 - Adapt to boost 1.81.0
+
+v3.3.4
 - Removed VSOMEIP_DEPRECATED_UID_GID from some elements.
 - Add nullptr guards to receive_cbk.
 - Add nullptr check to receive_cbk.
@@ -28,10 +46,14 @@ and after deserializing the policy it is 0.
 - Reduce log level of some vsomeip messages.
 - Change dependency on LINK UP.
 - Change rejoining mechanism in UDP server endpoint.
+
+v3.3.3
 - Fixed android build issues
 - Added more DLT log info on credentials error
 - Fixed ICON register issues.
 - Added an  unlocked method to get the policy extension path
+
+v3.3.2
 - Manage E2E Profile04 counters per instance
 - Fix handling of subscription objects during unsubscribe.
 - Remove subscription on connection resets.
@@ -48,6 +70,8 @@ and after deserializing the policy it is 0.
 - Handling with some udp errors in send_cbk process.
 - Avoid services becoming available when the daemon is suspended.
 - refactor: remove `set_bound_sec_client()` from `local_tcp_server_endpoint_impl`.
+
+v3.3.1
 - Refactor `plugin_manager_impl::load_symbol()`
 - Use consistent naming for `security::is_client_allowed_to_access()`
 - Raise C++ standard used to C++17 on non-Windows platforms
@@ -65,6 +89,8 @@ and after deserializing the policy it is 0.
 - Make the sec client a member of the connection
 - Add support for TCP clients in the default security hooks
 - Fix security checks when using internal TCP sockets
+
+v3.3.0
 - Introduced protocol classes
 - Extended interface to allow application specific configurations
 - Allow to switch off internal routing

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set (VSOMEIP_COMPAT_NAME vsomeip)
 
 set (VSOMEIP_MAJOR_VERSION 3)
 set (VSOMEIP_MINOR_VERSION 3)
-set (VSOMEIP_PATCH_VERSION 0)
+set (VSOMEIP_PATCH_VERSION 5)
 set (VSOMEIP_HOTFIX_VERSION 0)
 
 set (VSOMEIP_VERSION ${VSOMEIP_MAJOR_VERSION}.${VSOMEIP_MINOR_VERSION}.${VSOMEIP_PATCH_VERSION})
@@ -288,7 +288,7 @@ set_target_properties (${VSOMEIP_NAME} PROPERTIES VERSION ${VSOMEIP_VERSION} SOV
 if (MSVC)
     set_target_properties(${VSOMEIP_NAME} PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION")
 else ()
-    set_target_properties(${VSOMEIP_NAME} PROPERTIES LINK_FLAGS "-Wl,-wrap,socket -Wl,-wrap,accept")
+    set_target_properties(${VSOMEIP_NAME} PROPERTIES LINK_FLAGS "-Wl,-wrap,socket -Wl,-wrap,accept -Wl,-wrap,open")
 endif ()
 target_include_directories(${VSOMEIP_NAME} INTERFACE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/interface>

--- a/implementation/configuration/include/internal_android.hpp
+++ b/implementation/configuration/include/internal_android.hpp
@@ -119,14 +119,14 @@ typedef enum {
     IS_SUBSCRIBING
 } subscription_state_e;
 
-const std::uint32_t MESSAGE_SIZE_UNLIMITED = (std::numeric_limits<std::uint32_t>::max)();
+const std::uint32_t MESSAGE_SIZE_UNLIMITED = std::numeric_limits<std::uint32_t>::max();
 
-const std::uint32_t QUEUE_SIZE_UNLIMITED = (std::numeric_limits<std::uint32_t>::max)();
+const std::uint32_t QUEUE_SIZE_UNLIMITED = std::numeric_limits<std::uint32_t>::max();
 
 #define VSOMEIP_DEFAULT_NPDU_DEBOUNCING_NANO         2 * 1000 * 1000
 #define VSOMEIP_DEFAULT_NPDU_MAXIMUM_RETENTION_NANO  5 * 1000 * 1000
 
-const std::uint32_t MAX_RECONNECTS_UNLIMITED = (std::numeric_limits<std::uint32_t>::max)();
+const std::uint32_t MAX_RECONNECTS_UNLIMITED = std::numeric_limits<std::uint32_t>::max();
 
 const std::uint32_t ANY_UID = 0xFFFFFFFF;
 const std::uint32_t ANY_GID = 0xFFFFFFFF;

--- a/implementation/configuration/include/routing.hpp
+++ b/implementation/configuration/include/routing.hpp
@@ -32,7 +32,7 @@ struct routing_host_t {
         unicast_ = _other.unicast_;
         port_ = _other.port_;
 
-        return (*this);
+        return *this;
     }
 };
 
@@ -44,7 +44,7 @@ struct routing_guests_t {
         unicast_ = _other.unicast_;
         ports_ = _other.ports_;
 
-        return (*this);
+        return *this;
     }
 };
 
@@ -61,7 +61,7 @@ struct routing_t {
         host_ = _other.host_;
         guests_ = _other.guests_;
 
-        return (*this);
+        return *this;
     }
 };
 

--- a/implementation/configuration/src/configuration_impl.cpp
+++ b/implementation/configuration/src/configuration_impl.cpp
@@ -834,9 +834,9 @@ configuration_impl::load_routing_host(const boost::property_tree::ptree &_tree,
         }
 
     } catch (...) {
-        return (false);
+        return false;
     }
-    return (true);
+    return true;
 }
 
 bool
@@ -862,7 +862,7 @@ configuration_impl::load_routing_guests(const boost::property_tree::ptree &_tree
     } catch (...) {
         // intentionally left empty
     }
-    return (true);
+    return true;
 }
 
 void
@@ -1570,8 +1570,8 @@ void configuration_impl::load_service_discovery(
                     int tmp;
                     its_converter << its_value;
                     its_converter >> tmp;
-                    sd_repetitions_max_ = (tmp > (std::numeric_limits<std::uint8_t>::max)()) ?
-                                    (std::numeric_limits<std::uint8_t>::max)() :
+                    sd_repetitions_max_ = (tmp > std::numeric_limits<std::uint8_t>::max()) ?
+                                    std::numeric_limits<std::uint8_t>::max() :
                                     static_cast<std::uint8_t>(tmp);
                     is_configured_[ET_SERVICE_DISCOVERY_REPETITION_MAX] = true;
                 }
@@ -1641,8 +1641,8 @@ void configuration_impl::load_service_discovery(
                     int tmp;
                     its_converter << its_value;
                     its_converter >> tmp;
-                    max_remote_subscribers_ = (tmp > (std::numeric_limits<std::uint8_t>::max)()) ?
-                                    (std::numeric_limits<std::uint8_t>::max)() :
+                    max_remote_subscribers_ = (tmp > std::numeric_limits<std::uint8_t>::max()) ?
+                                    std::numeric_limits<std::uint8_t>::max() :
                                     static_cast<std::uint8_t>(tmp);
                     if (max_remote_subscribers_ == 0) {
                         VSOMEIP_WARNING << "max_remote_subscribers_ = 0 is not allowed. Using default ("
@@ -1675,8 +1675,8 @@ void configuration_impl::load_delays(
                 its_converter >> tmp_repetition_max;
                 sd_repetitions_max_ =
                         (tmp_repetition_max
-                                > (std::numeric_limits<std::uint8_t>::max)()) ?
-                                        (std::numeric_limits<std::uint8_t>::max)() :
+                                > std::numeric_limits<std::uint8_t>::max()) ?
+                                        std::numeric_limits<std::uint8_t>::max() :
                                         static_cast<std::uint8_t>(tmp_repetition_max);
             } else if (its_key == "cyclic-offer") {
                 its_converter << std::dec << i->second.data();
@@ -2030,8 +2030,8 @@ void configuration_impl::load_eventgroup(
                 its_converter << std::dec << its_value;
                 its_converter >> std::dec >> its_threshold;
                 its_eventgroup->threshold_ =
-                        (its_threshold > (std::numeric_limits<std::uint8_t>::max)()) ?
-                                (std::numeric_limits<std::uint8_t>::max)() :
+                        (its_threshold > std::numeric_limits<std::uint8_t>::max()) ?
+                                std::numeric_limits<std::uint8_t>::max() :
                                 static_cast<uint8_t>(its_threshold);
             } else if (its_key == "events") {
                 for (auto k = j->second.begin(); k != j->second.end(); ++k) {
@@ -2829,37 +2829,37 @@ bool configuration_impl::has_enabled_magic_cookies(const std::string &_address,
 }
 
 bool configuration_impl::is_routing_enabled() const {
-    return (routing_.is_enabled_);
+    return routing_.is_enabled_;
 }
 
 const std::string &
 configuration_impl::get_routing_host_name() const {
 
-    return (routing_.host_.name_);
+    return routing_.host_.name_;
 }
 
 const boost::asio::ip::address &
 configuration_impl::get_routing_host_address() const {
 
-    return (routing_.host_.unicast_);
+    return routing_.host_.unicast_;
 }
 
 port_t
 configuration_impl::get_routing_host_port() const {
 
-    return (routing_.host_.port_);
+    return routing_.host_.port_;
 }
 
 const boost::asio::ip::address &
 configuration_impl::get_routing_guest_address() const {
 
-    return (routing_.guests_.unicast_);
+    return routing_.guests_.unicast_;
 }
 
 std::set<std::pair<port_t, port_t> >
 configuration_impl::get_routing_guest_ports() const {
 
-    return (routing_.guests_.ports_);
+    return routing_.guests_.ports_;
 }
 
 bool
@@ -2872,7 +2872,7 @@ configuration_impl::is_local_routing() const {
     } catch (...) {
     }
 
-    return (is_local);
+    return is_local;
 }
 
 client_t configuration_impl::get_id(const std::string &_name) const {
@@ -2955,7 +2955,7 @@ bool configuration_impl::has_session_handling(const std::string &_name) const {
     if (found_application != applications_.end())
         its_value = found_application->second.has_session_handling_;
 
-    return (its_value);
+    return its_value;
 }
 
 std::set<std::pair<service_t, instance_t> >
@@ -4331,7 +4331,7 @@ configuration_impl::get_debounce(const std::string &_name,
             if (found_instance != found_service->second.end()) {
                 auto found_event = found_instance->second.find(_event);
                 if (found_event != found_instance->second.end()) {
-                    return (found_event->second);
+                    return found_event->second;
                 }
             }
         }
@@ -4345,11 +4345,11 @@ configuration_impl::get_debounce(const std::string &_name,
         if (found_instance != found_service->second.end()) {
             auto found_event = found_instance->second.find(_event);
             if (found_event != found_instance->second.end()) {
-                return (found_event->second);
+                return found_event->second;
             }
         }
     }
-    return (nullptr);
+    return nullptr;
 }
 
 void
@@ -4441,7 +4441,7 @@ bool configuration_impl::is_protected_port(
         }
     }
 
-    return (is_required);
+    return is_required;
 }
 
 bool configuration_impl::is_secure_port(
@@ -4463,7 +4463,7 @@ bool configuration_impl::is_secure_port(
         }
     }
 
-    return (is_secure);
+    return is_secure;
 }
 
 void configuration_impl::set_sd_acceptance_rule(
@@ -4626,12 +4626,12 @@ bool configuration_impl::is_secure_service(service_t _service, instance_t _insta
     const auto its_service = secure_services_.find(_service);
     if (its_service != secure_services_.end())
         return (its_service->second.find(_instance) != its_service->second.end());
-    return (false);
+    return false;
 }
 
 int configuration_impl::get_udp_receive_buffer_size() const {
 
-	return (udp_receive_buffer_size_);
+	return udp_receive_buffer_size_;
 }
 
 bool configuration_impl::is_tp_client(
@@ -4748,7 +4748,7 @@ configuration_impl::get_partition_id(
         }
     }
 
-    return (its_id);
+    return its_id;
 }
 
 reliability_type_e
@@ -4776,19 +4776,19 @@ configuration_impl::get_reliability_type(
 bool
 configuration_impl::is_security_enabled() const {
 
-    return (is_security_enabled_);
+    return is_security_enabled_;
 }
 
 bool
 configuration_impl::is_security_audit() const {
 
-    return (is_security_audit_);
+    return is_security_audit_;
 }
 
 bool
 configuration_impl::is_remote_access_allowed() const {
 
-    return (is_remote_access_allowed_);
+    return is_remote_access_allowed_;
 }
 
 }  // namespace cfg

--- a/implementation/configuration/src/configuration_plugin_impl.cpp
+++ b/implementation/configuration/src/configuration_plugin_impl.cpp
@@ -43,7 +43,7 @@ configuration_plugin_impl::get_configuration(const std::string &_name,
         configurations_[_name] = its_configuration;
     }
 
-    return (its_configuration);
+    return its_configuration;
 #endif
 }
 

--- a/implementation/e2e_protection/src/e2e/profile/e2e_provider_impl.cpp
+++ b/implementation/e2e_protection/src/e2e/profile/e2e_provider_impl.cpp
@@ -99,9 +99,9 @@ std::size_t e2e_provider_impl::get_protection_base(e2exf::data_identifier_t id) 
 {
     const auto found_base = custom_bases_.find(id);
     if (found_base != custom_bases_.end())
-        return (found_base->second);
+        return found_base->second;
 
-    return (0);
+    return 0;
 }
 
 void e2e_provider_impl::protect(e2exf::data_identifier_t id, e2e_buffer &_buffer,

--- a/implementation/e2e_protection/src/e2e/profile/profile04/checker.cpp
+++ b/implementation/e2e_protection/src/e2e/profile/profile04/checker.cpp
@@ -94,7 +94,7 @@ profile_04_checker::read_16(const e2e_buffer &_buffer,
 
     _data = VSOMEIP_BYTES_TO_WORD(_buffer[config_.offset_ + _index],
                                   _buffer[config_.offset_ + _index + 1]);
-    return (true);
+    return true;
 }
 
 bool
@@ -105,7 +105,7 @@ profile_04_checker::read_32(const e2e_buffer &_buffer,
                                   _buffer[config_.offset_ + _index + 1],
                                   _buffer[config_.offset_ + _index + 2],
                                   _buffer[config_.offset_ + _index + 3]);
-    return (true);
+    return true;
 }
 
 } // namespace profile01

--- a/implementation/e2e_protection/src/e2e/profile/profile04/profile_04.cpp
+++ b/implementation/e2e_protection/src/e2e/profile/profile04/profile_04.cpp
@@ -20,7 +20,7 @@ uint32_t profile_04::compute_crc(const profile_config &_config, const e2e_buffer
         computed_crc = e2e_crc::calculate_profile_04(its_after, computed_crc);
     }
 
-    return (computed_crc);
+    return computed_crc;
 }
 
 } // namespace profile04

--- a/implementation/e2e_protection/src/e2e/profile/profile04/protector.cpp
+++ b/implementation/e2e_protection/src/e2e/profile/profile04/protector.cpp
@@ -79,7 +79,7 @@ protector::get_counter(instance_t _instance) const {
     if (find_counter != counter_.end())
         its_counter = find_counter->second;
 
-    return (its_counter);
+    return its_counter;
 }
 
 void

--- a/implementation/endpoints/include/server_endpoint_impl.hpp
+++ b/implementation/endpoints/include/server_endpoint_impl.hpp
@@ -70,7 +70,7 @@ public:
     void prepare_stop(const endpoint::prepare_stop_handler_t &_handler,
                       service_t _service);
     virtual void stop();
-    bool flush(target_data_iterator_type _it);
+    bool flush(endpoint_type _it);
 
     size_t get_queue_size() const;
 
@@ -80,9 +80,9 @@ public:
 
 public:
     void connect_cbk(boost::system::error_code const &_error);
-    void send_cbk(const target_data_iterator_type _it,
+    void send_cbk(const endpoint_type _key,
                   boost::system::error_code const &_error, std::size_t _bytes);
-    void flush_cbk(target_data_iterator_type _it,
+    void flush_cbk(endpoint_type _key,
             const boost::system::error_code &_error_code);
 
 protected:

--- a/implementation/endpoints/src/client_endpoint_impl.cpp
+++ b/implementation/endpoints/src/client_endpoint_impl.cpp
@@ -36,7 +36,7 @@ client_endpoint_impl<Protocol>::client_endpoint_impl(
         const std::shared_ptr<configuration>& _configuration)
         : endpoint_impl<Protocol>(_endpoint_host, _routing_host, _local, _io,
                 _max_message_size, _queue_limit, _configuration),
-          socket_(new socket_type(_io)), remote_(_remote),
+          socket_(std::make_unique<socket_type>(_io)), remote_(_remote),
           flush_timer_(_io), connect_timer_(_io),
           connect_timeout_(VSOMEIP_DEFAULT_CONNECT_TIMEOUT), // TODO: use config variable
           state_(cei_state_e::CLOSED),
@@ -146,7 +146,7 @@ client_endpoint_impl<Protocol>::get_front() {
     if (queue_.size())
         its_entry = queue_.front();
 
-    return (its_entry);
+    return its_entry;
 }
 
 
@@ -405,7 +405,7 @@ bool client_endpoint_impl<Protocol>::flush() {
         start_dispatch_timer(its_now);
     }
 
-    return (has_queued);
+    return has_queued;
 }
 
 template<typename Protocol>

--- a/implementation/endpoints/src/endpoint_impl.cpp
+++ b/implementation/endpoints/src/endpoint_impl.cpp
@@ -141,7 +141,7 @@ instance_t endpoint_impl<Protocol>::get_instance(service_t _service) {
     if (its_host)
         its_instance = its_host->find_instance(_service, this);
 
-    return (its_instance);
+    return its_instance;
 }
 
 // Instantiate template

--- a/implementation/endpoints/src/endpoint_manager_base.cpp
+++ b/implementation/endpoints/src/endpoint_manager_base.cpp
@@ -57,7 +57,7 @@ std::shared_ptr<endpoint> endpoint_manager_base::find_or_create_local(client_t _
         its_endpoint = create_local_unlocked(_client);
         its_endpoint->start();
     }
-    return (its_endpoint);
+    return its_endpoint;
 }
 
 std::shared_ptr<endpoint> endpoint_manager_base::find_local(client_t _client) {
@@ -154,7 +154,7 @@ std::shared_ptr<endpoint> endpoint_manager_base::create_local_server(
         }
     }
 
-    return (its_server_endpoint);
+    return its_server_endpoint;
 }
 
 void endpoint_manager_base::on_connect(std::shared_ptr<endpoint> _endpoint) {
@@ -305,7 +305,7 @@ endpoint_manager_base::create_local_unlocked(client_t _client) {
         rm_->register_client_error_handler(_client, its_endpoint);
     }
 
-    return (its_endpoint);
+    return its_endpoint;
 }
 
 std::shared_ptr<endpoint> endpoint_manager_base::find_local_unlocked(client_t _client) {
@@ -314,7 +314,7 @@ std::shared_ptr<endpoint> endpoint_manager_base::find_local_unlocked(client_t _c
     if (found_endpoint != local_endpoints_.end()) {
         its_endpoint = found_endpoint->second;
     }
-    return (its_endpoint);
+    return its_endpoint;
 }
 
 instance_t endpoint_manager_base::find_instance(
@@ -342,12 +342,12 @@ endpoint_manager_base::get_local_server_port(port_t &_port,
                     && r != configuration_->get_routing_host_port()) {
 
                 _port = port_t(r);
-                return (true);
+                return true;
             }
         }
     }
 
-    return (false);
+    return false;
 }
 
 void

--- a/implementation/endpoints/src/endpoint_manager_impl.cpp
+++ b/implementation/endpoints/src/endpoint_manager_impl.cpp
@@ -292,7 +292,7 @@ std::shared_ptr<endpoint> endpoint_manager_impl::create_server_endpoint(
                 << " (" << _reliable << ")";
     }
 
-    return (its_endpoint);
+    return its_endpoint;
 }
 
 std::shared_ptr<endpoint> endpoint_manager_impl::find_server_endpoint(
@@ -306,7 +306,7 @@ std::shared_ptr<endpoint> endpoint_manager_impl::find_server_endpoint(
             its_endpoint = found_endpoint->second;
         }
     }
-    return (its_endpoint);
+    return its_endpoint;
 }
 
 std::shared_ptr<endpoint> endpoint_manager_impl::find_or_create_server_endpoint(
@@ -327,7 +327,7 @@ std::shared_ptr<endpoint> endpoint_manager_impl::find_or_create_server_endpoint(
         }
         its_endpoint->increment_use_count();
     }
-    return (its_endpoint);
+    return its_endpoint;
 }
 
 bool endpoint_manager_impl::remove_server_endpoint(uint16_t _port, bool _reliable) {
@@ -631,7 +631,7 @@ endpoint_manager_impl::create_routing_root(
                 << its_routing_host_id
                 << "]";
 
-        return (false);
+        return false;
     }
 
     if (configuration_->is_local_routing()) {
@@ -691,7 +691,7 @@ endpoint_manager_impl::create_routing_root(
                             << std::hex << std::setw(4) << std::setfill('0')
                             << VSOMEIP_ROUTING_CLIENT << ": " << e.what();
 
-                    return (false);
+                    return false;
                 }
             }
 
@@ -713,7 +713,7 @@ endpoint_manager_impl::create_routing_root(
                     << std::hex << std::setw(4) << std::setfill('0')
                     << VSOMEIP_ROUTING_CLIENT << ": " << e.what();
 
-            return (false);
+            return false;
         }
 
         _is_socket_activated = false;
@@ -736,13 +736,13 @@ endpoint_manager_impl::create_routing_root(
                     << std::hex << std::setw(4) << std::setfill('0')
                     << VSOMEIP_ROUTING_CLIENT << ": " << e.what();
 
-            return (false);
+            return false;
         }
 
         _is_socket_activated = false;
     }
 
-    return (true);
+    return true;
 }
 
 instance_t endpoint_manager_impl::find_instance(
@@ -800,11 +800,11 @@ bool endpoint_manager_impl::remove_instance_multicast(service_t _service,
                         service_instances_multicast_.erase(_service);
                     }
                 }
-                return (true);
+                return true;
             }
         }
     }
-    return (false);
+    return false;
 }
 
 void endpoint_manager_impl::on_connect(std::shared_ptr<endpoint> _endpoint) {
@@ -1057,7 +1057,7 @@ endpoint_manager_impl::find_remote_client(
         }
     }
 
-    return (its_endpoint);
+    return its_endpoint;
 }
 
 std::shared_ptr<endpoint> endpoint_manager_impl::create_remote_client(
@@ -1166,7 +1166,7 @@ std::shared_ptr<endpoint> endpoint_manager_impl::create_client_endpoint(
         VSOMEIP_ERROR << __func__ << " Client endpoint creation failed";
     }
 
-    return (its_endpoint);
+    return its_endpoint;
 }
 
 void

--- a/implementation/endpoints/src/local_tcp_client_endpoint_impl.cpp
+++ b/implementation/endpoints/src/local_tcp_client_endpoint_impl.cpp
@@ -355,7 +355,7 @@ bool local_tcp_client_endpoint_impl::is_reliable() const {
 
 std::uint32_t local_tcp_client_endpoint_impl::get_max_allowed_reconnects() const {
 
-    return (MAX_RECONNECTS_UNLIMITED);
+    return MAX_RECONNECTS_UNLIMITED;
 }
 
 bool local_tcp_client_endpoint_impl::tp_segmentation_enabled(

--- a/implementation/endpoints/src/local_tcp_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/local_tcp_server_endpoint_impl.cpp
@@ -438,11 +438,11 @@ client_t local_tcp_server_endpoint_impl::assign_client(
         VSOMEIP_ERROR << __func__
                 << ": assign client command deserialization failed ("
                 << std::dec << static_cast<int>(its_error) << ")";
-        return (VSOMEIP_CLIENT_UNSET);
+        return VSOMEIP_CLIENT_UNSET;
     }
 
-    return (utility::request_client_id(configuration_,
-            its_command.get_name(), its_command.get_client()));
+    return utility::request_client_id(configuration_,
+            its_command.get_name(), its_command.get_client());
 }
 
 void local_tcp_server_endpoint_impl::get_configured_times_from_endpoint(

--- a/implementation/endpoints/src/local_uds_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/local_uds_server_endpoint_impl.cpp
@@ -572,11 +572,11 @@ client_t local_uds_server_endpoint_impl::assign_client(
         VSOMEIP_ERROR << __func__
                 << ": assign client command deserialization failed ("
                 << std::dec << static_cast<int>(its_error) << ")";
-        return (VSOMEIP_CLIENT_UNSET);
+        return VSOMEIP_CLIENT_UNSET;
     }
 
-    return (utility::request_client_id(configuration_,
-            its_command.get_name(), its_command.get_client()));
+    return utility::request_client_id(configuration_,
+            its_command.get_name(), its_command.get_client());
 }
 
 void local_uds_server_endpoint_impl::get_configured_times_from_endpoint(

--- a/implementation/endpoints/src/tcp_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/tcp_server_endpoint_impl.cpp
@@ -498,7 +498,7 @@ void tcp_server_endpoint_impl::connection::send_queued(
                            std::chrono::steady_clock::now()),
                 std::bind(&tcp_server_endpoint_base_impl::send_cbk,
                           its_server,
-                          _it,
+                          _it->first,
                           std::placeholders::_1,
                           std::placeholders::_2));
     }

--- a/implementation/endpoints/src/tp.cpp
+++ b/implementation/endpoints/src/tp.cpp
@@ -51,7 +51,7 @@ tp::tp_split_message(const std::uint8_t * const _data, std::uint32_t _size,
         // insert tp_header
         const tp_header_t header = htonl(
                 static_cast<tp_header_t>((current_offset - VSOMEIP_FULL_HEADER_SIZE - _data)) |
-                static_cast<tp_header_t>((is_last_segment) ? 0x0u : 0x1u));
+                static_cast<tp_header_t>(is_last_segment ? 0x0u : 0x1u));
 
         const byte_t * const headerp = reinterpret_cast<const byte_t*>(&header);
         msg->insert(msg->end(), headerp, headerp + sizeof(tp_header_t));

--- a/implementation/endpoints/src/tp_message.cpp
+++ b/implementation/endpoints/src/tp_message.cpp
@@ -223,7 +223,7 @@ bool tp_message::add_segment(const byte_t* const _data,
             }
             if (last_segment_received_) {
                 // check if all segments are present
-                std::uint32_t last_end = (std::numeric_limits<std::uint32_t>::max)();
+                std::uint32_t last_end = std::numeric_limits<std::uint32_t>::max();
                 bool complete(true);
                 for (const auto& seg : segments_) {
                     if (last_end + 1 != seg.start_) {

--- a/implementation/endpoints/src/udp_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/udp_server_endpoint_impl.cpp
@@ -321,7 +321,7 @@ bool udp_server_endpoint_impl::send_queued(
         std::bind(
             &udp_server_endpoint_base_impl::send_cbk,
             shared_from_this(),
-            _it,
+            _it->first,
             std::placeholders::_1,
             std::placeholders::_2
         )
@@ -708,10 +708,10 @@ bool udp_server_endpoint_impl::is_same_subnet(const boost::asio::ip::address &_a
                 its_mask = byte_t(0xff << (((i+1) * sizeof(byte_t)) - prefix_));
 
             if ((its_local[i] & its_mask) != (its_address[i] & its_mask))
-                return (false);
+                return false;
         }
 
-        return (true);
+        return true;
     }
 #else
     if (_address.is_v4()) {
@@ -724,7 +724,7 @@ bool udp_server_endpoint_impl::is_same_subnet(const boost::asio::ip::address &_a
         is_same = (its_hosts.find(_address.to_v6()) != its_hosts.end());
     }
 #endif
-    return (is_same);
+    return is_same;
 }
 
 void udp_server_endpoint_impl::print_status() {
@@ -807,8 +807,7 @@ udp_server_endpoint_impl::set_multicast_option(
         if (!multicast_socket_) {
             std::lock_guard<std::mutex> its_guard(multicast_mutex_);
 
-            multicast_socket_ = std::unique_ptr<socket_type>(
-                    new socket_type(io_, local_.protocol()));
+            multicast_socket_ = std::make_unique<socket_type>(io_, local_.protocol());
 
             multicast_socket_->set_option(ip::udp::socket::reuse_address(true), ec);
             if (ec)
@@ -834,11 +833,11 @@ udp_server_endpoint_impl::set_multicast_option(
 
             if (!multicast_local_) {
                 if (is_v4_) {
-                    multicast_local_ = std::unique_ptr<endpoint_type>(
-                        new endpoint_type(boost::asio::ip::address_v4::any(), local_port_));
+                    multicast_local_ = std::make_unique<endpoint_type>
+                        (boost::asio::ip::address_v4::any(), local_port_);
                 } else { // is_v6
-                    multicast_local_ = std::unique_ptr<endpoint_type>(
-                        new endpoint_type(boost::asio::ip::address_v6::any(), local_port_));
+                    multicast_local_ = std::make_unique<endpoint_type>
+                        (boost::asio::ip::address_v6::any(), local_port_);
                 }
             }
 

--- a/implementation/endpoints/src/virtual_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/virtual_server_endpoint_impl.cpp
@@ -148,6 +148,6 @@ void virtual_server_endpoint_impl::print_status() {
 }
 
 size_t virtual_server_endpoint_impl::get_queue_size() const {
-    return 0;;
+    return 0;
 }
 } // namespace vsomeip_v3

--- a/implementation/logger/src/logger_impl.cpp
+++ b/implementation/logger/src/logger_impl.cpp
@@ -98,9 +98,9 @@ logger_impl::get() {
         if (!(*the_logger_ptr__)) {
             *the_logger_ptr__ = std::make_shared<logger_impl>();
         }
-        return (*the_logger_ptr__);
+        return *the_logger_ptr__;
     }
-    return (nullptr);
+    return nullptr;
 }
 
 #if defined(__linux__) || defined(ANDROID)
@@ -108,7 +108,7 @@ static void logger_impl_teardown(void) __attribute__((destructor));
 static void logger_impl_teardown(void)
 {
     // TODO: This mutex is causing a crash due to changes in the way mutexes are defined.
-    // Since this function only runs on the main thread, no mutex should be needed. Leaving a 
+    // Since this function only runs on the main thread, no mutex should be needed. Leaving a
     // comment pending a refactor.
     // std::lock_guard<std::mutex> its_lock(the_logger_mutex__);
     if (the_logger_ptr__ != nullptr) {

--- a/implementation/logger/src/message.cpp
+++ b/implementation/logger/src/message.cpp
@@ -203,13 +203,13 @@ message::buffer::overflow(std::streambuf::int_type c) {
         data_ << (char)c;
     }
 
-    return (c);
+    return c;
 }
 
 std::streamsize
 message::buffer::xsputn(const char *s, std::streamsize n) {
     data_.write(s, n);
-    return (n);
+    return n;
 }
 
 } // namespace logger

--- a/implementation/message/src/deserializer.cpp
+++ b/implementation/message/src/deserializer.cpp
@@ -165,7 +165,7 @@ bool deserializer::look_ahead(std::size_t _index, uint32_t &_value) const {
 }
 
 message_impl * deserializer::deserialize_message() try {
-    std::unique_ptr<message_impl> deserialized_message{new message_impl};
+    std::unique_ptr<message_impl> deserialized_message = std::make_unique<message_impl>();
     if (false == deserialized_message->deserialize(this)) {
         VSOMEIP_ERROR << "SOME/IP message deserialization failed!";
         deserialized_message = nullptr;

--- a/implementation/message/src/message_impl.cpp
+++ b/implementation/message/src/message_impl.cpp
@@ -75,7 +75,7 @@ uid_t message_impl::get_uid() const {
         its_uid = sec_client_.client.uds_client.user;
     }
 
-    return (its_uid);
+    return its_uid;
 }
 
 gid_t message_impl::get_gid() const {
@@ -86,12 +86,12 @@ gid_t message_impl::get_gid() const {
         its_gid = sec_client_.client.uds_client.group;
     }
 
-    return (its_gid);
+    return its_gid;
 }
 
 vsomeip_sec_client_t message_impl::get_sec_client() const {
 
-    return (sec_client_);
+    return sec_client_;
 }
 
 void message_impl::set_sec_client(const vsomeip_sec_client_t &_sec_client) {

--- a/implementation/protocol/include/protocol.hpp
+++ b/implementation/protocol/include/protocol.hpp
@@ -123,7 +123,7 @@ static inline id_e get_command(byte_t _byte) {
     id_e its_id(id_e::UNKNOWN_ID);
     if (_byte <= static_cast<byte_t>(id_e::SUSPEND_ID))
         its_id = static_cast<id_e>(_byte);
-    return (its_id);
+    return its_id;
 }
 
 static inline bool operator==(const byte_t &_lhs, const id_e &_rhs) {

--- a/implementation/protocol/src/assign_client_ack_command.cpp
+++ b/implementation/protocol/src/assign_client_ack_command.cpp
@@ -66,7 +66,7 @@ assign_client_ack_command::deserialize(const std::vector<byte_t> &_buffer,
 client_t
 assign_client_ack_command::get_assigned() const {
 
-    return (assigned_);
+    return assigned_;
 }
 
 void

--- a/implementation/protocol/src/assign_client_command.cpp
+++ b/implementation/protocol/src/assign_client_command.cpp
@@ -70,7 +70,7 @@ assign_client_command::deserialize(const std::vector<byte_t> &_buffer,
 std::string
 assign_client_command::get_name() const {
 
-    return (name_);
+    return name_;
 }
 
 void

--- a/implementation/protocol/src/distribute_security_policies_command.cpp
+++ b/implementation/protocol/src/distribute_security_policies_command.cpp
@@ -100,7 +100,7 @@ distribute_security_policies_command::deserialize(const std::vector<byte_t> &_bu
 std::set<std::shared_ptr<policy> >
 distribute_security_policies_command::get_policies() const {
 
-    return (policies_);
+    return policies_;
 }
 
 void

--- a/implementation/protocol/src/multiple_services_command_base.cpp
+++ b/implementation/protocol/src/multiple_services_command_base.cpp
@@ -99,7 +99,7 @@ multiple_services_command_base::deserialize(const std::vector<byte_t> &_buffer,
 std::set<service>
 multiple_services_command_base::get_services() const {
 
-    return (services_);
+    return services_;
 }
 
 void

--- a/implementation/protocol/src/offered_services_request_command.cpp
+++ b/implementation/protocol/src/offered_services_request_command.cpp
@@ -65,7 +65,7 @@ offered_services_request_command::deserialize(const std::vector<byte_t> &_buffer
 offer_type_e
 offered_services_request_command::get_offer_type() const {
 
-    return (offer_type_);
+    return offer_type_;
 }
 
 void

--- a/implementation/protocol/src/register_application_command.cpp
+++ b/implementation/protocol/src/register_application_command.cpp
@@ -68,7 +68,7 @@ register_application_command::deserialize(const std::vector<byte_t> &_buffer,
 port_t
 register_application_command::get_port() const {
 
-    return (port_);
+    return port_;
 }
 
 void

--- a/implementation/protocol/src/release_service_command.cpp
+++ b/implementation/protocol/src/release_service_command.cpp
@@ -76,7 +76,7 @@ release_service_command::deserialize(const std::vector<byte_t> &_buffer,
 service_t
 release_service_command::get_service() const {
 
-    return (service_.service_);
+    return service_.service_;
 }
 
 void
@@ -88,7 +88,7 @@ release_service_command::set_service(service_t _service) {
 instance_t
 release_service_command::get_instance() const {
 
-    return (service_.instance_);
+    return service_.instance_;
 }
 
 void

--- a/implementation/protocol/src/remove_security_policy_command.cpp
+++ b/implementation/protocol/src/remove_security_policy_command.cpp
@@ -76,7 +76,7 @@ remove_security_policy_command::deserialize(const std::vector<byte_t> &_buffer,
 uint32_t
 remove_security_policy_command::get_update_id() const {
 
-    return (update_id_);
+    return update_id_;
 }
 
 void
@@ -89,7 +89,7 @@ remove_security_policy_command::set_update_id(uint32_t _update_id) {
 uid_t
 remove_security_policy_command::get_uid() const {
 
-    return (uid_);
+    return uid_;
 }
 
 void
@@ -101,7 +101,7 @@ remove_security_policy_command::set_uid(uid_t _uid) {
 gid_t
 remove_security_policy_command::get_gid() const {
 
-    return (gid_);
+    return gid_;
 }
 
 void

--- a/implementation/protocol/src/resend_provided_events_command.cpp
+++ b/implementation/protocol/src/resend_provided_events_command.cpp
@@ -66,7 +66,7 @@ resend_provided_events_command::deserialize(const std::vector<byte_t> &_buffer,
 pending_remote_offer_id_t
 resend_provided_events_command::get_remote_offer_id() const {
 
-    return (remote_offer_id_);
+    return remote_offer_id_;
 }
 
 void

--- a/implementation/protocol/src/routing_info_command.cpp
+++ b/implementation/protocol/src/routing_info_command.cpp
@@ -79,7 +79,7 @@ routing_info_command::deserialize(const std::vector<byte_t> &_buffer,
 const std::vector<routing_info_entry> &
 routing_info_command::get_entries() const {
 
-    return (entries_);
+    return entries_;
 }
 
 void

--- a/implementation/protocol/src/routing_info_entry.cpp
+++ b/implementation/protocol/src/routing_info_entry.cpp
@@ -217,7 +217,7 @@ routing_info_entry::deserialize(const std::vector<byte_t> &_buffer,
 routing_info_entry_type_e
 routing_info_entry::get_type() const {
 
-    return (type_);
+    return type_;
 }
 
 void
@@ -249,13 +249,13 @@ routing_info_entry::get_size() const {
                  sizeof(major_version_t) + sizeof(minor_version_t)));
     }
 
-    return (its_size);
+    return its_size;
 }
 
 client_t
 routing_info_entry::get_client() const {
 
-    return (client_);
+    return client_;
 }
 
 void
@@ -267,7 +267,7 @@ routing_info_entry::set_client(client_t _client) {
 boost::asio::ip::address
 routing_info_entry::get_address() const {
 
-    return (address_);
+    return address_;
 }
 
 void
@@ -279,7 +279,7 @@ routing_info_entry::set_address(const boost::asio::ip::address &_address) {
 port_t
 routing_info_entry::get_port() const {
 
-    return (port_);
+    return port_;
 }
 
 void
@@ -291,7 +291,7 @@ routing_info_entry::set_port(port_t _port) {
 const std::vector<service> &
 routing_info_entry::get_services() const {
 
-    return (services_);
+    return services_;
 }
 
 void

--- a/implementation/protocol/src/security_policy_response_command_base.cpp
+++ b/implementation/protocol/src/security_policy_response_command_base.cpp
@@ -67,7 +67,7 @@ security_policy_response_command_base::deserialize(
 uint32_t
 security_policy_response_command_base::get_update_id() const {
 
-    return (update_id_);
+    return update_id_;
 }
 
 void

--- a/implementation/protocol/src/update_security_credentials_command.cpp
+++ b/implementation/protocol/src/update_security_credentials_command.cpp
@@ -89,7 +89,7 @@ update_security_credentials_command::deserialize(const std::vector<byte_t> &_buf
 std::set<std::pair<uid_t, gid_t> >
 update_security_credentials_command::get_credentials() const {
 
-    return (credentials_);
+    return credentials_;
 }
 
 void

--- a/implementation/protocol/src/update_security_policy_command.cpp
+++ b/implementation/protocol/src/update_security_policy_command.cpp
@@ -94,7 +94,7 @@ update_security_policy_command::deserialize(const std::vector<byte_t> &_buffer,
 uint32_t
 update_security_policy_command::get_update_id() const {
 
-    return (update_id_);
+    return update_id_;
 }
 
 void
@@ -106,7 +106,7 @@ update_security_policy_command::set_update_id(uint32_t _update_id) {
 std::shared_ptr<policy>
 update_security_policy_command::get_policy() const {
 
-    return (policy_);
+    return policy_;
 }
 
 void

--- a/implementation/routing/include/routing_manager_stub.hpp
+++ b/implementation/routing/include/routing_manager_stub.hpp
@@ -179,7 +179,7 @@ private:
             return (find_source->second.find(_sink)
                     != find_source->second.end());
 
-        return (false);
+        return false;
     }
     inline void add_connection(client_t _source, client_t _sink) {
 

--- a/implementation/routing/src/event.cpp
+++ b/implementation/routing/src/event.cpp
@@ -45,7 +45,7 @@ event::event(routing_manager *_routing, bool _is_shadow)
 service_t
 event::get_service() const {
 
-    return (current_->get_service());
+    return current_->get_service();
 }
 
 void
@@ -58,7 +58,7 @@ event::set_service(service_t _service) {
 instance_t
 event::get_instance() const {
 
-    return (current_->get_instance());
+    return current_->get_instance();
 }
 
 void
@@ -84,7 +84,7 @@ event::set_version(major_version_t _major) {
 event_t
 event::get_event() const {
 
-    return (current_->get_method());
+    return current_->get_method();
 }
 
 void
@@ -97,7 +97,7 @@ event::set_event(event_t _event) {
 event_type_e
 event::get_type() const {
 
-    return (type_);
+    return type_;
 }
 
 void
@@ -115,7 +115,7 @@ event::is_field() const {
 bool
 event::is_provided() const {
 
-    return (is_provided_);
+    return is_provided_;
 }
 
 void
@@ -132,7 +132,7 @@ std::shared_ptr<payload>
 event::get_payload() const {
 
     std::lock_guard<std::mutex> its_lock(mutex_);
-    return (current_->get_payload());
+    return current_->get_payload();
 }
 
 void
@@ -234,10 +234,10 @@ event::set_payload_notify_pending(const std::shared_ptr<payload> &_payload) {
 
         update_payload_unlocked();
 
-        return (true);
+        return true;
     }
 
-    return (false);
+    return false;
 }
 
 void
@@ -436,7 +436,7 @@ event::prepare_update_payload(const std::shared_ptr<payload> &_payload,
         bool _force) {
 
     std::lock_guard<std::mutex> its_lock(mutex_);
-    return (prepare_update_payload_unlocked(_payload, _force));
+    return prepare_update_payload_unlocked(_payload, _force);
 }
 
 bool
@@ -454,7 +454,7 @@ event::prepare_update_payload_unlocked(
             && cycle_ == std::chrono::milliseconds::zero()
             && !is_change) {
 
-        return (false);
+        return false;
     }
 
     if (is_change)
@@ -465,7 +465,7 @@ event::prepare_update_payload_unlocked(
 
     is_set_ = true;
 
-    return (true);
+    return true;
 }
 
 void
@@ -688,7 +688,7 @@ event::get_filtered_subscribers(bool _force) {
                 || epsilon_change_func_(its_payload, its_payload_update));
 
         if (must_forward)
-            return (its_subscribers);
+            return its_subscribers;
 
     } else {
         byte_t is_allowed(0xff);
@@ -714,7 +714,7 @@ event::get_filtered_subscribers(bool _force) {
         }
     }
 
-    return (its_filtered_subscribers);
+    return its_filtered_subscribers;
 }
 
 std::set<client_t>
@@ -728,7 +728,7 @@ event::update_and_get_filtered_subscribers(
     if (_is_from_remote)
         update_payload_unlocked();
 
-    return (its_subscribers);
+    return its_subscribers;
 }
 
 void
@@ -816,7 +816,7 @@ event::has_changed(const std::shared_ptr<payload> &_lhs,
             its_pos++;
         }
     }
-    return (is_change);
+    return is_change;
 }
 
 std::set<client_t>

--- a/implementation/routing/src/eventgroupinfo.cpp
+++ b/implementation/routing/src/eventgroupinfo.cpp
@@ -232,7 +232,7 @@ eventgroupinfo::update_remote_subscription(
 
     if (_subscription == nullptr) {
         VSOMEIP_ERROR << __func__ << ": Received ptr is null";
-        return (its_result);
+        return its_result;
     }
 
     std::shared_ptr<endpoint_definition> its_subscriber;
@@ -306,7 +306,7 @@ eventgroupinfo::update_remote_subscription(
             its_event->remove_pending(its_subscriber);
     }
 
-    return (its_result);
+    return its_result;
 }
 
 bool
@@ -316,7 +316,7 @@ eventgroupinfo::is_remote_subscription_limit_reached(
 
     if (_subscription == nullptr) {
         VSOMEIP_ERROR << __func__ << ": Received ptr is null";
-        return (limit_reached);
+        return limit_reached;
     }
 
     if (subscriptions_.size() <= max_remote_subscribers_) {

--- a/implementation/routing/src/routing_manager_base.cpp
+++ b/implementation/routing/src/routing_manager_base.cpp
@@ -50,12 +50,12 @@ routing_manager_base::routing_manager_base(routing_manager_host *_host) :
 
 boost::asio::io_context &routing_manager_base::get_io() {
 
-    return (io_);
+    return io_;
 }
 
 client_t routing_manager_base::get_client() const {
 
-    return (host_->get_client());
+    return host_->get_client();
 }
 
 void routing_manager_base::set_client(const client_t &_client) {
@@ -69,7 +69,7 @@ session_t routing_manager_base::get_session(bool _is_request) {
 
 const vsomeip_sec_client_t *routing_manager_base::get_sec_client() const {
 
-    return (host_->get_sec_client());
+    return host_->get_sec_client();
 }
 
 std::string routing_manager_base::get_client_host() const {
@@ -528,11 +528,11 @@ std::set<std::shared_ptr<event>> routing_manager_base::find_events(
         if (found_instance != found_service->second.end()) {
             auto found_eventgroup = found_instance->second.find(_eventgroup);
             if (found_eventgroup != found_instance->second.end()) {
-                return (found_eventgroup->second->get_events());
+                return found_eventgroup->second->get_events();
             }
         }
     }
-    return (its_events);
+    return its_events;
 }
 
 std::vector<event_t> routing_manager_base::find_events(
@@ -548,7 +548,7 @@ std::vector<event_t> routing_manager_base::find_events(
             }
         }
     }
-    return (its_events);
+    return its_events;
 }
 
 bool routing_manager_base::is_response_allowed(client_t _sender, service_t _service,
@@ -908,7 +908,7 @@ bool routing_manager_base::send(client_t _client,
     } else {
         VSOMEIP_ERROR << "Failed to serialize message. Check message size!";
     }
-    return (is_sent);
+    return is_sent;
 }
 
 // ********************************* PROTECTED **************************************
@@ -940,7 +940,7 @@ std::shared_ptr<serviceinfo> routing_manager_base::find_service(
             its_info = found_instance->second;
         }
     }
-    return (its_info);
+    return its_info;
 }
 
 void routing_manager_base::clear_service_info(service_t _service, instance_t _instance,
@@ -1128,7 +1128,7 @@ std::shared_ptr<event> routing_manager_base::find_event(service_t _service,
             }
         }
     }
-    return (its_event);
+    return its_event;
 }
 
 std::shared_ptr<eventgroupinfo> routing_manager_base::find_eventgroup(
@@ -1176,7 +1176,7 @@ std::shared_ptr<eventgroupinfo> routing_manager_base::find_eventgroup(
             }
         }
     }
-    return (its_info);
+    return its_info;
 }
 
 void routing_manager_base::remove_eventgroup_info(service_t _service,
@@ -1259,7 +1259,7 @@ bool routing_manager_base::send_local(
         has_sent = _target->send(&its_buffer[0], uint32_t(its_buffer.size()));
     }
 
-    return (has_sent);
+    return has_sent;
 }
 
 bool routing_manager_base::insert_subscription(
@@ -1347,7 +1347,7 @@ std::shared_ptr<serializer> routing_manager_base::get_serializer() {
     auto its_serializer = serializers_.front();
     serializers_.pop();
 
-    return (its_serializer);
+    return its_serializer;
 }
 
 void routing_manager_base::put_serializer(
@@ -1373,7 +1373,7 @@ std::shared_ptr<deserializer> routing_manager_base::get_deserializer() {
     auto its_deserializer = deserializers_.front();
     deserializers_.pop();
 
-    return (its_deserializer);
+    return its_deserializer;
 }
 
 void routing_manager_base::put_deserializer(
@@ -1461,12 +1461,12 @@ routing_manager_base::get_guest(client_t _client,
     std::lock_guard<std::mutex> its_lock(guests_mutex_);
     auto find_guest = guests_.find(_client);
     if (find_guest == guests_.end())
-        return (false);
+        return false;
 
     _address = find_guest->second.first;
     _port = find_guest->second.second;
 
-    return (true);
+    return true;
 }
 
 void

--- a/implementation/routing/src/routing_manager_client.cpp
+++ b/implementation/routing/src/routing_manager_client.cpp
@@ -291,7 +291,7 @@ std::string routing_manager_client::get_env_unlocked(client_t _client) const {
 
    auto find_client = known_clients_.find(_client);
    if (find_client != known_clients_.end()) {
-       return (find_client->second);
+       return find_client->second;
    }
    return "";
 }
@@ -936,7 +936,7 @@ bool routing_manager_client::send(client_t _client, const byte_t *_data,
                     _data, _size, _instance, _reliable, its_command, _status_check);
         }
     }
-    return (is_sent);
+    return is_sent;
 }
 
 bool routing_manager_client::send_to(const client_t _client,
@@ -947,7 +947,7 @@ bool routing_manager_client::send_to(const client_t _client,
     (void)_target;
     (void)_message;
 
-    return (false);
+    return false;
 }
 
 bool routing_manager_client::send_to(
@@ -959,7 +959,7 @@ bool routing_manager_client::send_to(
     (void)_size;
     (void)_instance;
 
-    return (false);
+    return false;
 }
 
 void routing_manager_client::on_connect(const std::shared_ptr<endpoint>& _endpoint) {
@@ -2088,7 +2088,7 @@ void routing_manager_client::assign_client() {
 
             boost::system::error_code ec;
             register_application_timer_.cancel(ec);
-            register_application_timer_.expires_from_now(std::chrono::milliseconds(10000));
+            register_application_timer_.expires_from_now(std::chrono::milliseconds(3000));
             register_application_timer_.async_wait(
                     std::bind(
                             &routing_manager_client::assign_client_timeout_cbk,

--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -104,7 +104,7 @@ client_t routing_manager_impl::get_client() const {
 
 const vsomeip_sec_client_t *routing_manager_impl::get_sec_client() const {
 
-    return (routing_manager_base::get_sec_client());
+    return routing_manager_base::get_sec_client();
 }
 
 std::string routing_manager_impl::get_client_host() const {
@@ -125,7 +125,7 @@ std::string routing_manager_impl::get_env_unlocked(client_t _client) const {
 
     auto find_client = known_clients_.find(_client);
     if (find_client != known_clients_.end()) {
-        return (find_client->second);
+        return find_client->second;
     }
     return "";
 }
@@ -1077,7 +1077,7 @@ bool routing_manager_impl::send(client_t _client, const byte_t *_data,
         }
     }
 
-    return (is_sent);
+    return is_sent;
 }
 
 bool routing_manager_impl::send_to(
@@ -1120,7 +1120,7 @@ bool routing_manager_impl::send_to(
     } else {
         VSOMEIP_ERROR<< "routing_manager_impl::send_to: serialization failed.";
     }
-    return (is_sent);
+    return is_sent;
 }
 
 bool routing_manager_impl::send_to(
@@ -2758,7 +2758,7 @@ routing_manager_impl::expire_subscriptions(
                     // Note: get_remote_subscription delivers a copied
                     // set of subscriptions. Thus, its is possible to
                     // to remove them within the loop.
-                    auto its_ep_definition = (_reliable) ?
+                    auto its_ep_definition = _reliable ?
                                     its_subscription->get_reliable() :
                                     its_subscription->get_unreliable();
 
@@ -4051,7 +4051,7 @@ routing_manager_impl::get_requested_services(client_t _client) {
             }
         }
     }
-    return (its_requests);
+    return its_requests;
 }
 
 std::set<client_t>
@@ -4059,7 +4059,7 @@ routing_manager_impl::get_requesters(service_t _service, instance_t _instance,
         major_version_t _major, minor_version_t _minor) {
 
     std::lock_guard<std::mutex> ist_lock(requested_services_mutex_);
-    return (get_requesters_unlocked(_service, _instance, _major, _minor));
+    return get_requesters_unlocked(_service, _instance, _major, _minor);
 }
 
 std::set<client_t>
@@ -4092,7 +4092,7 @@ routing_manager_impl::get_requesters_unlocked(
             }
         }
     }
-    return (its_requesters);
+    return its_requesters;
 }
 
 bool
@@ -4112,14 +4112,14 @@ routing_manager_impl::has_requester_unlocked(
                                 || _minor == DEFAULT_MINOR
                                 || its_minor.first == ANY_MINOR) {
 
-                            return (true);
+                            return true;
                         }
                     }
                 }
             }
         }
     }
-    return (false);
+    return false;
 }
 
 std::set<eventgroup_t>
@@ -4744,7 +4744,7 @@ routing_manager_impl::update_security_policy_configuration(
         return stub_->update_security_policy_configuration(_uid, _gid,
                           _policy, _payload, _handler);
 
-    return (false);
+    return false;
 }
 
 bool
@@ -4756,7 +4756,7 @@ routing_manager_impl::remove_security_policy_configuration(
         return stub_->remove_security_policy_configuration(_uid, _gid,
                           _handler);
 
-    return (false);
+    return false;
 }
 #endif // !VSOMEIP_DISABLE_SECURITY
 
@@ -4866,7 +4866,7 @@ bool
 routing_manager_impl::get_guest(client_t _client,
         boost::asio::ip::address &_address, port_t &_port) const {
 
-    return (routing_manager_base::get_guest(_client, _address, _port));
+    return routing_manager_base::get_guest(_client, _address, _port);
 }
 
 void

--- a/implementation/routing/src/routing_manager_stub.cpp
+++ b/implementation/routing/src/routing_manager_stub.cpp
@@ -706,7 +706,8 @@ void routing_manager_stub::on_message(const byte_t *_data, length_t _size,
                         << std::hex << std::setfill('0')
                         << std::setw(4) << its_client << "): ["
                         << std::setw(4) << its_service << "."
-                        << std::setw(4) << its_instance
+                        << std::setw(4) << its_instance << "."
+                        << std::setw(4) << register_event.get_event()
                         << ":eventtype=" << std::dec << (int)register_event.get_event_type()
                         << ":is_provided=" << std::boolalpha << register_event.is_provided()
                         << ":reliable=" << (int)register_event.get_reliability() << "]";
@@ -1338,7 +1339,7 @@ bool routing_manager_stub::send_subscribe(
             << " subscriber: " << std::setw(4) << _client;
     }
 
-    return (has_sent);
+    return has_sent;
 }
 
 bool routing_manager_stub::send_unsubscribe(
@@ -1380,7 +1381,7 @@ bool routing_manager_stub::send_unsubscribe(
             << " subscriber: "<< std::setw(4) << _client;
     }
 
-    return (has_sent);
+    return has_sent;
 }
 
 bool routing_manager_stub::send_expired_subscription(
@@ -1422,7 +1423,7 @@ bool routing_manager_stub::send_expired_subscription(
             << " subscriber: "<< std::setw(4) << _client;
     }
 
-    return (has_sent);
+    return has_sent;
 }
 
 void routing_manager_stub::send_subscribe_ack(client_t _client, service_t _service,
@@ -1667,7 +1668,7 @@ bool routing_manager_stub::send_ping(client_t _client) {
         }
     }
 
-    return (has_sent);
+    return has_sent;
 }
 
 void routing_manager_stub::on_ping_timer_expired(
@@ -2036,14 +2037,14 @@ bool routing_manager_stub::send_provided_event_resend_request(
         its_command.serialize(its_buffer, its_error);
 
         if (its_error == protocol::error_e::ERROR_OK)
-            return (its_endpoint->send(&its_buffer[0], uint32_t(its_buffer.size())));
+            return its_endpoint->send(&its_buffer[0], uint32_t(its_buffer.size()));
     } else {
         VSOMEIP_WARNING << __func__ << " Couldn't send provided event resend "
                 "request to local client: 0x"
                 << std::hex << std::setw(4) << std::setfill('0') << _client;
     }
 
-    return (false);
+    return false;
 }
 
 #ifndef VSOMEIP_DISABLE_SECURITY
@@ -2152,7 +2153,7 @@ bool routing_manager_stub::send_cached_security_policies(client_t _client) {
             << ": could not send cached security policies to registering client: 0x"
             << std::hex << std::setw(4) << std::setfill('0') << _client;
 
-    return (false);
+    return false;
 }
 
 bool routing_manager_stub::send_remove_security_policy_request(
@@ -2172,7 +2173,7 @@ bool routing_manager_stub::send_remove_security_policy_request(
     if (its_error == protocol::error_e::ERROR_OK) {
         std::shared_ptr<endpoint> its_endpoint = host_->find_local(_client);
         if (its_endpoint)
-            return (its_endpoint->send(&its_buffer[0], uint32_t(its_buffer.size())));
+            return its_endpoint->send(&its_buffer[0], uint32_t(its_buffer.size()));
         else
             VSOMEIP_ERROR << __func__
                 << ": cannot find local client endpoint for client "
@@ -2184,7 +2185,7 @@ bool routing_manager_stub::send_remove_security_policy_request(
             << std::dec << static_cast<int>(its_error)
             << ")";
 
-    return (false);
+    return false;
 
 }
 
@@ -2213,7 +2214,7 @@ routing_manager_stub::add_requester_policies(uid_t _uid, gid_t _gid,
     if (!its_clients.empty())
         return send_requester_policies(its_clients, _policies);
 
-    return (true);
+    return true;
 }
 
 void
@@ -2316,7 +2317,7 @@ routing_manager_stub::send_requester_policies(const std::unordered_set<client_t>
         }
     }
 
-    return (true);
+    return true;
 }
 
 void routing_manager_stub::on_security_update_timeout(

--- a/implementation/routing/src/serviceinfo.cpp
+++ b/implementation/routing/src/serviceinfo.cpp
@@ -80,7 +80,7 @@ void serviceinfo::set_precise_ttl(std::chrono::milliseconds _precise_ttl) {
 
 std::shared_ptr<endpoint> serviceinfo::get_endpoint(bool _reliable) const {
   std::lock_guard<std::mutex> its_lock(endpoint_mutex_);
-  return (_reliable ? reliable_ : unreliable_);
+  return _reliable ? reliable_ : unreliable_;
 }
 
 void serviceinfo::set_endpoint(const std::shared_ptr<endpoint>& _endpoint,

--- a/implementation/runtime/src/application_impl.cpp
+++ b/implementation/runtime/src/application_impl.cpp
@@ -657,7 +657,7 @@ application_impl::is_available_unlocked(
                     || _minor == DEFAULT_MINOR) {
                 its_state = found_major->second.second;
             }
-        } else if ((_major == DEFAULT_MAJOR || _major == ANY_MAJOR)) {
+        } else if (_major == DEFAULT_MAJOR || _major == ANY_MAJOR) {
             for (const auto &found_major : _found_instance->second) {
                 if (_minor == DEFAULT_MINOR || _minor == ANY_MINOR) {
                     its_state = found_major.second.second;
@@ -705,7 +705,7 @@ application_impl::is_available_unlocked(
             }
         }
     }
-    return (its_state);
+    return its_state;
 }
 
 bool application_impl::are_available(
@@ -836,9 +836,9 @@ application_impl::are_available_unlocked(available_t &_available,
     if (_available.empty()) {
         _available[_service][_instance][_major] = _minor ;
 
-        return (availability_state_e::AS_UNAVAILABLE);
+        return availability_state_e::AS_UNAVAILABLE;
     }
-    return (availability_state_e::AS_AVAILABLE);
+    return availability_state_e::AS_AVAILABLE;
 }
 
 void application_impl::send(std::shared_ptr<message> _message) {
@@ -853,8 +853,8 @@ void application_impl::send(std::shared_ptr<message> _message) {
             << std::setw(4) << _message->get_service() << "."
             << std::setw(4) << _message->get_instance() << "."
             << std::setw(4) << _message->get_method() << ":"
-            << std::setw(4) << ((is_request) ? session_ : _message->get_session()) << ":"
-            << std::setw(4) << ((is_request) ? client_.load() : _message->get_client()) << "] "
+            << std::setw(4) << (is_request ? session_ : _message->get_session()) << ":"
+            << std::setw(4) << (is_request ? client_.load() : _message->get_client()) << "] "
             << "type=" << static_cast<std::uint32_t>(_message->get_message_type())
             << " thread=" << std::this_thread::get_id();
     }
@@ -1442,7 +1442,7 @@ void application_impl::set_client(const client_t &_client) {
 session_t application_impl::get_session(bool _is_request) {
 
     if (!has_session_handling_ && !_is_request)
-        return (0);
+        return 0;
 
     std::lock_guard<std::mutex> its_lock(session_mutex_);
     if (0 == ++session_) {
@@ -2911,11 +2911,11 @@ application_impl::is_local_endpoint(const boost::asio::ip::address &_unicast,
         boost::asio::ip::tcp::socket its_socket(io_, its_endpoint);
         its_socket.close();
 
-        return (true);
+        return true;
     } catch (...) {
     }
 
-    return (false);
+    return false;
 }
 
 void application_impl::register_message_acceptance_handler(

--- a/implementation/runtime/src/runtime_impl.cpp
+++ b/implementation/runtime/src/runtime_impl.cpp
@@ -36,7 +36,7 @@ runtime_impl::~runtime_impl() {
 std::shared_ptr<application> runtime_impl::create_application(
         const std::string &_name) {
 
-    return (create_application(_name, ""));
+    return create_application(_name, "");
 }
 
 std::shared_ptr<application> runtime_impl::create_application(
@@ -61,7 +61,7 @@ std::shared_ptr<message> runtime_impl::create_message(bool _reliable) const {
     its_message->set_return_code(return_code_e::E_OK);
     its_message->set_reliable(_reliable);
     its_message->set_interface_version(DEFAULT_MAJOR);
-    return (its_message);
+    return its_message;
 }
 
 std::shared_ptr<message> runtime_impl::create_request(bool _reliable) const {
@@ -72,7 +72,7 @@ std::shared_ptr<message> runtime_impl::create_request(bool _reliable) const {
     its_request->set_return_code(return_code_e::E_OK);
     its_request->set_reliable(_reliable);
     its_request->set_interface_version(DEFAULT_MAJOR);
-    return (its_request);
+    return its_request;
 }
 
 std::shared_ptr<message> runtime_impl::create_response(
@@ -88,7 +88,7 @@ std::shared_ptr<message> runtime_impl::create_response(
     its_response->set_message_type(message_type_e::MT_RESPONSE);
     its_response->set_return_code(return_code_e::E_OK);
     its_response->set_reliable(_request->is_reliable());
-    return (its_response);
+    return its_response;
 }
 
 std::shared_ptr<message> runtime_impl::create_notification(
@@ -100,21 +100,21 @@ std::shared_ptr<message> runtime_impl::create_notification(
     its_notification->set_return_code(return_code_e::E_OK);
     its_notification->set_reliable(_reliable);
     its_notification->set_interface_version(DEFAULT_MAJOR);
-    return (its_notification);
+    return its_notification;
 }
 
 std::shared_ptr<payload> runtime_impl::create_payload() const {
-    return (std::make_shared<payload_impl>());
+    return std::make_shared<payload_impl>();
 }
 
 std::shared_ptr<payload> runtime_impl::create_payload(const byte_t *_data,
         uint32_t _size) const {
-    return (std::make_shared<payload_impl>(_data, _size));
+    return std::make_shared<payload_impl>(_data, _size);
 }
 
 std::shared_ptr<payload> runtime_impl::create_payload(
         const std::vector<byte_t> &_data) const {
-    return (std::make_shared<payload_impl>(_data));
+    return std::make_shared<payload_impl>(_data);
 }
 
 std::shared_ptr<application> runtime_impl::get_application(

--- a/implementation/security/src/policy.cpp
+++ b/implementation/security/src/policy.cpp
@@ -16,22 +16,22 @@ bool
 policy::get_uid_gid(uid_t &_uid, gid_t &_gid) const {
 
     if (credentials_.size() != 1)
-        return (false);
+        return false;
 
     const auto its_uids = credentials_.begin()->first;
     const auto its_gids = credentials_.begin()->second;
 
     if (its_gids.size() != 1)
-        return (false);
+        return false;
 
     if (its_uids.lower() != its_uids.upper()
         || its_gids.begin()->lower() != its_gids.begin()->upper())
-        return (false);
+        return false;
 
     _uid = its_uids.lower();
     _gid = its_gids.begin()->lower();
 
-    return (true);
+    return true;
 }
 
 bool
@@ -42,13 +42,13 @@ policy::deserialize_uid_gid(const byte_t * &_data, uint32_t &_size,
 
     its_result = deserialize_u32(_data, _size, _uid);
     if (its_result == false)
-        return (false);
+        return false;
 
     its_result = deserialize_u32(_data, _size, _gid);
     if (its_result == false)
-        return (false);
+        return false;
 
-    return (true);
+    return true;
 }
 
 bool
@@ -62,7 +62,7 @@ policy::deserialize(const byte_t * &_data, uint32_t &_size) {
 
     its_result = deserialize_uid_gid(_data, _size, its_uid, its_gid);
     if (its_result == false)
-        return (false);
+        return false;
 
     // Fill policy uid/gid
     const auto its_uid_interval
@@ -79,7 +79,7 @@ policy::deserialize(const byte_t * &_data, uint32_t &_size) {
     uint32_t its_requests_length;
     its_result = deserialize_u32(_data, _size, its_requests_length);
     if (its_result == false)
-        return (false);
+        return false;
 
     // Deserialize requests
     while (0 < its_requests_length) {
@@ -89,12 +89,12 @@ policy::deserialize(const byte_t * &_data, uint32_t &_size) {
         uint16_t its_service;
         its_result = deserialize_u16(_data, _size, its_service);
         if (its_result == false)
-            return (false);
+            return false;
 
         if (its_service == 0x0000 || its_service == 0xffff) {
             VSOMEIP_WARNING << "vSomeIP Security: Policy with service ID: 0x"
                     << std::hex << its_service << " is not allowed!";
-            return (false);
+            return false;
         }
 
         const auto its_service_interval
@@ -104,7 +104,7 @@ policy::deserialize(const byte_t * &_data, uint32_t &_size) {
             boost::icl::interval_set<method_t> > its_ids;
         its_result = deserialize_ids(_data, _size, its_ids);
         if (its_result == false)
-            return (false);
+            return false;
 
         requests_ += std::make_pair(its_service_interval, its_ids);
 
@@ -115,7 +115,7 @@ policy::deserialize(const byte_t * &_data, uint32_t &_size) {
     uint32_t its_offers_length;
     its_result = deserialize_u32(_data, _size, its_offers_length);
     if (its_result == false)
-        return (false);
+        return false;
 
     while (0 < its_offers_length) {
 
@@ -124,7 +124,7 @@ policy::deserialize(const byte_t * &_data, uint32_t &_size) {
         uint16_t its_service;
         its_result = deserialize_u16(_data, _size, its_service);
         if (its_result == false)
-            return (false);
+            return false;
 
         if (its_service == 0x0000 || its_service == 0xFFFF) {
             VSOMEIP_WARNING << "vSomeIP Security: Policy with service ID: 0x"
@@ -139,14 +139,14 @@ policy::deserialize(const byte_t * &_data, uint32_t &_size) {
         its_result = deserialize_id_item_list(_data, _size,
                 its_instance_interval_set);
         if (its_result == false)
-            return (false);
+            return false;
 
         offers_ += std::make_pair(its_service_interval, its_instance_interval_set);
 
         its_offers_length -= (its_current_size - _size);
     }
 
-    return (true);
+    return true;
 }
 
 bool
@@ -161,7 +161,7 @@ policy::deserialize_ids(const byte_t * &_data, uint32_t &_size,
 
     its_result = deserialize_u32(_data, _size, its_array_length);
     if (its_result == false)
-        return (false);
+        return false;
 
     while (0 < its_array_length) {
         uint32_t its_current_size(_size);
@@ -169,11 +169,11 @@ policy::deserialize_ids(const byte_t * &_data, uint32_t &_size,
         boost::icl::interval_set<uint16_t> its_instances, its_methods;
         its_result = deserialize_id_item_list(_data, _size, its_instances);
         if (its_result == false)
-            return (false);
+            return false;
 
         its_result = deserialize_id_item_list(_data, _size, its_methods);
         if (its_result == false)
-            return (false);
+            return false;
 
         for (const auto i : its_instances)
             its_ids += std::make_pair(i, its_methods);
@@ -183,7 +183,7 @@ policy::deserialize_ids(const byte_t * &_data, uint32_t &_size,
 
     _ids = std::move(its_ids);
 
-    return (true);
+    return true;
 }
 
 bool
@@ -196,7 +196,7 @@ policy::deserialize_id_item_list(const byte_t * &_data, uint32_t &_size,
 
     its_result = deserialize_u32(_data, _size, its_length);
     if (its_result == false)
-        return (its_result);
+        return its_result;
 
     while (0 < its_length) {
 
@@ -206,7 +206,7 @@ policy::deserialize_id_item_list(const byte_t * &_data, uint32_t &_size,
         uint16_t its_high = 0;
         its_result = deserialize_id_item(_data, _size, its_low, its_high);
         if (its_result == false)
-            return (false);
+            return false;
 
         its_intervals.insert(boost::icl::interval<uint16_t>::closed(its_low, its_high));
 
@@ -215,7 +215,7 @@ policy::deserialize_id_item_list(const byte_t * &_data, uint32_t &_size,
 
     _intervals = std::move(its_intervals);
 
-    return (true);
+    return true;
 }
 
 bool
@@ -227,30 +227,30 @@ policy::deserialize_id_item(const byte_t * &_data, uint32_t &_size,
 
     its_result = deserialize_u32(_data, _size, its_length);
     if (its_result == false)
-        return (false);
+        return false;
 
     its_result = deserialize_u32(_data, _size, its_type);
     if (its_result == false)
-        return (false);
+        return false;
 
     if (its_type == 1 && its_length == sizeof(uint16_t)) {
         its_result = deserialize_u16(_data, _size, _low);
         if (its_result == false)
-            return (false);
+            return false;
 
         _high = _low;
     } else if (its_type == 2
             && its_length == sizeof(uint16_t) + sizeof(uint16_t)) {
         its_result = deserialize_u16(_data, _size, _low);
         if (its_result == false)
-            return (false);
+            return false;
 
         its_result = deserialize_u16(_data, _size, _high);
         if (its_result == false)
-            return (false);
+            return false;
 
         if (_low > _high)
-            return (false);
+            return false;
     }
 
     // handle ANY_METHOD configuration
@@ -266,14 +266,14 @@ policy::deserialize_u16(const byte_t * &_data, uint32_t &_size,
         uint16_t &_value) const {
 
     if (_size < sizeof(uint16_t))
-        return (false);
+        return false;
 
     _value = VSOMEIP_BYTES_TO_WORD(_data[0], _data[1]);
 
     _data += sizeof(uint16_t);
     _size -= static_cast<uint16_t>(sizeof(uint16_t));
 
-    return (true);
+    return true;
 }
 
 bool
@@ -281,14 +281,14 @@ policy::deserialize_u32(const byte_t * &_data, uint32_t &_size,
         uint32_t &_value) const {
 
     if (_size < sizeof(uint32_t))
-        return (false);
+        return false;
 
     _value = VSOMEIP_BYTES_TO_LONG(_data[0], _data[1], _data[2], _data[3]);
 
     _data += sizeof(uint32_t);
     _size -= static_cast<uint32_t>(sizeof(uint32_t));
 
-    return (true);
+    return true;
 }
 
 bool
@@ -300,7 +300,7 @@ policy::serialize(std::vector<byte_t> &_data) const {
 
     its_result = serialize_uid_gid(_data);
     if (!its_result)
-        return (false);
+        return false;
 
     size_t its_requests_pos = _data.size();
     uint32_t its_requests_size(0);
@@ -335,7 +335,7 @@ policy::serialize(std::vector<byte_t> &_data) const {
     uint32_t its_offers_size = 0;
     serialize_u32(its_offers_size, _data);
 
-    return (true);
+    return true;
 }
 
 bool
@@ -343,31 +343,31 @@ policy::serialize_uid_gid(std::vector<byte_t> &_data) const {
 
     if (credentials_.size() != 1) {
         VSOMEIP_ERROR << "Unserializable policy (ids).";
-        return (false);
+        return false;
     }
 
     auto its_credential = *(credentials_.begin());
     if (its_credential.second.size() != 1) {
         VSOMEIP_ERROR << "Unserializable policy (intervals).";
-        return (false);
+        return false;
     }
 
     auto its_uid_interval = its_credential.first;
     if (its_uid_interval.lower() != its_uid_interval.upper()) {
         VSOMEIP_ERROR << "Unserializable policy (uid).";
-        return (false);
+        return false;
     }
 
     auto its_gid_interval = *(its_credential.second.begin());
     if (its_gid_interval.lower() != its_gid_interval.upper()) {
         VSOMEIP_ERROR << "Unserializable policy (gid).";
-        return (false);
+        return false;
     }
 
     serialize_u32(its_uid_interval.lower(), _data);
     serialize_u32(its_gid_interval.lower(), _data);
 
-    return (true);
+    return true;
 }
 
 void

--- a/implementation/security/src/policy_manager_impl.cpp
+++ b/implementation/security/src/policy_manager_impl.cpp
@@ -55,18 +55,18 @@ policy_manager_impl::policy_manager_impl()
 bool
 policy_manager_impl::is_enabled() const {
 #ifdef VSOMEIP_DISABLE_SECURITY
-    return (false);
+    return false;
 #else
-    return (policy_enabled_);
+    return policy_enabled_;
 #endif
 }
 
 bool
 policy_manager_impl::is_audit() const {
 #ifdef VSOMEIP_DISABLE_SECURITY
-    return (false);
+    return false;
 #else
-    return (!check_credentials_);
+    return !check_credentials_;
 #endif
 }
 
@@ -78,16 +78,16 @@ policy_manager_impl::check_credentials(client_t _client,
     (void)_client;
     (void)_sec_client;
 
-    return (true);
+    return true;
 #else
     if (!policy_enabled_)
-        return (true);
+        return true;
 
     if (!_sec_client)
-        return (true);
+        return true;
 
     if (_sec_client->client_type != VSOMEIP_CLIENT_UDS)
-        return (true);
+        return true;
 
     uid_t its_uid(_sec_client->client.uds_client.user);
     gid_t its_gid(_sec_client->client.uds_client.group);
@@ -146,7 +146,7 @@ policy_manager_impl::check_routing_credentials(
 #ifdef VSOMEIP_DISABLE_SECURITY
     (void)_sec_client;
 
-    return (true);
+    return true;
 #else
     uid_t its_uid(0);
     gid_t its_gid(0);
@@ -160,7 +160,7 @@ policy_manager_impl::check_routing_credentials(
         if (routing_credentials_.first == its_uid
                 && routing_credentials_.second == its_gid) {
 
-            return (true);
+            return true;
         }
 
         is_known_uid_gid = true;
@@ -181,7 +181,7 @@ policy_manager_impl::check_routing_credentials(
             << "do not match with routing manager credentials"
             << security_mode_text;
 
-    return (!check_routing_credentials_);
+    return !check_routing_credentials_;
 #endif // VSOMEIP_DISABLE_SECURITY
 }
 
@@ -210,7 +210,7 @@ policy_manager_impl::is_client_allowed(const vsomeip_sec_client_t *_sec_client,
     (void)_method;
     (void)_is_request_service;
 
-    return (true);
+    return true;
 #else
     if (!policy_enabled_) {
         return true;
@@ -236,7 +236,7 @@ policy_manager_impl::is_client_allowed(const vsomeip_sec_client_t *_sec_client,
                 << _service << "/" << _instance
                 << security_mode_text;
 
-        return (!check_credentials_);
+        return !check_credentials_;
     }
 
     // Check cache
@@ -247,7 +247,7 @@ policy_manager_impl::is_client_allowed(const vsomeip_sec_client_t *_sec_client,
         const auto its_iter = is_client_allowed_cache_.find(its_credentials);
         if (its_iter != is_client_allowed_cache_.end()) {
             if (its_iter->second.find(its_key) != its_iter->second.end()) {
-                return (true);
+                return true;
             }
         }
     }
@@ -287,7 +287,7 @@ policy_manager_impl::is_client_allowed(const vsomeip_sec_client_t *_sec_client,
                 if (is_matching) {
                     boost::unique_lock<boost::shared_mutex> its_cache_lock(is_client_allowed_cache_mutex_);
                     is_client_allowed_cache_[its_credentials].insert(its_key);
-                    return (true);
+                    return true;
                 }
             } else {
                 // deny policy
@@ -298,7 +298,7 @@ policy_manager_impl::is_client_allowed(const vsomeip_sec_client_t *_sec_client,
                         || (!is_matching && (_method == ANY_METHOD) && p->requests_.empty())) {
                      boost::unique_lock<boost::shared_mutex> its_cache_lock(is_client_allowed_cache_mutex_);
                      is_client_allowed_cache_[its_credentials].insert(its_key);
-                     return (true);
+                     return true;
                 }
             }
         }
@@ -315,7 +315,7 @@ policy_manager_impl::is_client_allowed(const vsomeip_sec_client_t *_sec_client,
             << std::hex << _service << "/" << _instance << "/" << _method
             << security_mode_text;
 
-    return (!check_credentials_);
+    return !check_credentials_;
 #endif // VSOMEIP_DISABLE_SECURITY
 }
 
@@ -328,7 +328,7 @@ policy_manager_impl::is_offer_allowed(const vsomeip_sec_client_t *_sec_client,
     (void)_service;
     (void)_instance;
 
-    return (true);
+    return true;
 #else
     if (!policy_enabled_)
         return true;
@@ -352,7 +352,7 @@ policy_manager_impl::is_offer_allowed(const vsomeip_sec_client_t *_sec_client,
                 << _service << "/" << _instance
                 << security_mode_text;
 
-        return (!check_credentials_);
+        return !check_credentials_;
     }
 
     boost::shared_lock<boost::shared_mutex> its_lock(any_client_policies_mutex_);
@@ -376,7 +376,7 @@ policy_manager_impl::is_offer_allowed(const vsomeip_sec_client_t *_sec_client,
         if ((has_uid && has_gid && p->allow_who_)
                 || ((!has_uid || !has_gid) && !p->allow_who_)) {
             if (p->allow_what_ == has_offer) {
-                return (true);
+                return true;
             }
         }
     }
@@ -392,7 +392,7 @@ policy_manager_impl::is_offer_allowed(const vsomeip_sec_client_t *_sec_client,
             << std::hex << _service << "/" << _instance
             << security_mode_text;
 
-    return (!check_credentials_);
+    return !check_credentials_;
 #endif // VSOMEIP_DISABLE_SECURITY
 }
 
@@ -450,7 +450,7 @@ policy_manager_impl::remove_security_policy(uint32_t _uid, uint32_t _gid) {
             is_client_allowed_cache_.erase(std::make_pair(_uid, _gid));
         }
     }
-    return (was_removed);
+    return was_removed;
 }
 
 void
@@ -576,10 +576,10 @@ policy_manager_impl::is_policy_update_allowed(uint32_t _uid, std::shared_ptr<pol
                             << std::hex << its_service
                             << " is not allowed! -> ignore update";
                 }
-                return (!check_whitelist_);
+                return !check_whitelist_;
             }
         }
-        return (true);
+        return true;
     } else {
         if (!check_whitelist_) {
             VSOMEIP_INFO << "vSomeIP Security: Policy update for UID: " << std::dec << _uid
@@ -588,7 +588,7 @@ policy_manager_impl::is_policy_update_allowed(uint32_t _uid, std::shared_ptr<pol
             VSOMEIP_WARNING << "vSomeIP Security: Policy update for UID: " << std::dec << _uid
                     << " is not allowed! -> ignore update";
         }
-        return (!check_whitelist_);
+        return !check_whitelist_;
     }
 }
 
@@ -597,7 +597,7 @@ policy_manager_impl::is_policy_removal_allowed(uint32_t _uid) const {
     std::lock_guard<std::mutex> its_lock(uid_whitelist_mutex_);
     for (auto its_uid_range : uid_whitelist_) {
         if (its_uid_range.lower() <= _uid && _uid <= its_uid_range.upper()) {
-            return (true);
+            return true;
         }
     }
 
@@ -610,7 +610,7 @@ policy_manager_impl::is_policy_removal_allowed(uint32_t _uid) const {
                 << std::dec << _uid
                 << " is not allowed! -> ignore removal";
     }
-    return (!check_whitelist_);
+    return !check_whitelist_;
 }
 
 bool
@@ -1323,15 +1323,15 @@ policy_manager_impl::store_client_to_sec_client_mapping(
                         << std::dec << its_old_uid << "/" << its_old_gid;
 
                 found_client->second = *_sec_client;
-                return (true);
+                return true;
             }
         } else {
             ids_[_client] = *_sec_client;
         }
-        return (true);
+        return true;
     }
 
-    return (false);
+    return false;
 }
 
 bool
@@ -1342,9 +1342,9 @@ policy_manager_impl::get_client_to_sec_client_mapping(client_t _client,
         std::lock_guard<std::mutex> its_lock(ids_mutex_);
         if (ids_.find(_client) != ids_.end()) {
             _sec_client = ids_[_client];
-            return (true);
+            return true;
         }
-        return (false);
+        return false;
     }
 }
 
@@ -1449,9 +1449,9 @@ policy_manager_impl::get() {
         if (!(*the_policy_manager_ptr__)) {
             *the_policy_manager_ptr__ = std::make_shared<policy_manager_impl>();
         }
-        return (*the_policy_manager_ptr__);
+        return *the_policy_manager_ptr__;
     }
-    return (nullptr);
+    return nullptr;
 }
 
 #if defined(__linux__) || defined(ANDROID)

--- a/implementation/service_discovery/src/configuration_option_impl.cpp
+++ b/implementation/service_discovery/src/configuration_option_impl.cpp
@@ -123,6 +123,8 @@ bool configuration_option_impl::deserialize(vsomeip_v3::deserializer *_from) {
                     is_successful = false;
                 }
             }
+        } else {
+              break;
         }
     } while (is_successful && _from->get_remaining() > 0);
 

--- a/implementation/service_discovery/src/ipv6_option_impl.cpp
+++ b/implementation/service_discovery/src/ipv6_option_impl.cpp
@@ -70,7 +70,7 @@ bool ipv6_option_impl::serialize(vsomeip_v3::serializer *_to) const {
 
 bool ipv6_option_impl::deserialize(vsomeip_v3::deserializer *_from) {
     bool is_successful = option_impl::deserialize(_from)
-                            && length_ == VSOMEIP_SD_IPV6_OPTION_LENGTH;;
+                            && length_ == VSOMEIP_SD_IPV6_OPTION_LENGTH;
     uint8_t its_reserved(static_cast<std::uint8_t>(layer_four_protocol_e::UNKNOWN));
     _from->deserialize(address_.data(), 16);
     _from->deserialize(its_reserved);

--- a/implementation/service_discovery/src/message_impl.cpp
+++ b/implementation/service_discovery/src/message_impl.cpp
@@ -419,11 +419,11 @@ length_t message_impl::get_someip_length() const {
 }
 
 uid_t message_impl::get_uid() const {
-    return (ANY_UID);
+    return ANY_UID;
 }
 
 gid_t message_impl::get_gid() const {
-    return (ANY_GID);
+    return ANY_GID;
 }
 
 vsomeip_sec_client_t message_impl::get_sec_client() const {
@@ -431,7 +431,7 @@ vsomeip_sec_client_t message_impl::get_sec_client() const {
         VSOMEIP_CLIENT_UDS, {vsomeip_sec_uds_client_credentials_t{ANY_UID, ANY_GID}}
     };
 
-    return (its_dummy_sec_client);
+    return its_dummy_sec_client;
 }
 
 std::string message_impl::get_env() const {

--- a/implementation/service_discovery/src/selective_option_impl.cpp
+++ b/implementation/service_discovery/src/selective_option_impl.cpp
@@ -33,7 +33,7 @@ selective_option_impl::equals(const option_impl &_other) const {
 
 std::set<client_t> selective_option_impl::get_clients() const {
     std::set<client_t> its_clients(clients_);
-    return (its_clients);
+    return its_clients;
 }
 
 void selective_option_impl::set_clients(const std::set<client_t> &_clients) {
@@ -44,7 +44,7 @@ void selective_option_impl::set_clients(const std::set<client_t> &_clients) {
 bool selective_option_impl::add_client(client_t _client) {
     auto its_result = clients_.insert(_client);
     length_ = uint16_t(1 + clients_.size() * sizeof(client_t));
-    return (its_result.second);
+    return its_result.second;
 }
 
 bool selective_option_impl::remove_client(client_t _client) {
@@ -55,7 +55,7 @@ bool selective_option_impl::remove_client(client_t _client) {
 }
 
 bool selective_option_impl::has_clients() const {
-    return (!clients_.empty());
+    return !clients_.empty();
 }
 
 bool selective_option_impl::has_client(client_t _client) {

--- a/implementation/service_discovery/src/service_discovery_impl.cpp
+++ b/implementation/service_discovery/src/service_discovery_impl.cpp
@@ -488,7 +488,7 @@ void
 service_discovery_impl::unsubscribe_all(
         service_t _service, instance_t _instance) {
 
-    auto its_current_message = std::make_shared<message_impl>();;
+    auto its_current_message = std::make_shared<message_impl>();
     boost::asio::ip::address its_address;
 
     {

--- a/implementation/service_discovery/src/subscription.cpp
+++ b/implementation/service_discovery/src/subscription.cpp
@@ -27,7 +27,7 @@ void subscription::set_ttl(ttl_t _ttl) {
 }
 
 std::shared_ptr<endpoint> subscription::get_endpoint(bool _reliable) const {
-    return (_reliable ? reliable_ : unreliable_);
+    return _reliable ? reliable_ : unreliable_;
 }
 
 void subscription::set_endpoint(const std::shared_ptr<endpoint>& _endpoint,
@@ -93,7 +93,7 @@ subscription::remove_client(const client_t _client) {
     std::lock_guard<std::mutex> its_lock(clients_mutex_);
     auto its_size = clients_.size();
     clients_.erase(_client);
-    return (its_size > clients_.size());
+    return its_size > clients_.size();
 }
 
 std::set<client_t> subscription::get_clients() const {
@@ -113,7 +113,7 @@ bool subscription::has_client() const {
 
 bool subscription::has_client(const client_t _client) const {
     std::lock_guard<std::mutex> its_lock(clients_mutex_);
-    return (clients_.find(_client) != clients_.end());
+    return clients_.find(_client) != clients_.end();
 }
 
 void subscription::set_eventgroupinfo(

--- a/implementation/tracing/src/channel_impl.cpp
+++ b/implementation/tracing/src/channel_impl.cpp
@@ -27,7 +27,7 @@ filter_id_t channel_impl::add_filter(
     filter_type_e its_filter_type = (_is_positive ?
         filter_type_e::POSITIVE : filter_type_e::NEGATIVE);
 
-    return (add_filter(_match, its_filter_type));
+    return add_filter(_match, its_filter_type);
 }
 
 filter_id_t channel_impl::add_filter(
@@ -102,7 +102,7 @@ filter_id_t channel_impl::add_filter(
     filter_type_e its_filter_type = (_is_positive ?
         filter_type_e::POSITIVE : filter_type_e::NEGATIVE);
 
-    return (add_filter(_matches, its_filter_type));
+    return add_filter(_matches, its_filter_type);
 }
 
 filter_id_t channel_impl::add_filter(
@@ -246,7 +246,7 @@ filter_id_t channel_impl::add_filter(
     filter_type_e its_filter_type = (_is_positive ?
         filter_type_e::POSITIVE : filter_type_e::NEGATIVE);
 
-    return (add_filter(_from, _to, its_filter_type));
+    return add_filter(_from, _to, its_filter_type);
 }
 
 void channel_impl::remove_filter(filter_id_t _id) {
@@ -260,10 +260,10 @@ filter_id_t channel_impl::add_filter_intern(const filter_func_t& _func, filter_t
 
     std::lock_guard<std::mutex> its_lock(mutex_);
     switch(_type) {
-        case (filter_type_e::NEGATIVE) :
+        case filter_type_e::NEGATIVE :
             negative_[its_id] = _func;
             break;
-        case (filter_type_e::HEADER_ONLY) :
+        case filter_type_e::HEADER_ONLY :
             positive_[its_id] = std::make_pair(_func, false);
             break;
         default :

--- a/implementation/utility/include/utility.hpp
+++ b/implementation/utility/include/utility.hpp
@@ -31,11 +31,11 @@ class configuration;
 class utility {
 public:
     static inline bool is_request(std::shared_ptr<message> _message) {
-        return (_message ? is_request(_message->get_message_type()) : false);
+        return _message ? is_request(_message->get_message_type()) : false;
     }
 
     static inline bool is_request(byte_t _type) {
-        return (is_request(static_cast<message_type_e>(_type)));
+        return is_request(static_cast<message_type_e>(_type));
     }
 
     static inline bool is_request(message_type_e _type) {
@@ -49,7 +49,7 @@ public:
     }
 
     static inline bool is_request_no_return(byte_t _type) {
-        return (is_request_no_return(static_cast<message_type_e>(_type)));
+        return is_request_no_return(static_cast<message_type_e>(_type));
     }
 
     static inline bool is_request_no_return(message_type_e _type) {
@@ -74,7 +74,7 @@ public:
     }
 
     static inline bool is_notification(byte_t _type) {
-        return (is_notification(static_cast<message_type_e>(_type)));
+        return is_notification(static_cast<message_type_e>(_type));
     }
 
     static inline bool is_notification(message_type_e _type) {
@@ -84,7 +84,7 @@ public:
     static uint64_t get_message_size(const byte_t *_data, size_t _size);
     static inline uint64_t get_message_size(std::vector<byte_t> &_data) {
         if (_data.size() > 0) {
-            return (get_message_size(&_data[0], _data.size()));
+            return get_message_size(&_data[0], _data.size());
         }
         return 0;
     }
@@ -131,7 +131,9 @@ public:
                 || _code == return_code_e::E_WRONG_PROTOCOL_VERSION
                 || _code == return_code_e::E_WRONG_INTERFACE_VERSION
                 || _code == return_code_e::E_MALFORMED_MESSAGE
-                || _code == return_code_e::E_WRONG_MESSAGE_TYPE);
+                || _code == return_code_e::E_WRONG_MESSAGE_TYPE
+                || (static_cast<std::uint8_t>(_code) >= 0x20
+                    && static_cast<std::uint8_t>(_code) <= 0x5E));
     }
 
     static inline bool compare(const vsomeip_sec_client_t &_lhs,
@@ -155,7 +157,7 @@ public:
                 break;
             }
         }
-        return (is_equal);
+        return is_equal;
     }
 
 private:

--- a/implementation/utility/src/utility.cpp
+++ b/implementation/utility/src/utility.cpp
@@ -49,7 +49,7 @@ uint64_t utility::get_message_size(const byte_t *_data, size_t _size) {
         its_size = VSOMEIP_SOMEIP_HEADER_SIZE
                 + VSOMEIP_BYTES_TO_LONG(_data[4], _data[5], _data[6], _data[7]);
     }
-    return (its_size);
+    return its_size;
 }
 
 uint32_t utility::get_payload_size(const byte_t *_data, uint32_t _size) {
@@ -58,7 +58,7 @@ uint32_t utility::get_payload_size(const byte_t *_data, uint32_t _size) {
         its_size = VSOMEIP_BYTES_TO_LONG(_data[4], _data[5], _data[6], _data[7])
                 - VSOMEIP_SOMEIP_HEADER_SIZE;
     }
-    return (its_size);
+    return its_size;
 }
 
 bool utility::is_routing_manager(const std::string &_network) {
@@ -66,11 +66,11 @@ bool utility::is_routing_manager(const std::string &_network) {
     // Therefore, subsequent calls can be immediately answered...
     std::lock_guard<std::mutex> its_lock(mutex__);
     if (data__.find(_network) != data__.end())
-        return (false);
+        return false;
 
     auto r = data__.insert(std::make_pair(_network, data_t()));
     if (!r.second)
-        return (false);
+        return false;
 
 #ifdef _WIN32
     wchar_t its_tmp_folder[MAX_PATH];
@@ -198,7 +198,7 @@ utility::request_client_id(
 
     auto r = data__.find(_config->get_network());
     if (r == data__.end())
-        return (VSOMEIP_CLIENT_UNSET);
+        return VSOMEIP_CLIENT_UNSET;
 
     if (r->second.next_client_ == VSOMEIP_CLIENT_UNSET) {
         r->second.next_client_ = its_smallest_client;
@@ -208,13 +208,13 @@ utility::request_client_id(
         const auto its_iterator = r->second.used_clients_.find(_client);
         if (its_iterator == r->second.used_clients_.end()) { // unused identifier
             r->second.used_clients_[_client] = _name;
-            return (_client);
+            return _client;
         } else { // already in use
 
             // The name matches the assigned name --> return client
             // NOTE: THIS REQUIRES A CONSISTENT CONFIGURATION!!!
             if (its_iterator->second == _name) {
-                return (_client);
+                return _client;
             }
 
             VSOMEIP_WARNING << "Requested client identifier "
@@ -243,13 +243,13 @@ utility::request_client_id(
                     "Max amount of possible concurrent active vsomeip "
                     "applications reached ("  << std::dec << r->second.used_clients_.size()
                     << ").";
-            return (VSOMEIP_CLIENT_UNSET);
+            return VSOMEIP_CLIENT_UNSET;
         }
     } while (r->second.used_clients_.find(r->second.next_client_) != r->second.used_clients_.end()
             || _config->is_configured_client_id(r->second.next_client_));
 
     r->second.used_clients_[r->second.next_client_] = _name;
-    return (r->second.next_client_);
+    return r->second.next_client_;
 }
 
 void

--- a/implementation/utility/src/wrappers.cpp
+++ b/implementation/utility/src/wrappers.cpp
@@ -5,6 +5,7 @@
 
 #ifdef __linux__
 
+#include <fcntl.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 
@@ -33,6 +34,20 @@ extern "C"
     {
         return accept4(sockfd, addr, addrlen, SOCK_CLOEXEC);
     }
+
+    /*
+     * The real open(2), renamed by GCC.
+     */
+    int __real_open(const char *filename, int flags, ...);
+
+    /*
+     * Overrides open(2) to set O_CLOEXEC by default.
+     */
+    int __wrap_open(const char *filename, int flags, ...)
+    {
+        return __real_open(filename, flags|O_CLOEXEC);
+    }
+
 }
 
 #endif

--- a/libvsomeip.yaml
+++ b/libvsomeip.yaml
@@ -1,5 +1,5 @@
 - name: libvsomeip
-  version: 3.3.0
+  version: 3.3.5
   vendor: Lynx Team
   license:
     concluded: CLOSED and MPLv2

--- a/test/benchmark_tests/security_tests/bm_load.cpp
+++ b/test/benchmark_tests/security_tests/bm_load.cpp
@@ -1,0 +1,60 @@
+// Copyright (C) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <benchmark/benchmark.h>
+
+#include "../../common/utility.hpp"
+
+namespace
+{
+    std::string configuration_file{"/vsomeip/vsomeip_policy_extensions.json"}; // set configuration file policy extension
+}
+
+static void BM_configuration_element(benchmark::State &state)
+{
+    // Test object path
+    std::unique_ptr<vsomeip_v3::policy_manager_impl> security(new vsomeip_v3::policy_manager_impl);
+
+    // Set element
+    std::vector<vsomeip_v3::configuration_element> full_element = {};
+
+    // After load try again and check size
+    std::set<std::string> its_failed;
+    std::vector<std::string> dir_skip;
+    utility::read_data(utility::get_all_files_in_dir(
+                           utility::get_policies_path(), dir_skip),
+                       full_element, its_failed);
+
+    // Load element and force lazy load = false
+    for (auto _ : state)
+    {
+        security->load(full_element.at(0), false);
+    }
+}
+
+static void BM_lazy_load(benchmark::State &state)
+{
+    // Test object path
+    std::unique_ptr<vsomeip_v3::policy_manager_impl> security(new vsomeip_v3::policy_manager_impl);
+
+    // Set element and lazy load = true
+    std::vector<vsomeip_v3::configuration_element> element = {};
+    const bool lazy_load = true;
+
+    // Load
+    std::set<std::string> its_failed;
+    std::vector<std::string> dir_skip;
+    utility::read_data(utility::get_all_files_in_dir(
+                           utility::get_policies_path(), dir_skip),
+                       element, its_failed);
+
+    for (auto _ : state)
+    {
+        security->load(element.at(0), lazy_load);
+    }
+}
+
+BENCHMARK(BM_configuration_element);
+BENCHMARK(BM_lazy_load);

--- a/test/internal_routing_disabled_acceptance_test/CMakeLists.txt
+++ b/test/internal_routing_disabled_acceptance_test/CMakeLists.txt
@@ -7,7 +7,7 @@ endif()
 
 project(internal_routing_disabled_acceptance_test LANGUAGES CXX)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_INIT} -pedantic -Wall -Wconversion -Wextra")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pedantic -Wall -Wconversion -Wextra")
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)

--- a/test/network_tests/debounce_tests/debounce_test_client.cpp
+++ b/test/network_tests/debounce_tests/debounce_test_client.cpp
@@ -58,7 +58,7 @@ debounce_test_client::init() {
         app_->subscribe(DEBOUNCE_SERVICE, DEBOUNCE_INSTANCE,
                 DEBOUNCE_EVENTGROUP, DEBOUNCE_MAJOR, DEBOUNCE_EVENT_4);
     }
-    return (its_result);
+    return its_result;
 }
 
 void
@@ -192,7 +192,7 @@ debounce_test_client::compare_payload(
         std::size_t _index) const {
 
     auto its_expected_payload = payloads__[test_id_][_index];
-    return ((*_payload) == (*its_expected_payload));
+    return (*_payload == *its_expected_payload);
 }
 
 void

--- a/test/network_tests/debounce_tests/debounce_test_service.cpp
+++ b/test/network_tests/debounce_tests/debounce_test_service.cpp
@@ -49,7 +49,7 @@ debounce_test_service::init() {
         app_->offer_service(DEBOUNCE_SERVICE, DEBOUNCE_INSTANCE,
                 DEBOUNCE_MAJOR, DEBOUNCE_MINOR);
     }
-    return (is_initialized);
+    return is_initialized;
 }
 
 void

--- a/test/network_tests/e2e_tests/e2e_profile_04_test_client.cpp
+++ b/test/network_tests/e2e_tests/e2e_profile_04_test_client.cpp
@@ -27,7 +27,7 @@ e2e_profile_04_test_client::init() {
 
     if (!app_->init()) {
         ADD_FAILURE() << __func__ << ": Cannot initialize application";
-        return (false);
+        return false;
     }
 
     app_->register_state_handler(
@@ -45,7 +45,7 @@ e2e_profile_04_test_client::init() {
                     std::placeholders::_1, std::placeholders::_2,
                     std::placeholders::_3));
 
-    return (true);
+    return true;
 }
 
 void

--- a/test/network_tests/e2e_tests/e2e_profile_04_test_service.cpp
+++ b/test/network_tests/e2e_tests/e2e_profile_04_test_service.cpp
@@ -70,7 +70,7 @@ e2e_profile_04_test_service::init() {
     app_->notify(vsomeip_test::TEST_SERVICE_SERVICE_ID, vsomeip_test::TEST_SERVICE_INSTANCE_ID,
             static_cast<vsomeip::event_t>(0x8001), its_payload);
 
-    return (true);
+    return true;
 }
 
 void

--- a/test/network_tests/suspend_resume_tests/suspend_resume_test_service.cpp
+++ b/test/network_tests/suspend_resume_tests/suspend_resume_test_service.cpp
@@ -179,7 +179,7 @@ private:
         VSOMEIP_DEBUG << __func__ << ": is_subscribe=" << std::boolalpha << _is_subscribe;
         if (!_is_subscribe)
             std::this_thread::sleep_for(std::chrono::milliseconds(2000));
-        return (true);
+        return true;
     }
 
 private: // members

--- a/test/unit_tests/security_tests/ut_load.cpp
+++ b/test/unit_tests/security_tests/ut_load.cpp
@@ -1,0 +1,108 @@
+// Copyright (C) 2022 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <gtest/gtest.h>
+
+#include <memory>
+
+#include "../../common/utility.hpp"
+
+namespace
+{
+    std::string configuration_file{"/vsomeip/0_0/vsomeip_security.json"};
+}
+
+TEST(load, No_element)
+{
+    // Test object path
+    std::unique_ptr<vsomeip_v3::policy_manager_impl> its_manager(new vsomeip_v3::policy_manager_impl);
+
+    // Set element
+    std::vector<vsomeip_v3::configuration_element> empty_element = {}; // elements
+    std::vector<vsomeip_v3::configuration_element> full_element = {};
+
+    // Check element and full element size init =zero
+    ASSERT_TRUE(empty_element.size() == 0) << " Initial element size is not zero";
+    ASSERT_TRUE(full_element.size() == 0) << " Initial full element size is not zero";
+
+    // After load try again and check size
+    std::set<std::string> its_failed;
+    std::vector<std::string> dir_skip;
+    utility::read_data(utility::get_all_files_in_dir(
+                           utility::get_policies_path(), dir_skip),
+                       full_element, its_failed); // check if this is load without for cicle
+
+    // Load each e into policy_elements
+    for (const auto &e : full_element)
+    {
+        its_manager->load(e, false); // for each e in policy_elements vector load e
+    };
+
+    // Check size of full_element after load >0
+    ASSERT_TRUE(full_element.size() > 0) << "Full element size is zero after load, should be >0 since policy was loaded";
+
+    // Compare full element greater than element
+    ASSERT_GT(full_element.size(), empty_element.size()) << "Full element is not greater than unit element";
+}
+
+TEST(load, _lazy_load)
+{
+    // Test object path
+    std::unique_ptr<vsomeip_v3::policy_manager_impl> its_manager(new vsomeip_v3::policy_manager_impl);
+
+    // Set element and lazy load
+    std::vector<vsomeip_v3::configuration_element> element = {};
+    const bool lazy_load = true;
+
+    // Load
+    std::set<std::string> its_failed;
+    std::vector<std::string> dir_skip;
+    utility::read_data(utility::get_all_files_in_dir(
+                           utility::get_policies_path(), dir_skip),
+                       element, its_failed);
+
+    // Apply load function for each e into element and check if lazy load=true for each e loaded
+    for (const auto &e : element)
+    {
+        its_manager->load(e, lazy_load);
+        EXPECT_EQ(lazy_load, true) << "Lazy load not equal true";
+    };
+
+    // Test first element without for cycle
+    const vsomeip_v3::configuration_element &e = element.at(0);
+    its_manager->load(e, lazy_load);
+    EXPECT_EQ(lazy_load, true) << "Lazy load not equal true";
+}
+
+TEST(load, policy_enabled_and_check_credentials)
+{
+    // Test object path
+    std::unique_ptr<vsomeip_v3::policy_manager_impl> its_manager(new vsomeip_v3::policy_manager_impl);
+
+    // Set element and lazy load
+    std::vector<vsomeip_v3::configuration_element> element = {};
+
+    // Check values for policy enabled and check_credentials before load policy
+    // No policies loaded -> check credentials will return false. policy_enabled is private so needs to be check like this
+    ASSERT_TRUE(its_manager->is_audit()) << "policies were loaded. policy_enable should be true";
+    ASSERT_FALSE(its_manager->is_enabled()) << "policies were loaded. check_credentials should be false";
+
+    // Load full
+    std::set<std::string> its_failed;
+    std::vector<std::string> dir_skip;
+    utility::read_data(utility::get_all_files_in_dir(
+                           utility::get_policies_path(), dir_skip),
+                       element, its_failed);
+
+    // Load each e into policy_elements
+    for (const auto &e : element)
+    {
+        its_manager->load(e, false); // for each e in policy_elements vector load e
+    };
+
+    // Check policies loaded after
+    ASSERT_FALSE(its_manager->is_audit()) << "policies were loaded. policy_enable should be false";
+    ASSERT_TRUE(its_manager->is_enabled()) << "policies were loaded. check_credentials should be true";
+}


### PR DESCRIPTION
Notes:
v3.3.5.1
- Fix typo in application_impl.cpp
- Update load_balancing_option_impl.cpp
- Fix format specifier in memory_log_timer_cbk
- Isolate boost
- Remove redundant ostream manipulators
- Fix for configuration option deserialize bug
- Accept return codes within range 0x20 - 0x5E as valid

v3.3.5
- Do NOT use iterators in asynchronous operations.
- Add event identifier to "REGISTER EVENT" log message at routing manager stub.
- Fix for crash in flush function, server_endpoint_impl class
- added FD_CLOEXEC flag in all open operations
- Use "make_unique" and "make_shared" to construct "unique_ptr" and "shared_ptr"
- Removed redundant pairs of parentheses
- Do not erase while iterating.
- Changed invalid call of deserialize to serialize
- Fixed the the problem in policy::deserialize counts down the given policy size, and after deserializing the policy it is 0.
- Monitor session IDs in SD messages and log missing IDs
- Fix timestamp format of log message
- Prevent crash when logging with DLT
- load_security_update_whitelist Unit and Benchmark Tests
- Added protection when a message is destroyed
- Pu/connect timeout refactor
- Rework the addition of services when in suspended mode
- Remove const qualifier from function return types
- Adapt to boost 1.81.0