### PR TITLE
renamed `ipv3_option_impl` to `ipv4_option_impl` in file message_impl.hpp

### DIFF
--- a/implementation/service_discovery/include/message_impl.hpp
+++ b/implementation/service_discovery/include/message_impl.hpp
@@ -36,8 +36,6 @@ class serviceentry_impl;
 
 class option_impl;
 class configuration_option_impl;
-class ipv4_option_impl;
-class ipv6_option_impl;
 class load_balancing_option_impl;
 class protection_option_impl;
 class selective_option_impl;

--- a/implementation/service_discovery/include/message_impl.hpp
+++ b/implementation/service_discovery/include/message_impl.hpp
@@ -36,7 +36,7 @@ class serviceentry_impl;
 
 class option_impl;
 class configuration_option_impl;
-class ipv3_option_impl;
+class ipv4_option_impl;
 class ipv6_option_impl;
 class load_balancing_option_impl;
 class protection_option_impl;


### PR DESCRIPTION
in implementation/service_discovery/include/message_impl.hpp
there are  a forward declaration： 
`class ipv3_option_impl;`
howerver，`ipv3_option_impl` is not exist and it should be `ipv4_option_impl`
