### PR TITLE
Added Covesa-Namespace for targets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -533,6 +533,7 @@ install (
 # Install the export set for use with the install-tree
 install (
     EXPORT ${VSOMEIP_NAME}Targets
+    NAMESPACE Covesa::
     DESTINATION "${INSTALL_CMAKE_DIR}"
     COMPONENT dev
 )


### PR DESCRIPTION
Add Covesa Namespace to VSomeIP-Targets. 

This simplifies the CMake structure in some cases.