### PR TITLE
Fix IPv6 Service Discovery

### DIFF
--- a/implementation/endpoints/include/udp_server_endpoint_impl_receive_op.hpp
+++ b/implementation/endpoints/include/udp_server_endpoint_impl_receive_op.hpp
@@ -143,9 +143,9 @@ struct udp_server_endpoint_impl_receive_op {
                     boost::asio::ip::address_v6::bytes_type its_bytes;
 
                     // sender
-                    boost::asio::ip::address_v6 its_sender_address;
                     for (size_t i = 0; i < its_bytes.size(); i++)
                         its_bytes[i] = addr.v6.sin6_addr.s6_addr[i];
+                    boost::asio::ip::address_v6 its_sender_address(its_bytes);
                     in_port_t its_sender_port(ntohs(addr.v6.sin6_port));
                     sender_ = endpoint_type_t(its_sender_address, its_sender_port);
 

--- a/implementation/endpoints/src/udp_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/udp_server_endpoint_impl.cpp
@@ -824,7 +824,7 @@ udp_server_endpoint_impl::set_multicast_option(
             int its_pktinfo_option(1);
             ::setsockopt(multicast_socket_->native_handle(),
                     (is_v4_ ? IPPROTO_IP : IPPROTO_IPV6),
-                    (is_v4_ ? IP_PKTINFO : IPV6_PKTINFO),
+                    (is_v4_ ? IP_PKTINFO : IPV6_RECVPKTINFO),
                     &its_pktinfo_option, sizeof(its_pktinfo_option));
 #endif
 


### PR DESCRIPTION
When switching from IPv4 addresses to IPv6 addresses, I noticed that service discovery was no longer working.

One bug was just a missing initialization of the IPv6 address while the other bug was a missing cmsg. For IPv6 on linux it seems like the correct socket option is not `IPV6_PKTINFO` but rather `IPV6_RECVPKTINFO`

I hope this can be merged soon, if there are any problems feel free to contact me