### PR TITLE
Allow service_discovery to continue without random_device

### DIFF
--- a/implementation/security/include/policy_manager_impl.hpp
+++ b/implementation/security/include/policy_manager_impl.hpp
@@ -153,10 +153,11 @@ private:
     mutable boost::shared_mutex policy_extension_paths_mutex_;
     //map[hostname, pair[path,  map[complete path with UID/GID, control loading]]
     std::map<std::string, std::pair<std::string, std::map<std::string, bool>>> policy_extension_paths_;
+
+    bool check_routing_credentials_;
 #endif // !VSOMEIP_DISABLE_SECURITY
 
     bool is_configured_;
-    bool check_routing_credentials_;
 
     mutable std::mutex routing_credentials_mutex_;
     std::pair<uint32_t, uint32_t> routing_credentials_;

--- a/implementation/security/src/policy_manager_impl.cpp
+++ b/implementation/security/src/policy_manager_impl.cpp
@@ -46,9 +46,9 @@ policy_manager_impl::policy_manager_impl()
     allow_remote_clients_(true),
     check_whitelist_(false),
     policy_base_path_(""),
+    check_routing_credentials_(false),
 #endif // !VSOMEIP_DISABLE_SECURITY
-    is_configured_(false),
-    check_routing_credentials_(false)
+    is_configured_(false)
 {
 }
 

--- a/implementation/service_discovery/src/service_discovery_impl.cpp
+++ b/implementation/service_discovery/src/service_discovery_impl.cpp
@@ -114,11 +114,31 @@ service_discovery_impl::init() {
         initial_delay_max = tmp;
     }
 
-    std::random_device r;
-    std::mt19937 e(r());
-    std::uniform_int_distribution<std::uint32_t> distribution(
-            initial_delay_min, initial_delay_max);
-    initial_delay_ = std::chrono::milliseconds(distribution(e));
+    try {
+        std::random_device r;
+        std::mt19937 e(r());
+        std::uniform_int_distribution<std::uint32_t> distribution(
+                initial_delay_min, initial_delay_max);
+        initial_delay_ = std::chrono::milliseconds(distribution(e));
+    } catch (std::exception const& e) {
+        VSOMEIP_ERROR << "Failed to generate random initial delay: " << e.what();
+
+        // Fallback to the Mersenne Twister engine
+        auto const seed = static_cast<std::mt19937::result_type>(
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::high_resolution_clock::now().time_since_epoch())
+                .count());
+
+        std::mt19937 mtwister{seed};
+
+        // Interpolate between initial_delay bounds
+        initial_delay_ = std::chrono::milliseconds(
+            initial_delay_min +
+            (static_cast<std::int64_t>(mtwister()) *
+             static_cast<std::int64_t>(initial_delay_max - initial_delay_min) /
+             static_cast<std::int64_t>(std::mt19937::max() -
+                                       std::mt19937::min())));
+    }
 
 
     repetitions_base_delay_ = std::chrono::milliseconds(

--- a/implementation/service_discovery/src/service_discovery_impl.cpp
+++ b/implementation/service_discovery/src/service_discovery_impl.cpp
@@ -120,11 +120,11 @@ service_discovery_impl::init() {
         std::uniform_int_distribution<std::uint32_t> distribution(
                 initial_delay_min, initial_delay_max);
         initial_delay_ = std::chrono::milliseconds(distribution(e));
-    } catch (std::exception const& e) {
+    } catch (const std::exception& e) {
         VSOMEIP_ERROR << "Failed to generate random initial delay: " << e.what();
 
         // Fallback to the Mersenne Twister engine
-        auto const seed = static_cast<std::mt19937::result_type>(
+        const auto seed = static_cast<std::mt19937::result_type>(
             std::chrono::duration_cast<std::chrono::milliseconds>(
                 std::chrono::high_resolution_clock::now().time_since_epoch())
                 .count());


### PR DESCRIPTION
Allow service discovery to continue even if the `random_device` isn't yet available. This is unlikely to occur on linux systems, but not impossible. It is more likely on other systems (_e.g_ QNX.)  In the event that the `random_device` isn't available, an error message is produced and the middle of the min/max for the delay is used.

This PR also removes the `check_routing_credentials_` member on the `policy_manager_impl` class when security is disabled.  This removes the private error warning turned error by -Werror:
```
error: private field 'check_routing_credentials_' is not used [-Werror,-Wunused-private-field] error
```