### PR TITLE
do not instantiate a non existent type for boost < 1.66.0

### DIFF
--- a/implementation/endpoints/src/endpoint_impl.cpp
+++ b/implementation/endpoints/src/endpoint_impl.cpp
@@ -146,9 +146,10 @@ instance_t endpoint_impl<Protocol>::get_instance(service_t _service) {
 
 // Instantiate template
 #ifdef __linux__
-template class endpoint_impl<boost::asio::local::stream_protocol>;
 #if VSOMEIP_BOOST_VERSION < 106600
 template class endpoint_impl<boost::asio::local::stream_protocol_ext>;
+#else
+template class endpoint_impl<boost::asio::local::stream_protocol>;
 #endif
 #endif
 


### PR DESCRIPTION
Running into this issue on ubuntu 18.04 with default boost 1.65.1:

"""
[ 13%] Building CXX object source_subfolder/CMakeFiles/vsomeip3.dir/implementation/endpoints/src/udp_server_endpoint_impl.cpp.o
/home/luminar/.conan/data/vsomeip/3.3.8/_/_/build/4680fa740d12425c07e8c5a8a78533712cfc0d37/source_subfolder/implementation/endpoints/src/server_endpoint_impl.cpp:841:57: error: ‘stream_protocol’ is not a member of ‘boost::asio::local’
 template class server_endpoint_impl<boost::asio::local::stream_protocol>;
                                                         ^~~~~~~~~~~~~~~
/home/luminar/.conan/data/vsomeip/3.3.8/_/_/build/4680fa740d12425c07e8c5a8a78533712cfc0d37/source_subfolder/implementation/endpoints/src/server_endpoint_impl.cpp:841:57: note: suggested alternative: ‘stream_protocol_ext’
 template class server_endpoint_impl<boost::asio::local::stream_protocol>;
                                                         ^~~~~~~~~~~~~~~
                                                         stream_protocol_ext
/home/luminar/.conan/data/vsomeip/3.3.8/_/_/build/4680fa740d12425c07e8c5a8a78533712cfc0d37/source_subfolder/implementation/endpoints/src/server_endpoint_impl.cpp:841:57: error: ‘stream_protocol’ is not a member of ‘boost::asio::local’
/home/luminar/.conan/data/vsomeip/3.3.8/_/_/build/4680fa740d12425c07e8c5a8a78533712cfc0d37/source_subfolder/implementation/endpoints/src/server_endpoint_impl.cpp:841:57: note: suggested alternative: ‘stream_protocol_ext’
 template class server_endpoint_impl<boost::asio::local::stream_protocol>;
                                                         ^~~~~~~~~~~~~~~
                                                         stream_protocol_ext
/home/luminar/.conan/data/vsomeip/3.3.8/_/_/build/4680fa740d12425c07e8c5a8a78533712cfc0d37/source_subfolder/implementation/endpoints/src/server_endpoint_impl.cpp:841:72: error: template argument 1 is invalid
 template class server_endpoint_impl<boost::asio::local::stream_protocol>;

"""