### PR TITLE
Add reuse port support in configuration

### DIFF
--- a/implementation/configuration/src/configuration_impl.cpp
+++ b/implementation/configuration/src/configuration_impl.cpp
@@ -2806,6 +2806,21 @@ bool configuration_impl::get_client_port(
             << _instance << " remote_port: "
             << _remote_port << " reliable: "
             << _reliable;
+
+    // Add reuse port support
+    uint16_t its_reuse_port(ILLEGAL_PORT);
+    if(!_used_client_ports[_reliable].empty()){
+        its_reuse_port = *(_used_client_ports[_reliable].begin());
+        if (its_reuse_port != ILLEGAL_PORT) {
+            _client_port = its_reuse_port;
+            VSOMEIP_INFO << "Cannot find free client port, so reuse port configuration for communication to service: "
+            << _service << " instance: "
+            << _instance << " remote_port: "
+            << _remote_port << "client_port:" << _client_port
+            << " reliable: " << _reliable;
+            return true;
+        }
+    }
     return false;
 }
 


### PR DESCRIPTION
current version is not able to auto reuse port for client in configuration_imp::get_client_port() when json configuration as below:
```json
"clients":[
{
        "service": "0x0001",
        "instance": "1",
        "unreliable": [
          "30501"
        ]
      },
      {
        "service": "0x002",
        "instance": "1",
        "unreliable": [
          "30501"
        ]
      },
      {
        "reliable_remote_ports": {
          "first": "30500",
          "last": "30500"
        },
        "unreliable_remote_ports": {
          "first": "30500",
          "last": "30500"
        },
        "reliable_client_ports": {
          "first": "30501",
          "last": "30501"
        },
        "unreliable_client_ports": {
          "first": "30501",
          "last": "30501"
        }
      }
]
```