### PR TITLE
in application interface change remaining handler types to const ref

### DIFF
--- a/implementation/compat/runtime/include/application_impl.hpp
+++ b/implementation/compat/runtime/include/application_impl.hpp
@@ -152,7 +152,7 @@ public:
 
     virtual void register_async_subscription_handler(
             service_t _service, instance_t _instance, eventgroup_t _eventgroup,
-            async_subscription_handler_t _handler);
+            const async_subscription_handler_t& _handler);
 
     virtual void set_offer_acceptance_required(
             ip_address_t _address, const std::string _path, bool _enable);

--- a/implementation/compat/runtime/src/application_impl.cpp
+++ b/implementation/compat/runtime/src/application_impl.cpp
@@ -509,7 +509,7 @@ application_impl::set_watchdog_handler(
 void
 application_impl::register_async_subscription_handler(
         service_t _service, instance_t _instance, eventgroup_t _eventgroup,
-        async_subscription_handler_t _handler) {
+        const async_subscription_handler_t& _handler) {
 
     {
         std::lock_guard<std::mutex> its_lock(eventgroups_mutex_);

--- a/implementation/runtime/include/application_impl.hpp
+++ b/implementation/runtime/include/application_impl.hpp
@@ -157,7 +157,7 @@ public:
             eventgroup_t _eventgroup, event_t _event, uint16_t _error);
     VSOMEIP_EXPORT void register_subscription_status_handler(service_t _service,
             instance_t _instance, eventgroup_t _eventgroup, event_t _event,
-            subscription_status_handler_t _handler, bool _is_selective);
+            const subscription_status_handler_t& _handler, bool _is_selective);
     VSOMEIP_EXPORT void unregister_subscription_status_handler(service_t _service,
                 instance_t _instance, eventgroup_t _eventgroup, event_t _event);
 
@@ -224,7 +224,7 @@ public:
                 const subscription_handler_sec_t &_handler);
     VSOMEIP_EXPORT void register_async_subscription_handler(
                 service_t _service, instance_t _instance, eventgroup_t _eventgroup,
-                async_subscription_handler_sec_t _handler);
+                const async_subscription_handler_sec_t& _handler);
 
 private:
     //

--- a/implementation/runtime/src/application_impl.cpp
+++ b/implementation/runtime/src/application_impl.cpp
@@ -1305,7 +1305,7 @@ void application_impl::deliver_subscription_state(service_t _service, instance_t
 
 void application_impl::register_subscription_status_handler(service_t _service,
             instance_t _instance, eventgroup_t _eventgroup, event_t _event,
-            subscription_status_handler_t _handler, bool _is_selective) {
+            const subscription_status_handler_t& _handler, bool _is_selective) {
     std::lock_guard<std::mutex> its_lock(subscription_status_handlers_mutex_);
     if (_handler) {
         subscription_status_handlers_[_service][_instance][_eventgroup][_event] =
@@ -2629,7 +2629,7 @@ void application_impl::register_async_subscription_handler(service_t _service,
 
 void application_impl::register_async_subscription_handler(service_t _service,
     instance_t _instance, eventgroup_t _eventgroup,
-    async_subscription_handler_sec_t _handler) {
+    const async_subscription_handler_sec_t& _handler) {
 
     std::lock_guard<std::mutex> its_lock(subscription_mutex_);
     subscription_[_service][_instance][_eventgroup] = std::make_pair(nullptr, _handler);

--- a/interface/compat/vsomeip/application.hpp
+++ b/interface/compat/vsomeip/application.hpp
@@ -947,7 +947,7 @@ public:
      */
     virtual void register_async_subscription_handler(
             service_t _service, instance_t _instance, eventgroup_t _eventgroup,
-            async_subscription_handler_t _handler) = 0;
+            const async_subscription_handler_t& _handler) = 0;
 
     /**
      *  \brief Enables or disables calling of registered offer acceptance

--- a/interface/vsomeip/application.hpp
+++ b/interface/vsomeip/application.hpp
@@ -718,7 +718,7 @@ public:
      */
     virtual void register_subscription_status_handler(service_t _service,
             instance_t _instance, eventgroup_t _eventgroup, event_t _event,
-            subscription_status_handler_t _handler, bool _is_selective = false) = 0;
+            const subscription_status_handler_t& _handler, bool _is_selective = false) = 0;
 
     /**
      *
@@ -1103,7 +1103,7 @@ public:
      */
     virtual void register_async_subscription_handler(
             service_t _service, instance_t _instance, eventgroup_t _eventgroup,
-            async_subscription_handler_sec_t _handler) = 0;
+            const async_subscription_handler_sec_t& _handler) = 0;
 };
 
 /** @} */


### PR DESCRIPTION
I have been mocking vsomeip for work and realized minor inconsistencies.
Looking at the implementations, it should avoid one or two unnecessary copies.

What do you think?

On an unrelated site note: The whole header `interface/vsomeip/vsomeip_sec.h` is missing namespaces. If you agree that this is not how it should be, I can setup another PR for that.