### PR TITLE
vsomeip 3.3.7

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -80,7 +80,7 @@ cc_library_shared {
 
     cflags: [
         "-DWITHOUT_SYSTEMD",
-        "-DVSOMEIP_COMPAT_VERSION=\"3.3.6\"",
+        "-DVSOMEIP_COMPAT_VERSION=\"3.3.7\"",
         "-DVSOMEIP_BASE_PATH=\"/vendor/run/someip/\"",
         "-DUSE_DLT",
     ],

--- a/Android.mk
+++ b/Android.mk
@@ -100,7 +100,7 @@ LOCAL_CFLAGS :=  \
     -frtti \
     -fexceptions \
     -DWITHOUT_SYSTEMD \
-    -DVSOMEIP_VERSION=\"3.3.6\" \
+    -DVSOMEIP_VERSION=\"3.3.7\" \
     -DVSOMEIP_BASE_PATH=\"/vendor/run/someip/\" \
     -Wno-unused-parameter \
     -Wno-non-virtual-dtor \
@@ -147,7 +147,7 @@ LOCAL_CFLAGS := \
     -frtti \
     -fexceptions \
     -DWITHOUT_SYSTEMD \
-    -DVSOMEIP_VERSION=\"3.3.6\" \
+    -DVSOMEIP_VERSION=\"3.3.7\" \
     -DVSOMEIP_BASE_PATH=\"/vendor/run/someip/\" \
     -Wno-unused-parameter \
     -Wno-non-virtual-dtor \
@@ -194,8 +194,8 @@ LOCAL_CFLAGS :=  \
     -frtti \
     -fexceptions \
     -DWITHOUT_SYSTEMD \
-    -DVSOMEIP_VERSION=\"3.3.6\" \
-    -DVSOMEIP_COMPAT_VERSION=\"3.3.6\" \
+    -DVSOMEIP_VERSION=\"3.3.7\" \
+    -DVSOMEIP_COMPAT_VERSION=\"3.3.7\" \
     -DVSOMEIP_BASE_PATH=\"/vendor/run/someip/\" \
     -Wno-unused-parameter \
     -Wno-non-virtual-dtor \

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,13 @@
 Changes
 =======
+v3.3.7
+- Fix handling of endpoint options
+- Fix build on Windows
+- Fix client-side logging filters
+- Rework in event::set_payload
+- Release no longer in use client endpoints
+- Rework condition for starting the send operation
+- Verify if the event is shadow
 
 v3.3.6
 - The "last forwarded" timestamp must be handled per event

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set (VSOMEIP_COMPAT_NAME vsomeip)
 
 set (VSOMEIP_MAJOR_VERSION 3)
 set (VSOMEIP_MINOR_VERSION 3)
-set (VSOMEIP_PATCH_VERSION 6)
+set (VSOMEIP_PATCH_VERSION 7)
 set (VSOMEIP_HOTFIX_VERSION 0)
 
 set (VSOMEIP_VERSION ${VSOMEIP_MAJOR_VERSION}.${VSOMEIP_MINOR_VERSION}.${VSOMEIP_PATCH_VERSION})
@@ -232,7 +232,7 @@ if (MSVC)
     # add_definitions(-DVSOMEIP_DLL_COMPILATION) now it is controlled per target
     SET(BOOST_WINDOWS_VERSION "0x600" CACHE STRING "Set the same Version as the Version with which Boost was built, otherwise there will be errors. (normaly 0x600 is for Windows 7 and 0x501 is for Windows XP)")
     # Disable warning C4250 since it warns that the compiler is correctly following the C++ Standard. It's a "We-Are-Doing-Things-By-The-Book" notice, not a real warning.
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS -D_WIN32_WINNT=${BOOST_WINDOWS_VERSION} -DWIN32 -DBOOST_ASIO_DISABLE_IOCP /EHsc /std:c++latest /wd4250")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS -D_WIN32_WINNT=${BOOST_WINDOWS_VERSION} -DWIN32 -DBOOST_ASIO_DISABLE_IOCP /EHsc /std:c++14 /wd4250")
     set(USE_RT "")
     link_directories(${Boost_LIBRARY_DIR_DEBUG})
     ADD_DEFINITIONS( -DBOOST_ALL_DYN_LINK )

--- a/implementation/endpoints/include/tcp_server_endpoint_impl.hpp
+++ b/implementation/endpoints/include/tcp_server_endpoint_impl.hpp
@@ -41,7 +41,6 @@ public:
     bool send_error(const std::shared_ptr<endpoint_definition> _target,
                 const byte_t *_data, uint32_t _size);
     bool send_queued(const target_data_iterator_type _it);
-    void send_queued_sync(const target_data_iterator_type _it);
     void get_configured_times_from_endpoint(
             service_t _service, method_t _method,
             std::chrono::nanoseconds *_debouncing,
@@ -83,7 +82,6 @@ private:
         void receive();
 
         void send_queued(const target_data_iterator_type _it);
-        void send_queued_sync(const target_data_iterator_type _it);
 
         void set_remote_info(const endpoint_type &_remote);
         std::string get_address_port_remote() const;

--- a/implementation/endpoints/src/endpoint_impl.cpp
+++ b/implementation/endpoints/src/endpoint_impl.cpp
@@ -145,14 +145,18 @@ instance_t endpoint_impl<Protocol>::get_instance(service_t _service) {
 }
 
 // Instantiate template
-#if defined(__linux__) || defined(ANDROID)
+#ifdef __linux__
 template class endpoint_impl<boost::asio::local::stream_protocol>;
 #if VSOMEIP_BOOST_VERSION < 106600
 template class endpoint_impl<boost::asio::local::stream_protocol_ext>;
-template class endpoint_impl<boost::asio::ip::udp_ext>;
 #endif
 #endif
+
 template class endpoint_impl<boost::asio::ip::tcp>;
 template class endpoint_impl<boost::asio::ip::udp>;
+
+#if VSOMEIP_BOOST_VERSION < 106600
+template class endpoint_impl<boost::asio::ip::udp_ext>;
+#endif
 
 } // namespace vsomeip_v3

--- a/implementation/logger/src/message.cpp
+++ b/implementation/logger/src/message.cpp
@@ -119,7 +119,11 @@ message::~message() try {
         // Prepare time stamp
         auto its_time_t = std::chrono::system_clock::to_time_t(when_);
         struct tm its_time;
+#ifdef _WIN32
+        localtime_s(&its_time, &its_time_t);
+#else
         localtime_r(&its_time_t, &its_time);
+#endif
         auto its_ms = (when_.time_since_epoch().count() / 100) % 1000000;
 
         if (its_configuration->has_console_log()) {

--- a/implementation/routing/include/event.hpp
+++ b/implementation/routing/include/event.hpp
@@ -56,7 +56,7 @@ public:
 
     void set_payload(const std::shared_ptr<payload> &_payload,
             const client_t _client,
-            const std::shared_ptr<endpoint_definition>& _target);
+            const std::shared_ptr<endpoint_definition>& _target, bool _force);
 
     bool prepare_update_payload(const std::shared_ptr<payload> &_payload,
             bool _force);

--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -1271,7 +1271,7 @@ void routing_manager_impl::notify_one(service_t _service, instance_t _instance,
 
             if (its_targets.size() > 0) {
                 for (const auto &its_target : its_targets) {
-                    its_event->set_payload(_payload, _client, its_target);
+                    its_event->set_payload(_payload, _client, its_target, _force);
                 }
             }
         } else {
@@ -1678,7 +1678,7 @@ void routing_manager_impl::on_notification(client_t _client,
                     its_event->set_payload(its_payload, false);
                 }
             } else {
-                 its_event->set_payload(its_payload, false, true);
+                 its_event->set_payload(its_payload, VSOMEIP_ROUTING_CLIENT, true);
             }
         }
     }

--- a/implementation/runtime/src/application_impl.cpp
+++ b/implementation/runtime/src/application_impl.cpp
@@ -204,34 +204,32 @@ bool application_impl::init() {
             do {
                 const uint16_t prev_val(val);
                 its_converter >> std::hex >> std::setw(4) >> val;
-                if (its_converter.good()) {
-                    const std::stringstream::int_type c = its_converter.eof()?'\0':its_converter.get();
-                    switch (c) {
-                    case '"':
-                    case '.':
-                    case ':':
-                    case ' ':
-                    case '\0': {
-                            if ('.' != c) {
-                                if (0xffffu == prev_val) {
-                                    VSOMEIP_INFO << "+filter "
-                                    << std::hex << std::setfill('0')
-                                    << std::setw(4) << val;
-                                    client_side_logging_filter_.insert(std::make_tuple(val, ANY_INSTANCE));
-                                } else {
-                                    VSOMEIP_INFO << "+filter "
-                                    << std::hex << std::setfill('0')
-                                    << std::setw(4) << prev_val << "." << std::setw(4) << val;
-                                    client_side_logging_filter_.insert(std::make_tuple(prev_val, val));
-                                }
-                                val = 0xffffu;
+                const std::stringstream::int_type c = its_converter.eof()?'\0':its_converter.get();
+                switch (c) {
+                case '"':
+                case '.':
+                case ':':
+                case ' ':
+                case '\0': {
+                        if ('.' != c) {
+                            if (0xffffu == prev_val) {
+                                VSOMEIP_INFO << "+filter "
+                                << std::hex << std::setfill('0')
+                                << std::setw(4) << val;
+                                client_side_logging_filter_.insert(std::make_tuple(val, ANY_INSTANCE));
+                            } else {
+                                VSOMEIP_INFO << "+filter "
+                                << std::hex << std::setfill('0')
+                                << std::setw(4) << prev_val << "." << std::setw(4) << val;
+                                client_side_logging_filter_.insert(std::make_tuple(prev_val, val));
                             }
+                            val = 0xffffu;
                         }
-                        break;
-                    default:
-                        stop_parsing = true;
-                        break;
                     }
+                    break;
+                default:
+                    stop_parsing = true;
+                    break;
                 }
             }
             while (!stop_parsing && its_converter.good());

--- a/implementation/service_discovery/include/unknown_option_impl.hpp
+++ b/implementation/service_discovery/include/unknown_option_impl.hpp
@@ -1,0 +1,46 @@
+// Copyright (C) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#ifndef VSOMEIP_V3_SD_UNKOWN_OPTION_IMPL_HPP_
+#define VSOMEIP_V3_SD_UNKOWN_OPTION_IMPL_HPP_
+
+#include <vector>
+
+#include "option_impl.hpp"
+
+namespace vsomeip_v3 {
+namespace sd {
+
+/// @brief An SD Endpoint Option of unknown type.
+///
+/// It is meant to allow the deserialization of an option even if its type is unknown.
+class unknown_option_impl : public option_impl
+{
+public:
+    /// @brief Constructor.
+    unknown_option_impl() = default;
+
+    /// @brief Destructor.
+    ~unknown_option_impl() = default;
+
+    /// @brief Reads the option from the deserializer.
+    ///
+    /// @param _from The deserializer that contains the option.
+    /// @return Whether the deserialization was successful.
+    virtual bool deserialize(deserializer* _from) override;
+
+    /// @brief The payload of the option as an array of bytes.
+    /// @return A reference to the payload.
+    const std::vector<uint8_t>& get_payload() const;
+
+private:
+    /// @brief The payload of the option as an array of bytes.
+    std::vector<uint8_t> payload_;
+};
+
+} // namespace sd
+} // namespace vsomeip_v3
+
+#endif

--- a/implementation/service_discovery/src/message_impl.cpp
+++ b/implementation/service_discovery/src/message_impl.cpp
@@ -27,6 +27,7 @@
 #include "../include/protection_option_impl.hpp"
 #include "../include/selective_option_impl.hpp"
 #include "../include/message_impl.hpp"
+#include "../include/unknown_option_impl.hpp"
 #include "../../message/include/deserializer.hpp"
 #include "../../message/include/payload_impl.hpp"
 #include "../../message/include/serializer.hpp"
@@ -399,7 +400,7 @@ option_impl * message_impl::deserialize_option(vsomeip_v3::deserializer *_from) 
             break;
 
         default:
-            deserialized_option = new option_impl();
+            deserialized_option = new unknown_option_impl();
             break;
         };
 

--- a/implementation/service_discovery/src/option_impl.cpp
+++ b/implementation/service_discovery/src/option_impl.cpp
@@ -57,8 +57,6 @@ bool option_impl::deserialize(vsomeip_v3::deserializer *_from) {
                 break;
             default:
                 type_ = option_type_e::UNKNOWN;
-                // No valid option type --> ignore the remaining parts of the message!
-                _from->set_remaining(0);
         }
     }
 

--- a/implementation/service_discovery/src/unknown_option_impl.cpp
+++ b/implementation/service_discovery/src/unknown_option_impl.cpp
@@ -1,0 +1,31 @@
+// Copyright (C) 2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include "../include/unknown_option_impl.hpp"
+
+#include "../../message/include/deserializer.hpp"
+
+namespace vsomeip_v3 {
+namespace sd {
+
+bool sd::unknown_option_impl::deserialize(deserializer * _from)
+{
+    // Deserialize the header.
+    if (!option_impl::deserialize(_from)) {
+        return false;
+    }
+    payload_ = std::vector<uint8_t>(length_ - 1);
+
+    // Deserialize the payload.
+    return _from->deserialize(payload_);
+}
+
+const std::vector<uint8_t>& unknown_option_impl::get_payload() const
+{
+    return payload_;
+}
+
+} // namespace sd
+} // namespace vsomeip_v3

--- a/libvsomeip.yaml
+++ b/libvsomeip.yaml
@@ -1,5 +1,5 @@
 - name: libvsomeip
-  version: 3.3.6
+  version: 3.3.7
   vendor: Lynx Team
   license:
     concluded: CLOSED and MPLv2


### PR DESCRIPTION
Notes:
- Fix handling of endpoint options
- Fix build on Windows
- Fix client-side logging filters
- Rework in event::set_payload
- Release no longer in use client endpoints
- Rework condition for starting the send operation
- Verify if the event is shadow