### PR TITLE
cmake_minimum_required to 3.13 which supports target_link_options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required (VERSION 3.10)
+cmake_minimum_required (VERSION 3.13)
 project (vsomeip)
 
 set (VSOMEIP_NAME vsomeip3)


### PR DESCRIPTION
**target_link_options** was added in cmake version **3.13** --> [ref](https://cmake.org/cmake/help/latest/command/target_link_options.html). This comamnd is used in CMakeLists.txt:L314

Because of this in unix enviroment you shall use at least cmake version 3.13. It seems that we shall add 
cmake_minimum_required as 3.13
