### PR TITLE
Allow static libs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,10 @@ if(NOT CMAKE_BUILD_TYPE)
   # Set the possible values of build type for cmake-gui
   set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
 endif()
+option(BUILD_SHARED_LIBS "Set to OFF to build static libraries" ON)
+if(NOT BUILD_SHARED_LIBS)
+  add_definitions(-DVSOMEIP_STATIC_PLUGINS)
+endif()
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -287,7 +291,7 @@ file(GLOB ${VSOMEIP_NAME}-cfg_SRC
 )
 list(SORT ${VSOMEIP_NAME}-cfg_SRC)
 if (VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS EQUAL 0)
-    add_library(${VSOMEIP_NAME}-cfg SHARED ${${VSOMEIP_NAME}-cfg_SRC})
+    add_library(${VSOMEIP_NAME}-cfg ${${VSOMEIP_NAME}-cfg_SRC})
     set_target_properties (${VSOMEIP_NAME}-cfg PROPERTIES VERSION ${VSOMEIP_VERSION} SOVERSION ${VSOMEIP_MAJOR_VERSION})
     target_compile_features(${VSOMEIP_NAME}-cfg PRIVATE cxx_std_17)
     if (MSVC)
@@ -322,7 +326,7 @@ endif()
 
 list(SORT ${VSOMEIP_NAME}_SRC)
 
-add_library(${VSOMEIP_NAME} SHARED ${${VSOMEIP_NAME}_SRC})
+add_library(${VSOMEIP_NAME} ${${VSOMEIP_NAME}_SRC})
 set_target_properties (${VSOMEIP_NAME} PROPERTIES VERSION ${VSOMEIP_VERSION} SOVERSION ${VSOMEIP_MAJOR_VERSION})
 target_compile_features(${VSOMEIP_NAME} PRIVATE cxx_std_17)
 if (MSVC)
@@ -354,7 +358,7 @@ file(GLOB ${VSOMEIP_NAME}-sd_SRC
 )
 list(SORT ${VSOMEIP_NAME}-sd_SRC)
 
-add_library(${VSOMEIP_NAME}-sd SHARED ${${VSOMEIP_NAME}-sd_SRC})
+add_library(${VSOMEIP_NAME}-sd ${${VSOMEIP_NAME}-sd_SRC})
 target_compile_features(${VSOMEIP_NAME}-sd PRIVATE cxx_std_17)
 set_target_properties (${VSOMEIP_NAME}-sd PROPERTIES VERSION ${VSOMEIP_VERSION} SOVERSION ${VSOMEIP_MAJOR_VERSION})
 if (MSVC)
@@ -372,7 +376,7 @@ file(GLOB_RECURSE ${VSOMEIP_NAME}-e2e_SRC
 )
 list(SORT ${VSOMEIP_NAME}-e2e_SRC)
 
-add_library(${VSOMEIP_NAME}-e2e SHARED ${${VSOMEIP_NAME}-e2e_SRC})
+add_library(${VSOMEIP_NAME}-e2e ${${VSOMEIP_NAME}-e2e_SRC})
 target_compile_features(${VSOMEIP_NAME}-e2e PRIVATE cxx_std_17)
 set_target_properties (${VSOMEIP_NAME}-e2e PROPERTIES VERSION ${VSOMEIP_VERSION} SOVERSION ${VSOMEIP_MAJOR_VERSION})
 if (MSVC)
@@ -404,7 +408,7 @@ file(GLOB_RECURSE ${VSOMEIP_COMPAT_NAME}_SRC
 )
 list(SORT ${VSOMEIP_COMPAT_NAME}_SRC)
 
-add_library(${VSOMEIP_COMPAT_NAME} SHARED ${${VSOMEIP_COMPAT_NAME}_SRC})
+add_library(${VSOMEIP_COMPAT_NAME} ${${VSOMEIP_COMPAT_NAME}_SRC})
 target_compile_features(${VSOMEIP_COMPAT_NAME} PRIVATE cxx_std_17)
 set_target_properties (${VSOMEIP_COMPAT_NAME} PROPERTIES VERSION ${VSOMEIP_COMPAT_VERSION} SOVERSION ${VSOMEIP_COMPAT_MAJOR_VERSION})
 if (MSVC)

--- a/examples/routingmanagerd/CMakeLists.txt
+++ b/examples/routingmanagerd/CMakeLists.txt
@@ -9,6 +9,9 @@ target_link_libraries(routingmanagerd ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${DL_LI
 if(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
     target_link_libraries(routingmanagerd socket)
 endif()
+if(NOT BUILD_SHARED_LIBS)
+    target_link_libraries(routingmanagerd ${VSOMEIP_NAME}-cfg ${VSOMEIP_NAME}-e2e ${VSOMEIP_NAME}-sd)
+endif()
 add_dependencies(routingmanagerd ${VSOMEIP_NAME})
 
 option(VSOMEIP_INSTALL_ROUTINGMANAGERD "Whether or not to install the routing manager daemon.")

--- a/implementation/configuration/src/configuration_plugin_impl.cpp
+++ b/implementation/configuration/src/configuration_plugin_impl.cpp
@@ -8,7 +8,18 @@
 #include "../include/configuration_plugin_impl.hpp"
 #include "../include/configuration_impl.hpp"
 
+#ifdef VSOMEIP_STATIC_PLUGINS
+namespace vsomeip_v3 {
+
+create_plugin_func plugin_manager_impl_init_hook_cfg()
+{
+    return configuration_plugin_impl::get_plugin;
+}
+
+} // namespace vsomeip_v3
+#else
 VSOMEIP_PLUGIN(vsomeip_v3::configuration_plugin_impl)
+#endif
 
 namespace vsomeip_v3 {
 

--- a/implementation/e2e_protection/src/e2e/profile/e2e_provider_impl.cpp
+++ b/implementation/e2e_protection/src/e2e/profile/e2e_provider_impl.cpp
@@ -58,8 +58,18 @@ value_t read_value_from_config(const std::shared_ptr<vsomeip_v3::cfg::e2e> &_con
 
 } // namespace
 
+#ifdef VSOMEIP_STATIC_PLUGINS
+namespace vsomeip_v3 {
 
+create_plugin_func plugin_manager_impl_init_hook_e2e()
+{
+    return e2e::e2e_provider_impl::get_plugin;
+}
+
+} // namespace vsomeip_v3
+#else
 VSOMEIP_PLUGIN(vsomeip_v3::e2e::e2e_provider_impl)
+#endif
 
 namespace vsomeip_v3 {
 namespace e2e {

--- a/implementation/plugin/include/plugin_manager_impl.hpp
+++ b/implementation/plugin/include/plugin_manager_impl.hpp
@@ -53,7 +53,17 @@ private:
         std::recursive_mutex plugins_mutex_;
 
         static std::shared_ptr<plugin_manager_impl> the_plugin_manager__;
+
+#ifdef VSOMEIP_STATIC_PLUGINS
+        plugin_init_func get_static_init_func(const std::string &library_);
+#endif
 };
+
+#ifdef VSOMEIP_STATIC_PLUGINS
+vsomeip_v3::create_plugin_func plugin_manager_impl_init_hook_cfg();
+vsomeip_v3::create_plugin_func plugin_manager_impl_init_hook_sd();
+vsomeip_v3::create_plugin_func plugin_manager_impl_init_hook_e2e();
+#endif
 
 } // namespace vsomeip_v3
 

--- a/implementation/service_discovery/src/runtime_impl.cpp
+++ b/implementation/service_discovery/src/runtime_impl.cpp
@@ -12,7 +12,18 @@
 #include "../include/runtime_impl.hpp"
 #include "../include/service_discovery_impl.hpp"
 
+#ifdef VSOMEIP_STATIC_PLUGINS
+namespace vsomeip_v3 {
+
+create_plugin_func plugin_manager_impl_init_hook_sd()
+{
+    return sd::runtime_impl::get_plugin;
+}
+
+} // namespace vsomeip_v3
+#else
 VSOMEIP_PLUGIN(vsomeip_v3::sd::runtime_impl)
+#endif
 
 namespace vsomeip_v3 {
 namespace sd {

--- a/vsomeip3Config.cmake.in
+++ b/vsomeip3Config.cmake.in
@@ -16,4 +16,9 @@ if (NOT TARGET vsomeip AND NOT vsomeip_BINARY_DIR)
 endif ()
 
 # These are IMPORTED targets created by vsomeipTargets.cmake
-set (VSOMEIP_LIBRARIES vsomeip3)
+if (NOT @BUILD_SHARED_LIBS@)
+    link_directories(@CMAKE_INSTALL_PREFIX@/@INSTALL_LIB_DIR@)
+    set (VSOMEIP_LIBRARIES vsomeip3 vsomeip3-cfg vsomeip3-e2e vsomeip3-sd)
+else ()
+    set (VSOMEIP_LIBRARIES vsomeip3)
+endif ()

--- a/vsomeipConfig.cmake.in
+++ b/vsomeipConfig.cmake.in
@@ -16,4 +16,9 @@ if (NOT TARGET vsomeip AND NOT vsomeip_BINARY_DIR)
 endif ()
 
 # These are IMPORTED targets created by vsomeipTargets.cmake
-set (VSOMEIP_LIBRARIES vsomeip)
+if (NOT @BUILD_SHARED_LIBS@)
+    link_directories(@CMAKE_INSTALL_PREFIX@/@INSTALL_LIB_DIR@)
+    set (VSOMEIP_LIBRARIES vsomeip vsomeip3-cfg vsomeip3-e2e vsomeip3-sd)
+else ()
+    set (VSOMEIP_LIBRARIES vsomeip)
+endif ()


### PR DESCRIPTION
- Remove SHARED option from add_library to allow static libs, CMake then respects the standard BUILD_SHARED_LIBS option.
- Set the default value of BUILD_SHARED_LIBS to ON.
- Modify plugin_manager_impl to call the plugin init function for built-in plugins via a hook, whilst still supporting external shared library plugins.
- Add plugin init hook function to each built-in plugin.
- Add plugin libs to link libs in CMake export config when static libs are enabled.