### PR TITLE
vsomeip 3.3.8

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -80,7 +80,7 @@ cc_library_shared {
 
     cflags: [
         "-DWITHOUT_SYSTEMD",
-        "-DVSOMEIP_COMPAT_VERSION=\"3.3.7\"",
+        "-DVSOMEIP_COMPAT_VERSION=\"3.3.8\"",
         "-DVSOMEIP_BASE_PATH=\"/vendor/run/someip/\"",
         "-DUSE_DLT",
     ],

--- a/Android.mk
+++ b/Android.mk
@@ -100,7 +100,7 @@ LOCAL_CFLAGS :=  \
     -frtti \
     -fexceptions \
     -DWITHOUT_SYSTEMD \
-    -DVSOMEIP_VERSION=\"3.3.7\" \
+    -DVSOMEIP_VERSION=\"3.3.8\" \
     -DVSOMEIP_BASE_PATH=\"/vendor/run/someip/\" \
     -Wno-unused-parameter \
     -Wno-non-virtual-dtor \
@@ -147,7 +147,7 @@ LOCAL_CFLAGS := \
     -frtti \
     -fexceptions \
     -DWITHOUT_SYSTEMD \
-    -DVSOMEIP_VERSION=\"3.3.7\" \
+    -DVSOMEIP_VERSION=\"3.3.8\" \
     -DVSOMEIP_BASE_PATH=\"/vendor/run/someip/\" \
     -Wno-unused-parameter \
     -Wno-non-virtual-dtor \
@@ -194,8 +194,8 @@ LOCAL_CFLAGS :=  \
     -frtti \
     -fexceptions \
     -DWITHOUT_SYSTEMD \
-    -DVSOMEIP_VERSION=\"3.3.7\" \
-    -DVSOMEIP_COMPAT_VERSION=\"3.3.7\" \
+    -DVSOMEIP_VERSION=\"3.3.8\" \
+    -DVSOMEIP_COMPAT_VERSION=\"3.3.8\" \
     -DVSOMEIP_BASE_PATH=\"/vendor/run/someip/\" \
     -Wno-unused-parameter \
     -Wno-non-virtual-dtor \

--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,11 @@
 Changes
 =======
+v3.3.8
+- Check buffer size when serializing/deserializing event registrations
+- Remove leftovers from shm usage
+- Avoid using uninitialized variable
+- Displays lib version when starting any app
+
 v3.3.7
 - Fix handling of endpoint options
 - Fix build on Windows
@@ -20,7 +26,7 @@ v3.3.5.1
 - Fix typo in application_impl.cpp
 - Update load_balancing_option_impl.cpp
 - Fix format specifier in memory_log_timer_cbk
-- Isolate boost
+- Prevent boost symbols from leaking into global namespace
 - Remove redundant ostream manipulators
 - Fix for configuration option deserialize bug
 - Accept return codes within range 0x20 - 0x5E as valid

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set (VSOMEIP_COMPAT_NAME vsomeip)
 
 set (VSOMEIP_MAJOR_VERSION 3)
 set (VSOMEIP_MINOR_VERSION 3)
-set (VSOMEIP_PATCH_VERSION 7)
+set (VSOMEIP_PATCH_VERSION 8)
 set (VSOMEIP_HOTFIX_VERSION 0)
 
 set (VSOMEIP_VERSION ${VSOMEIP_MAJOR_VERSION}.${VSOMEIP_MINOR_VERSION}.${VSOMEIP_PATCH_VERSION})
@@ -105,13 +105,22 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVSOMEIP_ENABLE_SIGNAL_HANDLING")
 endif ()
 
 if (NOT MSVC)
-    # Sanitizer
+    # Sanitizers
+
+    if (ENABLE_UNDEFINED_SANITIZER)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined")
+    endif ()
+
     if (ENABLE_THREAD_SANITIZER)
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread")
     endif ()
 
     if (ENABLE_LEAK_SANITIZER)
-        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=leak")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=leak")
+    endif ()
+
+    if (ENABLE_ADDRESS_SANITIZER)
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
     endif ()
 
     if (ENABLE_PROFILING)

--- a/implementation/configuration/include/configuration.hpp
+++ b/implementation/configuration/include/configuration.hpp
@@ -186,7 +186,6 @@ public:
 
     // File permissions
     virtual std::uint32_t get_permissions_uds() const = 0;
-    virtual std::uint32_t get_permissions_shm() const = 0;
 
     virtual bool log_version() const = 0;
     virtual uint32_t get_log_version_interval() const = 0;

--- a/implementation/configuration/include/configuration_impl.hpp
+++ b/implementation/configuration/include/configuration_impl.hpp
@@ -182,7 +182,6 @@ public:
     VSOMEIP_EXPORT uint32_t get_allowed_missing_pongs() const;
 
     VSOMEIP_EXPORT std::uint32_t get_permissions_uds() const;
-    VSOMEIP_EXPORT std::uint32_t get_permissions_shm() const;
 
     VSOMEIP_EXPORT bool check_routing_credentials(client_t _client,
             const vsomeip_sec_client_t *_sec_client) const;
@@ -560,7 +559,6 @@ protected:
     };
 
     bool is_configured_[ET_MAX];
-    std::uint32_t permissions_shm_;
     std::uint32_t permissions_uds_;
 
     std::string network_;

--- a/implementation/configuration/include/internal.hpp.in
+++ b/implementation/configuration/include/internal.hpp.in
@@ -126,6 +126,10 @@
 
 #define VSOMEIP_ROUTING_READY_MESSAGE           "@VSOMEIP_ROUTING_READY_MESSAGE@"
 
+#ifndef VSOMEIP_VERSION
+#define VSOMEIP_VERSION "unknown version"
+#endif
+
 namespace vsomeip_v3 {
 
 typedef enum {

--- a/implementation/configuration/include/internal_android.hpp
+++ b/implementation/configuration/include/internal_android.hpp
@@ -106,6 +106,10 @@
 
 #define VSOMEIP_ROUTING_READY_MESSAGE           "SOME/IP routing ready."
 
+#ifndef VSOMEIP_VERSION
+#define VSOMEIP_VERSION "unknown version"
+#endif
+
 namespace vsomeip_v3 {
 
 typedef enum {

--- a/implementation/configuration/src/configuration_impl.cpp
+++ b/implementation/configuration/src/configuration_impl.cpp
@@ -76,7 +76,6 @@ configuration_impl::configuration_impl(const std::string &_path)
       watchdog_(std::make_shared<watchdog>()),
       log_version_(true),
       log_version_interval_(10),
-      permissions_shm_(VSOMEIP_DEFAULT_SHM_PERMISSION),
       permissions_uds_(VSOMEIP_DEFAULT_UDS_PERMISSIONS),
       network_("vsomeip"),
       e2e_enabled_(false),
@@ -123,7 +122,6 @@ configuration_impl::configuration_impl(const configuration_impl &_other)
       max_reliable_message_size_(_other.max_reliable_message_size_),
       max_unreliable_message_size_(_other.max_unreliable_message_size_),
       buffer_shrink_threshold_(_other.buffer_shrink_threshold_),
-      permissions_shm_(VSOMEIP_DEFAULT_SHM_PERMISSION),
       permissions_uds_(VSOMEIP_DEFAULT_UDS_PERMISSIONS),
       endpoint_queue_limit_external_(_other.endpoint_queue_limit_external_),
       endpoint_queue_limit_local_(_other.endpoint_queue_limit_local_),
@@ -2427,11 +2425,7 @@ void configuration_impl::load_permissions(const configuration_element &_element)
                     ++i) {
                 std::string its_key(i->first);
                 std::stringstream its_converter;
-                if (its_key == "permissions-shm") {
-                    std::string its_value(i->second.data());
-                    its_converter << std::oct << its_value;
-                    its_converter >> permissions_shm_;
-                } else if (its_key == "permissions-uds") {
+                if (its_key == "permissions-uds") {
                     std::string its_value(i->second.data());
                     its_converter << std::oct << its_value;
                     its_converter >> permissions_uds_;
@@ -3458,10 +3452,6 @@ uint32_t configuration_impl::get_allowed_missing_pongs() const {
 }
 std::uint32_t configuration_impl::get_permissions_uds() const {
     return permissions_uds_;
-}
-
-std::uint32_t configuration_impl::get_permissions_shm() const {
-    return permissions_shm_;
 }
 
 std::map<plugin_type_e, std::set<std::string>> configuration_impl::get_plugins(

--- a/implementation/protocol/include/register_event.hpp
+++ b/implementation/protocol/include/register_event.hpp
@@ -20,8 +20,8 @@ public:
                     bool is_provided = false, reliability_type_e reliability = reliability_type_e::RT_UNKNOWN,
                     bool is_cyclic = false, uint16_t num_eventg = 0,
                     const std::set<eventgroup_t> &eventgroups = std::set<eventgroup_t>());
-    void serialize(std::vector<byte_t> &_buffer, size_t &_offset) const;
-    void deserialize(const std::vector<byte_t> &_buffer, size_t &_offset);
+    void serialize(std::vector<byte_t> &_buffer, size_t &_offset, error_e &_error) const;
+    void deserialize(const std::vector<byte_t> &_buffer, size_t &_offset, error_e &_error);
 
     service_t get_service() const  { return service_; }
     void set_service(service_t _service) { service_ = _service; }

--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -3395,10 +3395,6 @@ routing_manager_impl::expire_subscriptions(bool _force) {
 
 void routing_manager_impl::log_version_timer_cbk(boost::system::error_code const & _error) {
     if (!_error) {
-
-#ifndef VSOMEIP_VERSION
-#define VSOMEIP_VERSION "unknown version"
-#endif
         static int its_counter(0);
         static uint32_t its_interval = configuration_->get_log_version_interval();
 

--- a/implementation/routing/src/routing_manager_stub.cpp
+++ b/implementation/routing/src/routing_manager_stub.cpp
@@ -347,7 +347,7 @@ void routing_manager_stub::on_message(const byte_t *_data, length_t _size,
                 its_minor = its_command.get_minor();
 
                 if (VSOMEIP_SEC_OK == security::is_client_allowed_to_offer(
-                		_sec_client, its_service, its_instance)) {
+                        _sec_client, its_service, its_instance)) {
                     host_->offer_service(its_client, its_service, its_instance,
                             its_major, its_minor);
                 } else {
@@ -413,7 +413,7 @@ void routing_manager_stub::on_message(const byte_t *_data, length_t _size,
                     }
                 } else {
                     if (VSOMEIP_SEC_OK == security::is_client_allowed_to_access_member(
-                    		_sec_client, its_service, its_instance, its_notifier)) {
+                            _sec_client, its_service, its_instance, its_notifier)) {
                         host_->subscribe(its_client, _sec_client, its_service, its_instance,
                                 its_eventgroup, its_major, its_notifier, its_filter);
                     } else {
@@ -571,7 +571,7 @@ void routing_manager_stub::on_message(const byte_t *_data, length_t _size,
                     // but check requests sent by local proxies to remote against policy.
                     if (utility::is_request(its_message_data[VSOMEIP_MESSAGE_TYPE_POS])) {
                         if (VSOMEIP_SEC_OK != security::is_client_allowed_to_access_member(
-                        		_sec_client, its_service, its_instance, its_method)) {
+                                _sec_client, its_service, its_instance, its_method)) {
                             VSOMEIP_WARNING << "vSomeIP Security: Client 0x" << std::hex << its_client
                                     << " : routing_manager_stub::on_message: "
                                     << " isn't allowed to send a request to service/instance/method "
@@ -644,7 +644,7 @@ void routing_manager_stub::on_message(const byte_t *_data, length_t _size,
                 std::set<protocol::service> its_allowed_requests;
                 for (const auto &r : its_requests) {
                     if (VSOMEIP_SEC_OK == security::is_client_allowed_to_request(
-                    		_sec_client, r.service_, r.instance_)) {
+                            _sec_client, r.service_, r.instance_)) {
                         host_->request_service(its_client,
                             r.service_, r.instance_, r.major_, r.minor_);
                         its_allowed_requests.insert(r);
@@ -836,14 +836,17 @@ void routing_manager_stub::on_register_application(client_t _client) {
             vsomeip_sec_client_t its_sec_client;
             std::set<std::shared_ptr<policy> > its_policies;
 
-            policy_manager_impl::get()->get_client_to_sec_client_mapping(_client, its_sec_client);
-            if (its_sec_client.client_type == VSOMEIP_CLIENT_UDS) {
-                get_requester_policies(its_sec_client.client.uds_client.user,
-                        its_sec_client.client.uds_client.group, its_policies);
-            }
+            bool has_mapping = policy_manager_impl::get()
+                    ->get_client_to_sec_client_mapping(_client, its_sec_client);
+            if (has_mapping) {
+                if (its_sec_client.client_type == VSOMEIP_CLIENT_UDS) {
+                    get_requester_policies(its_sec_client.client.uds_client.user,
+                            its_sec_client.client.uds_client.group, its_policies);
+                }
 
-            if (!its_policies.empty())
-                send_requester_policies({ _client }, its_policies);
+                if (!its_policies.empty())
+                    send_requester_policies({ _client }, its_policies);
+            }
         }
 #endif // !VSOMEIP_DISABLE_SECURITY
     }

--- a/implementation/runtime/src/application_impl.cpp
+++ b/implementation/runtime/src/application_impl.cpp
@@ -238,7 +238,7 @@ bool application_impl::init() {
 
     std::shared_ptr<configuration> its_configuration = get_configuration();
     if (its_configuration) {
-        VSOMEIP_INFO << "Initializing vsomeip application \"" << name_ << "\".";
+        VSOMEIP_INFO << "Initializing vsomeip (" VSOMEIP_VERSION ") application \"" << name_ << "\".";
         client_ = its_configuration->get_id(name_);
 
         // Max dispatchers is the configured maximum number of dispatchers and

--- a/libvsomeip.yaml
+++ b/libvsomeip.yaml
@@ -1,5 +1,5 @@
 - name: libvsomeip
-  version: 3.3.7
+  version: 3.3.8
   vendor: Lynx Team
   license:
     concluded: CLOSED and MPLv2

--- a/test/network_tests/configuration_tests/configuration-test.cpp
+++ b/test/network_tests/configuration_tests/configuration-test.cpp
@@ -232,7 +232,6 @@ void check_file(const std::string &_config_file,
     EXPECT_EQ(7u, its_configuration->get_allowed_missing_pongs());
 
     // file permissions
-    EXPECT_EQ(0444u, its_configuration->get_permissions_shm());
     EXPECT_EQ(0222u, its_configuration->get_permissions_uds());
 
     // selective broadcasts


### PR DESCRIPTION
Notes:
- Check buffer size when serializing/deserializing event registrations
- Remove leftovers from shm usage
- Avoid using uninitialized variable
- Displays lib version when starting any app