### PR TITLE
Correction of interface description comments

### DIFF
--- a/interface/vsomeip/message_base.hpp
+++ b/interface/vsomeip/message_base.hpp
@@ -110,7 +110,7 @@ public:
     VSOMEIP_EXPORT virtual request_t get_request() const = 0;
 
     /**
-     * \brief Set the client identifier in the message header.
+     * \brief Get the client identifier in the message header.
      */
     VSOMEIP_EXPORT virtual client_t get_client() const = 0;
 


### PR DESCRIPTION
When I looked at the interface description, I found the interface description of vsomeip::message_Base::get_client() is incorrect. Fixed the description of this interface in this branch.