### PR TITLE
Consistently use uid_t/gid_t for credentials

### DIFF
--- a/implementation/configuration/include/internal.hpp.in
+++ b/implementation/configuration/include/internal.hpp.in
@@ -168,7 +168,7 @@ inline constexpr std::uint32_t MAX_RECONNECTS_LOCAL_TCP = 5;
 #endif
 
 inline constexpr uid_t ANY_UID = (std::numeric_limits<uid_t>::max)();
-inline constexpr gid_t ANY_GID = (std::numeric_limits<uid_t>::max)();
+inline constexpr gid_t ANY_GID = (std::numeric_limits<gid_t>::max)();
 
 enum class port_type_e {
     PT_OPTIONAL,

--- a/implementation/configuration/include/internal.hpp.in
+++ b/implementation/configuration/include/internal.hpp.in
@@ -63,6 +63,8 @@
 
 #ifdef _WIN32
 #define VSOMEIP_INTERNAL_BASE_PORT              51234
+#endif
+#if defined(_WIN32) || defined(__QNX__)
 #define __func__ __FUNCTION__
 #endif
 
@@ -160,8 +162,13 @@ inline constexpr std::uint32_t MAX_RECONNECTS_UNLIMITED = (std::numeric_limits<s
 inline constexpr std::uint32_t MAX_RECONNECTS_LOCAL_UDS = 13;
 inline constexpr std::uint32_t MAX_RECONNECTS_LOCAL_TCP = 5;
 
-const uid_t ANY_UID = 0xFFFFFFFF;
-const gid_t ANY_GID = 0xFFFFFFFF;
+#if defined(_WIN32)
+    using uid_t = std::uint32_t;
+    using git_t = std::uint32_t;
+#endif
+
+inline constexpr uid_t ANY_UID = (std::numeric_limits<uid_t>::max)();
+inline constexpr gid_t ANY_GID = (std::numeric_limits<uid_t>::max)();
 
 enum class port_type_e {
     PT_OPTIONAL,

--- a/implementation/configuration/include/internal_android.hpp
+++ b/implementation/configuration/include/internal_android.hpp
@@ -151,7 +151,7 @@ inline constexpr std::uint32_t MAX_RECONNECTS_LOCAL_UDS = 13;
 inline constexpr std::uint32_t MAX_RECONNECTS_LOCAL_TCP = 5;
 
 inline constexpr uid_t ANY_UID = (std::numeric_limits<uid_t>::max)();
-inline constexpr gid_t ANY_GID = (std::numeric_limits<uid_t>::max)();
+inline constexpr gid_t ANY_GID = (std::numeric_limits<gid_t>::max)();
 
 enum class port_type_e {
     PT_OPTIONAL,

--- a/implementation/configuration/include/internal_android.hpp
+++ b/implementation/configuration/include/internal_android.hpp
@@ -150,8 +150,8 @@ inline constexpr std::uint32_t MAX_RECONNECTS_UNLIMITED = std::numeric_limits<st
 inline constexpr std::uint32_t MAX_RECONNECTS_LOCAL_UDS = 13;
 inline constexpr std::uint32_t MAX_RECONNECTS_LOCAL_TCP = 5;
 
-inline constexpr std::uint32_t ANY_UID = 0xFFFFFFFF;
-inline constexpr std::uint32_t ANY_GID = 0xFFFFFFFF;
+inline constexpr uid_t ANY_UID = (std::numeric_limits<uid_t>::max)();
+inline constexpr gid_t ANY_GID = (std::numeric_limits<uid_t>::max)();
 
 enum class port_type_e {
     PT_OPTIONAL,

--- a/implementation/endpoints/include/local_server_endpoint_impl_receive_op.hpp
+++ b/implementation/endpoints/include/local_server_endpoint_impl_receive_op.hpp
@@ -26,8 +26,8 @@ struct storage :
     receive_handler_t handler_;
     byte_t *buffer_ = nullptr;
     size_t length_;
-    uid_t uid_;
-    gid_t gid_;
+    uid_t uid_ = ANY_UID;
+    gid_t gid_ = ANY_GID;
     size_t bytes_;
 
     storage(

--- a/implementation/endpoints/include/local_uds_server_endpoint_impl.hpp
+++ b/implementation/endpoints/include/local_uds_server_endpoint_impl.hpp
@@ -109,7 +109,7 @@ private:
         void receive_cbk(boost::system::error_code const &_error,
                          std::size_t _bytes
 #if defined(__linux__) || defined(ANDROID) || defined(__QNX__)
-                         , std::uint32_t const &_uid, std::uint32_t const &_gid
+                         , uid_t const &_uid, gid_t const &_gid
 #endif
         );
         void calculate_shrink_count();

--- a/implementation/endpoints/include/udp_server_endpoint_impl_receive_op.hpp
+++ b/implementation/endpoints/include/udp_server_endpoint_impl_receive_op.hpp
@@ -306,7 +306,7 @@ receive_cb (std::shared_ptr<storage> _data) {
                     _data->sender_ = endpoint_type_t(its_sender_address, its_sender_port);
 
                     // destination
-                    struct in_pktinfo *its_pktinfo_v4;
+                    struct in_pktinfo *its_pktinfo_v4 = nullptr;
                     for (struct cmsghdr *cmsg = CMSG_FIRSTHDR(&its_header);
                          cmsg != NULL;
                          cmsg = CMSG_NXTHDR(&its_header, cmsg)) {

--- a/implementation/endpoints/src/local_uds_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/local_uds_server_endpoint_impl.cpp
@@ -474,8 +474,8 @@ void local_uds_server_endpoint_impl::connection::start() {
             ),
             &recv_buffer_[recv_buffer_size_],
             left_buffer_size,
-            std::numeric_limits<std::uint32_t>::max(),
-            std::numeric_limits<std::uint32_t>::max(),
+            std::numeric_limits<uid_t>::max(),
+            std::numeric_limits<gid_t>::max(),
             std::numeric_limits<std::size_t>::min()
         );
 
@@ -580,7 +580,7 @@ void local_uds_server_endpoint_impl::connection::send_cbk(const message_buffer_p
 
 void local_uds_server_endpoint_impl::connection::receive_cbk(
         boost::system::error_code const &_error, std::size_t _bytes,
-        std::uint32_t const &_uid, std::uint32_t const &_gid)
+        uid_t const &_uid, gid_t const &_gid)
 {
     std::shared_ptr<local_uds_server_endpoint_impl> its_server(server_.lock());
     if (!its_server) {

--- a/implementation/security/include/policy_manager_impl.hpp
+++ b/implementation/security/include/policy_manager_impl.hpp
@@ -144,7 +144,7 @@ private:
     boost::icl::interval_set<service_t> service_interface_whitelist_;
 
     mutable std::mutex uid_whitelist_mutex_;
-    boost::icl::interval_set<uint32_t> uid_whitelist_;
+    boost::icl::interval_set<uid_t> uid_whitelist_;
 
     mutable std::mutex policy_base_path_mutex_;
     std::string policy_base_path_;
@@ -159,7 +159,7 @@ private:
     bool is_configured_;
 
     mutable std::mutex routing_credentials_mutex_;
-    std::pair<uint32_t, uint32_t> routing_credentials_;
+    std::pair<uid_t, gid_t> routing_credentials_;
 
     mutable std::mutex ids_mutex_;
     std::map<client_t, vsomeip_sec_client_t> ids_;

--- a/implementation/security/src/policy.cpp
+++ b/implementation/security/src/policy.cpp
@@ -455,14 +455,14 @@ policy::print() const {
 
     for (auto its_credential : credentials_) {
         auto its_uid_interval = its_credential.first;
-        if (its_uid_interval.lower() == std::numeric_limits<uint32_t>::max()) {
+        if (its_uid_interval.lower() == std::numeric_limits<uid_t>::max()) {
             VSOMEIP_INFO << "policy::print Security configuration: UID: any";
         } else {
             VSOMEIP_INFO << "policy::print Security configuration: UID: "
                     << std::dec << its_uid_interval.lower();
         }
         for (auto its_gid_interval : its_credential.second) {
-            if (its_gid_interval.lower() == std::numeric_limits<uint32_t>::max()) {
+            if (its_gid_interval.lower() == std::numeric_limits<gid_t>::max()) {
                 VSOMEIP_INFO << "    policy::print Security configuration: GID: any";
             } else {
                 VSOMEIP_INFO << "    policy::print Security configuration: GID: "

--- a/implementation/security/src/policy_manager_impl.cpp
+++ b/implementation/security/src/policy_manager_impl.cpp
@@ -334,7 +334,8 @@ policy_manager_impl::is_offer_allowed(const vsomeip_sec_client_t *_sec_client,
     if (!policy_enabled_)
         return true;
 
-    gid_t its_uid(ANY_UID), its_gid(ANY_GID);
+    uid_t its_uid(ANY_UID);
+    gid_t its_gid(ANY_GID);
     if (_sec_client) {
         if (_sec_client->port == VSOMEIP_SEC_PORT_UNUSED) {
             its_uid = _sec_client->user;

--- a/implementation/security/src/policy_manager_impl.cpp
+++ b/implementation/security/src/policy_manager_impl.cpp
@@ -334,7 +334,7 @@ policy_manager_impl::is_offer_allowed(const vsomeip_sec_client_t *_sec_client,
     if (!policy_enabled_)
         return true;
 
-    uint32_t its_uid(ANY_UID), its_gid(ANY_GID);
+    gid_t its_uid(ANY_UID), its_gid(ANY_GID);
     if (_sec_client) {
         if (_sec_client->port == VSOMEIP_SEC_PORT_UNUSED) {
             its_uid = _sec_client->user;
@@ -703,7 +703,7 @@ policy_manager_impl::load_policy(const boost::property_tree::ptree &_tree) {
                         has_uid_range = true;
                     } else {
                         if (its_value != "any") {
-                            uint32_t its_uid;
+                            uid_t its_uid;
                             read_data(its_value, its_uid);
                             its_uid_interval = boost::icl::construct<
                                 boost::icl::discrete_interval<uid_t> >(
@@ -724,7 +724,7 @@ policy_manager_impl::load_policy(const boost::property_tree::ptree &_tree) {
                         has_gid_range = true;
                     } else {
                         if (its_value != "any") {
-                            uint32_t its_gid;
+                            gid_t its_gid;
                             read_data(its_value, its_gid);
                             its_gid_interval = boost::icl::construct<
                                 boost::icl::discrete_interval<gid_t> >(
@@ -946,12 +946,12 @@ policy_manager_impl::load_routing_credentials(const configuration_element &_elem
                 std::string its_key(i->first);
                 std::string its_value(i->second.data());
                 if (its_key == "uid") {
-                    uint32_t its_uid(0);
+                    uid_t its_uid(0);
                     read_data(its_value, its_uid);
                     std::lock_guard<std::mutex> its_lock(routing_credentials_mutex_);
                     std::get<0>(routing_credentials_) = its_uid;
                 } else if (its_key == "gid") {
-                    uint32_t its_gid(0);
+                    gid_t its_gid(0);
                     read_data(its_value, its_gid);
                     std::lock_guard<std::mutex> its_lock(routing_credentials_mutex_);
                     std::get<1>(routing_credentials_) = its_gid;


### PR DESCRIPTION
Consistent use `uid_t`/`gid_t` types for user/group IDs rather than sometimes using `std::uint32_t`.

We found this important in 3.1.20 and 3.3.8 on QNX, but also using these types should make vsomeip more platform independent.