### PR TITLE
test/common/CMakeLists.txt: add missing link with dlt

### DIFF
--- a/test/common/CMakeLists.txt
+++ b/test/common/CMakeLists.txt
@@ -27,6 +27,7 @@ TARGET_LINK_LIBRARIES (
         ${Boost_LIBRARIES}
         ${DL_LIBRARY}
         ${TEST_LINK_LIBRARIES}
+        ${DLT_LIBRARIES}
 )
 
 # ----------------------------------------------------------------------------


### PR DESCRIPTION
The libvsomeip_utilities library uses functions e.g. dlt_check_library_version/dlt_register_app/dlt_unregister_app which are provided by dlt therefore add it to linker flags.

Fixes:
x86_64-poky-linux-ld.lld: error: undefined reference due to --no-allow-shlib-undefined: dlt_check_library_version
>>> referenced by test/common/libvsomeip_utilities.so

x86_64-poky-linux-ld.lld: error: undefined reference due to --no-allow-shlib-undefined: dlt_register_app
>>> referenced by test/common/libvsomeip_utilities.so

x86_64-poky-linux-ld.lld: error: undefined reference due to --no-allow-shlib-undefined: dlt_unregister_app
>>> referenced by test/common/libvsomeip_utilities.so