### PR TITLE
Fix network interface identification for VLAN in IPv6

### DIFF
--- a/implementation/configuration/include/configuration_impl.hpp
+++ b/implementation/configuration/include/configuration_impl.hpp
@@ -471,6 +471,7 @@ private:
     void load_partition(const boost::property_tree::ptree &_tree);
 
 private:
+#if defined(__linux__)
     //! @brief Returns the network interface (NIC) that contains the given local 
     //!         address. Relevant for VLAN communication in IPv6.
     //! @param[in] _local_address The IP address in IPv6 format that should be
@@ -478,6 +479,7 @@ private:
     //! @param[out] The network interface identifier that "contains" the IP
     //!         address.
     int get_nic(const std::string& _local_address);
+#endif
     std::mutex mutex_;
 
     const std::string default_unicast_;

--- a/implementation/configuration/include/configuration_impl.hpp
+++ b/implementation/configuration/include/configuration_impl.hpp
@@ -477,7 +477,7 @@ private:
     //!         used as a host.
     //! @param[out] The network interface identifier that "contains" the IP
     //!         address.
-    int getNIC(const std::string& _local_address);
+    int get_nic(const std::string& _local_address);
     std::mutex mutex_;
 
     const std::string default_unicast_;

--- a/implementation/configuration/include/configuration_impl.hpp
+++ b/implementation/configuration/include/configuration_impl.hpp
@@ -471,6 +471,13 @@ private:
     void load_partition(const boost::property_tree::ptree &_tree);
 
 private:
+    //! @brief Returns the network interface (NIC) that contains the given local 
+    //!         address. Relevant for VLAN communication in IPv6.
+    //! @param[in] _local_address The IP address in IPv6 format that should be
+    //!         used as a host.
+    //! @param[out] The network interface identifier that "contains" the IP
+    //!         address.
+    int getNIC(const std::string& _local_address);
     std::mutex mutex_;
 
     const std::string default_unicast_;

--- a/implementation/configuration/src/configuration_impl.cpp
+++ b/implementation/configuration/src/configuration_impl.cpp
@@ -41,7 +41,9 @@
 #include "../../security/include/policy_manager_impl.hpp"
 #include "../../security/include/security.hpp"
 
+#if defined(__linux__)
 #include <ifaddrs.h>
+#endif
 
 namespace vsomeip_v3 {
 namespace cfg {
@@ -1382,8 +1384,8 @@ void configuration_impl::load_trace_filter_match(
     }
 }
 
-int configuration_impl::get_nic(const std::string& _local_address)
-{
+#if defined(__linux__)
+int configuration_impl::get_nic(const std::string& _local_address) {
     // creating structures to browse through the available network interfaces
     struct ifaddrs* ifaddr, *ifa;
     int family, n;
@@ -1396,41 +1398,34 @@ int configuration_impl::get_nic(const std::string& _local_address)
     searched_address.sin6_port = htons( 0xdead );
     inet_pton( AF_INET6, _local_address.c_str(), &searched_address.sin6_addr ); // actually copying 
 
-    if (getifaddrs(&ifaddr) == -1) // "-1" is an error value
-    {
-        VSOMEIP_ERROR << __func__ <<  
-            strerror(errno) << ::std::endl;
+    if (getifaddrs(&ifaddr) == -1) { // "-1" is an error value
+        VSOMEIP_WARNING << __func__ << ": " << strerror(errno);
         return -1;
     }
 
     /* Walk through linked list of network interfaces*/
-    for (ifa = ifaddr, n = 0; ifa != NULL; ifa = ifa->ifa_next, n++)
-    {
+    for (ifa = ifaddr, n = 0; ifa != NULL; ifa = ifa->ifa_next, n++) {
         if (ifa->ifa_addr == NULL)
             continue;
         family = ifa->ifa_addr->sa_family;
 
         /* For an AF_INET6 interface address, compare the address of the NIC
         with the searched address */
-        if (family == AF_INET6)
-        {
+        if (family == AF_INET6) {
             p_addrIP6 = reinterpret_cast<sockaddr_in6*>(ifa->ifa_addr);
-            if (::bcmp(p_addrIP6->sin6_addr.s6_addr, searched_address.sin6_addr.s6_addr, 16) == 0)
-            {
+            if (::bcmp(p_addrIP6->sin6_addr.s6_addr, searched_address.sin6_addr.s6_addr, 16) == 0) {
                 nic.push_back(if_nametoindex(ifa->ifa_name));
             }
         }
     }
-    if (nic.size() > 1)
-    {
-        VSOMEIP_ERROR << __func__ << " found multiple network interfaces " <<
+    if (nic.size() > 1) {
+        VSOMEIP_WARNING << __func__ << ": Found multiple network interfaces " <<
             "with IP address " << _local_address << ". Please check your " <<
             "network settings. In the meanwhile, using the first NIC.";
             // message must be in sync with "return nic[0]"
     }
-    else if (nic.size() == 0)
-    {
-        VSOMEIP_ERROR << __func__ << " NO network interfaces available" <<
+    else if (nic.size() == 0) {
+        VSOMEIP_WARNING << __func__ << ": NO network interfaces available" <<
             "with IP address " << _local_address << ". Please check your " <<
             "network settings.";
         return -1;
@@ -1439,6 +1434,7 @@ int configuration_impl::get_nic(const std::string& _local_address)
     freeifaddrs(ifaddr);
     return nic[0];
 }
+#endif
 
 void configuration_impl::load_suppress_events(const configuration_element &_element) {
     try {
@@ -1617,21 +1613,22 @@ void configuration_impl::load_unicast_address(const configuration_element &_elem
             VSOMEIP_WARNING << "Multiple definitions for unicast."
                     "Ignoring definition from " << _element.name_;
         } else {
+            #if defined(__linux__)
             boost::asio::ip::address temp = unicast_.from_string(its_value);
-            if (temp.is_v6())
-            {
+            if (temp.is_v6()) {
                 int scope_id = get_nic(its_value);
-                if (scope_id >= 0)
-                {
+                if (scope_id >= 0) {
                     // below: '%' is the delimiter to distinguish between IP-address and scope-id, e.g. "beef::1%7"
                     unicast_ = boost::asio::ip::make_address(its_value + "%" + std::to_string(scope_id)); 
                 } // else, keep the default scope_id in local_
                 else unicast_ = unicast_.from_string(its_value);
             }
-            else if (temp.is_v4()) // IPv4 somehow "automatically" processes the network interface and does NOT require special treatment
-            {
+            else if (temp.is_v4()) { // IPv4 somehow "automatically" processes the network interface and does NOT require special treatment
                 unicast_ = unicast_.from_string(its_value);
             }
+            #else
+            unicast_ = unicast_.from_string(its_value); 
+            #endif
             is_configured_[ET_UNICAST] = true;
         }
     } catch (...) {
@@ -2616,7 +2613,7 @@ void configuration_impl::load_payload_sizes(const configuration_element &_elemen
                 buffer_shrink_threshold_ = static_cast<std::uint32_t>(
                         std::stoul(s.c_str(), NULL, 10));
             } catch (const std::exception &e) {
-                VSOMEIP_ERROR<< __func__ << ": " << buffer_shrink_threshold
+                VSOMEIP_ERROR<<  << ": " << buffer_shrink_threshold
                 << " " << e.what();
             }
         }

--- a/implementation/configuration/src/configuration_impl.cpp
+++ b/implementation/configuration/src/configuration_impl.cpp
@@ -1382,7 +1382,7 @@ void configuration_impl::load_trace_filter_match(
     }
 }
 
-int configuration_impl::getNIC( const std::string& _local_address )
+int configuration_impl::get_nic( const std::string& _local_address )
 {
     // creating structures to browse through the available network interfaces
     struct ifaddrs* ifaddr, *ifa;
@@ -1620,7 +1620,7 @@ void configuration_impl::load_unicast_address(const configuration_element &_elem
             boost::asio::ip::address temp = unicast_.from_string(its_value);
             if (temp.is_v6())
             {
-                int scope_id = getNIC(its_value);
+                int scope_id = get_nic(its_value);
                 if ( scope_id >= 0)
                 {
                     // below: '%' is the delimiter to distinguish between IP-address and scope-id, e.g. "beef::1%7"

--- a/implementation/configuration/src/configuration_impl.cpp
+++ b/implementation/configuration/src/configuration_impl.cpp
@@ -1382,7 +1382,7 @@ void configuration_impl::load_trace_filter_match(
     }
 }
 
-int configuration_impl::get_nic( const std::string& _local_address )
+int configuration_impl::get_nic(const std::string& _local_address)
 {
     // creating structures to browse through the available network interfaces
     struct ifaddrs* ifaddr, *ifa;
@@ -1396,32 +1396,32 @@ int configuration_impl::get_nic( const std::string& _local_address )
     searched_address.sin6_port = htons( 0xdead ); // dummy value. TODO: is this necessary?
     inet_pton( AF_INET6, _local_address.c_str(), &searched_address.sin6_addr ); // actually copying 
 
-    if( getifaddrs( &ifaddr ) == -1 ) // "-1" is an error value
+    if (getifaddrs(&ifaddr) == -1) // "-1" is an error value
     {
         VSOMEIP_ERROR << __func__ <<  
-            strerror( errno ) << ::std::endl;
+            strerror(errno) << ::std::endl;
         return -1;
     }
 
     /* Walk through linked list of network interfaces*/
-    for( ifa = ifaddr, n = 0; ifa != NULL; ifa = ifa->ifa_next, n++ )
+    for (ifa = ifaddr, n = 0; ifa != NULL; ifa = ifa->ifa_next, n++)
     {
-        if( ifa->ifa_addr == NULL )
+        if (ifa->ifa_addr == NULL)
             continue;
         family = ifa->ifa_addr->sa_family;
 
         /* For an AF_INET6 interface address, compare the address of the NIC
         with the searched address */
-        if( family == AF_INET6 )
+        if (family == AF_INET6)
         {
-            p_addrIP6 = reinterpret_cast<sockaddr_in6*>( ifa->ifa_addr );
-            if( ::bcmp( p_addrIP6->sin6_addr.s6_addr, searched_address.sin6_addr.s6_addr, 16 ) == 0 ) // TODO: is bcmp a Linux only function?
+            p_addrIP6 = reinterpret_cast<sockaddr_in6*>(ifa->ifa_addr);
+            if (::bcmp(p_addrIP6->sin6_addr.s6_addr, searched_address.sin6_addr.s6_addr, 16) == 0) // TODO: is bcmp a Linux only function?
             {
-                nic.push_back(if_nametoindex( ifa->ifa_name ));
+                nic.push_back(if_nametoindex(ifa->ifa_name));
             }
         }
     }
-    if( nic.size() > 1)
+    if (nic.size() > 1)
     {
         VSOMEIP_ERROR << __func__ << " found multiple network interfaces " <<
             "with IP address " << _local_address << ". Please check your " <<
@@ -1436,7 +1436,7 @@ int configuration_impl::get_nic( const std::string& _local_address )
         return -1;
     } // the good case 'nic.size() == 1' needs no error handling
     
-    freeifaddrs( ifaddr );
+    freeifaddrs(ifaddr);
     return nic[0];
 }
 
@@ -1621,7 +1621,7 @@ void configuration_impl::load_unicast_address(const configuration_element &_elem
             if (temp.is_v6())
             {
                 int scope_id = get_nic(its_value);
-                if ( scope_id >= 0)
+                if (scope_id >= 0)
                 {
                     // below: '%' is the delimiter to distinguish between IP-address and scope-id, e.g. "beef::1%7"
                     unicast_ = boost::asio::ip::make_address(its_value + "%" + std::to_string(scope_id)); 

--- a/implementation/configuration/src/configuration_impl.cpp
+++ b/implementation/configuration/src/configuration_impl.cpp
@@ -41,7 +41,7 @@
 #include "../../security/include/policy_manager_impl.hpp"
 #include "../../security/include/security.hpp"
 
-#include <ifaddrs.h> // TODO: only for LInux?
+#include <ifaddrs.h>
 
 namespace vsomeip_v3 {
 namespace cfg {
@@ -1392,8 +1392,8 @@ int configuration_impl::get_nic(const std::string& _local_address)
                     // more than one interface contains the searched IP address
     struct sockaddr_in6 searched_address;
     searched_address.sin6_family = AF_INET6;
-    searched_address.sin6_addr = in6addr_any;   // TODO: is this necessary?
-    searched_address.sin6_port = htons( 0xdead ); // dummy value. TODO: is this necessary?
+    searched_address.sin6_addr = in6addr_any;
+    searched_address.sin6_port = htons( 0xdead );
     inet_pton( AF_INET6, _local_address.c_str(), &searched_address.sin6_addr ); // actually copying 
 
     if (getifaddrs(&ifaddr) == -1) // "-1" is an error value
@@ -1415,7 +1415,7 @@ int configuration_impl::get_nic(const std::string& _local_address)
         if (family == AF_INET6)
         {
             p_addrIP6 = reinterpret_cast<sockaddr_in6*>(ifa->ifa_addr);
-            if (::bcmp(p_addrIP6->sin6_addr.s6_addr, searched_address.sin6_addr.s6_addr, 16) == 0) // TODO: is bcmp a Linux only function?
+            if (::bcmp(p_addrIP6->sin6_addr.s6_addr, searched_address.sin6_addr.s6_addr, 16) == 0)
             {
                 nic.push_back(if_nametoindex(ifa->ifa_name));
             }

--- a/implementation/configuration/src/configuration_impl.cpp
+++ b/implementation/configuration/src/configuration_impl.cpp
@@ -1618,17 +1618,17 @@ void configuration_impl::load_unicast_address(const configuration_element &_elem
                     "Ignoring definition from " << _element.name_;
         } else {
             boost::asio::ip::address temp = unicast_.from_string(its_value);
-            if( temp.is_v6())
+            if (temp.is_v6())
             {
-                if ( getNIC(its_value) >= 0)
+                int scope_id = getNIC(its_value);
+                if ( scope_id >= 0)
                 {
                     // below: '%' is the delimiter to distinguish between IP-address and scope-id, e.g. "beef::1%7"
                     unicast_ = boost::asio::ip::make_address(its_value + "%" + std::to_string(scope_id)); 
-                    VSOMEIP_INFO << "\033[41mDEBUG <configuration_impl::load_unicast_address> scope_id after getNIC: " << unicast_.to_v6().scope_id() << "\033[0m";
                 } // else, keep the default scope_id in local_
                 else unicast_ = unicast_.from_string(its_value);
             }
-            else if ( temp.is_v4()) // IPv4 somehow "automatically" processes the network interface and does NOT require special treatment
+            else if (temp.is_v4()) // IPv4 somehow "automatically" processes the network interface and does NOT require special treatment
             {
                 unicast_ = unicast_.from_string(its_value);
             }

--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -234,7 +234,7 @@ void routing_manager_impl::start() {
     // if network interface is part of unicast-address-string. So strip it!
     char delimiter {'%'}; // "%" is a symbol for the device, e.g. "beef::1%7",
         // where 7 is the network interface #7
-    if( its_unicast.to_string().find(delimiter) != std::string::npos) 
+    if (its_unicast.to_string().find(delimiter) != std::string::npos) 
     {
         std::string temp_address = its_unicast.to_string().substr(0, (size_t)its_unicast.to_string().find(delimiter));
         netlink_connector_ = std::make_shared<netlink_connector>(

--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -228,7 +228,19 @@ void routing_manager_impl::start() {
             << ", "
             << its_netmask_or_prefix.str();
 
-    netlink_connector_ = std::make_shared<netlink_connector>(
+    boost::asio::ip::address temp {configuration_->get_unicast_address()};
+    
+    // PRECONDITION: netlink_connector_ has troubles to create a correct object,
+    // if network interface is part of unicast-address-string. So strip it!
+    char delimiter {'%'}; // "%" is a symbol for the device, e.g. "beef::1%7",
+        // where 7 is the network interface #7
+    if( its_unicast.to_string().find(delimiter) != std::string::npos) 
+    {
+        std::string temp_address = its_unicast.to_string().substr(0, (size_t)its_unicast.to_string().find(delimiter));
+        netlink_connector_ = std::make_shared<netlink_connector>(
+            host_->get_io(), boost::asio::ip::address::from_string(temp_address), its_multicast);
+    }
+    else netlink_connector_ = std::make_shared<netlink_connector>(
             host_->get_io(), configuration_->get_unicast_address(), its_multicast);
     netlink_connector_->register_net_if_changes_handler(
             std::bind(&routing_manager_impl::on_net_interface_or_route_state_changed,


### PR DESCRIPTION
**Attention**: pull-request only tested with Linux.

### The Problem
VLAN in IPv6 did not work with vsomeip 3.3.8 for communication partners that use a different SOME/IP stack than vsomeip. The problem is that the wrong network interface is used to send the message. The network interface is chosen based on the unicast-IPv6-address in the json file. **The effect is that there is no 802.1Q field in the sent Ethernet frame during service discovery.** Consequently, the communication partner does not talk on the same "channel".
Providing a network interface to the unicast address in the json-file shows no effect, i.e. {"unicast" : "beef::1%7"}. 
This problem is NOT observed with IPv4.

### The solution
So I chose to identify the network interface address during the configuration part when the user defined "unicast" address is fixed. The idea of the solution is to go through all network interfaces on the system and find the "unicast" address that is assigned to one of the network interfaces. Its ID is used to extend the given IPv6 unicast-address and this way create the correct socket for communication using the boost library.

### The test environment
I tested this with a Xenomai 3.2.2 operating system on the one end, and a embedded ECU on the other end. The ECU runs a different SOME/IP-stack than my Xenomai machine. Xenomai is based on a Linux Kernel.

### Alternative solutions
An alternative could be to to change "udp_server_endpoint_impl.cpp" and assign the correct outbound interface in "boost::asio::ip::multicast::outbound_interface" for IPv6. I did not look into it, because I thought that the IPv6 address with network interface ID might be used somewhere else during the setup of the communication. 