### PR TITLE
deleted unused param _use_exclusive_proxy

### DIFF
--- a/interface/vsomeip/application.hpp
+++ b/interface/vsomeip/application.hpp
@@ -258,8 +258,6 @@ public:
      * \param _instance Instance identifier of the requested service instance.
      * \param _major Major service version (Default: 0xFF).
      * \param _minor Minor service version (Default: 0xFFFFFF).
-     * \param _use_exclusive_proxy Create an IP endpoint that is exclusively
-     * used for the communication of this application to the service instance.
      *
      */
     virtual void request_service(service_t _service, instance_t _instance,


### PR DESCRIPTION
This seems a parameter that was used in old versions of vsomeip, right now in vsomeip3 this parameter is not used

vsomeip 2.6:
https://github.com/COVESA/vsomeip/blob/5315798ff81796217b55eb8c622f154bb0a1c487/interface/vsomeip/application.hpp#L222-L231

