### PR TITLE
Improve serialization and deserialization of Configuration Option

### DIFF
--- a/implementation/service_discovery/include/configuration_option_impl.hpp
+++ b/implementation/service_discovery/include/configuration_option_impl.hpp
@@ -21,6 +21,13 @@ namespace sd {
 
 class configuration_option_impl: public option_impl {
 
+    struct configuration_value {
+        bool only_present_;
+        std::string value_;
+
+        bool operator==(const configuration_value& other) const;
+    };
+
 public:
     configuration_option_impl();
     virtual ~configuration_option_impl();
@@ -28,17 +35,21 @@ public:
     bool equals(const option_impl &_other) const;
 
     void add_item(const std::string &_key, const std::string &_value);
+    void add_item(const std::string &_key);
     void remove_item(const std::string &_key);
 
     std::vector<std::string> get_keys() const;
     std::vector<std::string> get_values() const;
-    std::string get_value(const std::string &_key) const;
+    std::string get_value(const std::string &_key, int occurence = 0) const;
+    uint is_present(const std::string &_key) const;
+    bool has_key(const std::string &_key, int occurence = 0) const;
+    bool has_value(const std::string &_key, int occurence = 0) const;
 
     bool serialize(vsomeip_v3::serializer *_to) const;
     bool deserialize(vsomeip_v3::deserializer *_from);
 
 private:
-    std::map<std::string, std::string> configuration_;
+    std::multimap<std::string, configuration_value> configuration_;
 };
 
 } // namespace sd

--- a/implementation/service_discovery/src/configuration_option_impl.cpp
+++ b/implementation/service_discovery/src/configuration_option_impl.cpp
@@ -4,6 +4,7 @@
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 #include <cstring>
+#include <vsomeip/internal/logger.hpp>
 
 #include "../include/configuration_option_impl.hpp"
 #include "../../message/include/deserializer.hpp"
@@ -11,6 +12,24 @@
 
 namespace vsomeip_v3 {
 namespace sd {
+
+namespace {
+    bool verify_key(const std::string& _key) {
+        for (const char c: _key) {
+            if (c < 0x20 || c > 0x7E) {
+                VSOMEIP_ERROR << "configuration_option_impl::" << __func__ <<
+                    "key must only contain ASCII characters";
+                    return false;
+            }
+            if (c == 0x3D) {
+                VSOMEIP_ERROR << "configuration_option_impl::" << __func__ <<
+                    "key must not contain an '=' character.";
+                    return false;
+            }
+        }
+        return true;
+    }
+}
 
 configuration_option_impl::configuration_option_impl() {
     length_ = 2; // always contains "Reserved" and the trailing '\0'
@@ -35,14 +54,28 @@ configuration_option_impl::equals(const option_impl &_other) const {
 
 void configuration_option_impl::add_item(const std::string &_key,
         const std::string &_value) {
-    configuration_[_key] = _value;
+    if (!verify_key(_key)) {
+        return;
+    }
+    configuration_.emplace(std::make_pair(_key, configuration_value{false,_value}));
     length_ = uint16_t(length_ + _key.length() + _value.length() + 2u); // +2 for the '=' and length
+}
+
+void configuration_option_impl::add_item(const std::string &_key) {
+    if (!verify_key(_key)) {
+        return;
+    }
+    configuration_.emplace(std::make_pair(_key, configuration_value{true, std::string()}));
+    length_ = uint16_t(length_ + _key.length() + 1u); // +1 for the 'length
 }
 
 void configuration_option_impl::remove_item(const std::string &_key) {
     auto it = configuration_.find(_key);
     if (it != configuration_.end()) {
-        length_ = uint16_t(length_ - (it->first.length() + it->second.length() + 2u));
+        length_ = uint16_t(length_ - (it->first.length() + it->second.value_.length() + 1u));
+        // +1 for the '=' sign.
+        if (!it->second.only_present_)
+            length_++;
         configuration_.erase(it);
     }
 }
@@ -57,17 +90,48 @@ std::vector<std::string> configuration_option_impl::get_keys() const {
 std::vector<std::string> configuration_option_impl::get_values() const {
     std::vector < std::string > l_values;
     for (const auto& elem : configuration_)
-        l_values.push_back(elem.second);
+        l_values.push_back(elem.second.value_);
     return l_values;
 }
 
 std::string configuration_option_impl::get_value(
-        const std::string &_key) const {
-    std::string l_value("");
-    auto l_elem = configuration_.find(_key);
-    if (l_elem != configuration_.end())
-        l_value = l_elem->second;
-    return l_value;
+        const std::string &_key,
+        const int occurence) const {
+    auto iterators = configuration_.equal_range(_key);
+    auto it = iterators.first;
+    if (occurence >= std::distance(iterators.first, iterators.second)) {
+        return std::string();
+    }
+
+    return it->second.value_;
+}
+
+bool configuration_option_impl::has_key(const std::string &_key, int occurence) const {
+    auto iterators = configuration_.equal_range(_key);
+    if (occurence >= std::distance(iterators.first, iterators.second)) {
+        return false;
+    }
+
+    return true;
+}
+
+bool configuration_option_impl::has_value(const std::string &_key, int occurence) const {
+    auto iterators = configuration_.equal_range(_key);
+    if (occurence >= std::distance(iterators.first, iterators.second)) {
+        return false;
+    }
+
+    auto it = iterators.first;
+    std::advance(it, occurence);
+    if (it->second.only_present_) {
+        return false;
+    }
+
+    return true;
+}
+
+uint configuration_option_impl::is_present(const std::string &_key) const {
+    return static_cast<uint>(configuration_.count(_key));
 }
 
 bool configuration_option_impl::serialize(vsomeip_v3::serializer *_to) const {
@@ -75,11 +139,17 @@ bool configuration_option_impl::serialize(vsomeip_v3::serializer *_to) const {
     std::string configuration_string;
 
     for (auto i = configuration_.begin(); i != configuration_.end(); ++i) {
-        char l_length = char(1 + i->first.length() + i->second.length());
+        // If key is just present, there will not be any '=' sign or value at all.
+        if (i->second.only_present_) {
+            configuration_string.push_back(static_cast<char>(i->first.length()));
+            configuration_string.append(i->first);
+            continue;
+        }
+        char l_length = char(1 + i->first.length() + i->second.value_.length());
         configuration_string.push_back(l_length);
         configuration_string.append(i->first);
         configuration_string.push_back('=');
-        configuration_string.append(i->second);
+        configuration_string.append(i->second.value_);
     }
     configuration_string.push_back('\0');
 
@@ -94,42 +164,96 @@ bool configuration_option_impl::serialize(vsomeip_v3::serializer *_to) const {
 }
 
 bool configuration_option_impl::deserialize(vsomeip_v3::deserializer *_from) {
-    bool is_successful = option_impl::deserialize(_from);
-    uint8_t l_itemLength = 0;
-    std::string l_item(256, 0), l_key, l_value;
+    if (!option_impl::deserialize(_from)) {
+        VSOMEIP_WARNING << __func__ << "Could not deserialize Option header.";
+        return false;
+    }
 
-    do {
-        l_itemLength = 0;
-        l_key.clear();
-        l_value.clear();
-        l_item.assign(256, '\0');
+    // Length contains reserved byte.
+    const uint32_t string_length = length_ - 1;
+    std::string raw_string(string_length, 0);
 
-        is_successful = is_successful && _from->deserialize(l_itemLength);
-        if (l_itemLength > 0) {
-            is_successful = is_successful
-                    && _from->deserialize(l_item, static_cast<std::size_t>(l_itemLength));
+    if (string_length == 0) {
+        VSOMEIP_WARNING << "Configuration Option: Invalid String length.";
+        return false;
+    }
 
-            if (is_successful) {
-                size_t l_eqPos = l_item.find('='); //SWS_SD_00292
-                l_key = l_item.substr(0, l_eqPos);
+    if (!_from->deserialize(raw_string, string_length)) {
+        VSOMEIP_WARNING << "Configuration Option: Could not deserialize Configuration String.";
+        return false;
+    }
 
-                //if no "=" is found, no value is present for key (SWS_SD_00466)
-                if( l_eqPos != std::string::npos )
-                    l_value = l_item.substr(l_eqPos + 1);
-                if (configuration_.end() == configuration_.find(l_key)) {
-                    configuration_[l_key] = l_value;
-                } else {
-                    // TODO: log reason for failing deserialization
-                    is_successful = false;
-                }
-            }
-        } else {
-              break;
+    uint32_t substring_size_index = 0;
+    uint8_t substring_size = static_cast<uint8_t>(raw_string[substring_size_index]);
+    while (substring_size != 0) {
+        const uint32_t substring_begin_index = substring_size_index + 1;
+        const uint32_t substring_end_index = substring_begin_index + substring_size;
+
+        if (substring_end_index > string_length) {
+            VSOMEIP_WARNING << "Configuration Option: Invalid Configuration substring size.";
+            return false;
         }
-    } while (is_successful && _from->get_remaining() > 0);
 
-    return is_successful;
+        const char* const sub_string = raw_string.data() + substring_begin_index;
+        uint32_t equal_sign_index = 0;
+        if (sub_string[0] == 0x3D) {
+            VSOMEIP_WARNING << "Configuration Option: Substring of Configuration Option starts with '='.";
+            return false;
+        }
+        for (uint32_t i = 0; i < substring_size; ++i) {
+            const char c = sub_string[i];
+            if (c < 0x20 || c > 0x7E) {
+                VSOMEIP_WARNING << "Configuration Option: Non ASCII character in Configuration Option key.";
+                return false;
+            }
+            if (c == 0x3D) {
+                equal_sign_index = i;
+                break;
+            }
+        }
+
+        if (equal_sign_index == 0) {
+            // No '=' sign means that key is present. (SWS_SD_00466)
+            configuration_.emplace(
+                std::make_pair(
+                    std::string(sub_string, substring_size),
+                    configuration_value{
+                        true,
+                        std::string()
+                    }
+                )
+            );
+        } else {
+            configuration_.emplace(
+                std::make_pair(
+                    std::string(sub_string, equal_sign_index),
+                    configuration_value{
+                        false,
+                        std::string(
+                            sub_string + equal_sign_index + 1,
+                            substring_size - equal_sign_index - 1
+                        )
+                    }
+                )
+            );
+        }
+
+        substring_size_index = substring_end_index;
+        substring_size = static_cast<uint8_t>(raw_string[substring_size_index]);
+    }
+
+    if (substring_size_index < string_length - 1) {
+        VSOMEIP_WARNING << "Configuration Option: String length exceeds escape character.";
+    }
+
+    return true;
 }
 
-} // namespace sd
+bool configuration_option_impl::configuration_value::operator==(const configuration_value& other) const {
+    return only_present_ == other.only_present_ && value_ == other.value_;
+}
+
+}
+
+// namespace sd
 } // namespace vsomeip_v3


### PR DESCRIPTION
- better support for Configuration Strings with no value present at all
- support for Configuration Strings with multiple occurences of same key -print warnings on parse error
- never deserialize further than given length of Configuration Option
- do not allow non ASCII-characters in Configuration String key

Fixes #511 