### PR TITLE
Fix session id issues in someip sd with ipv6

### DIFF
--- a/implementation/endpoints/include/tcp_server_endpoint_impl.hpp
+++ b/implementation/endpoints/include/tcp_server_endpoint_impl.hpp
@@ -86,6 +86,7 @@ private:
         void set_remote_info(const endpoint_type &_remote);
         std::string get_address_port_remote() const;
         std::size_t get_recv_buffer_capacity() const;
+        static boost::asio::ip::address strip_ipv6_interface_device(boost::asio::ip::address _address);
 
     private:
         connection(const std::weak_ptr<tcp_server_endpoint_impl>& _server,

--- a/implementation/endpoints/src/endpoint_manager_impl.cpp
+++ b/implementation/endpoints/src/endpoint_manager_impl.cpp
@@ -1091,7 +1091,8 @@ std::shared_ptr<endpoint> endpoint_manager_impl::create_remote_client(
             auto found_reliability = found_instance->second.find(_reliable);
             if (found_reliability != found_instance->second.end()) {
                 its_endpoint_def = found_reliability->second;
-                its_remote_address = its_endpoint_def->get_address();
+                std::size_t pos = its_endpoint_def->get_address().to_string().find('%');
+                its_remote_address = boost::asio::ip::make_address(its_endpoint_def->get_address().to_string().substr(0,pos));
                 its_remote_port = its_endpoint_def->get_port();
             }
         }

--- a/implementation/endpoints/src/tcp_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/tcp_server_endpoint_impl.cpp
@@ -130,7 +130,9 @@ bool tcp_server_endpoint_impl::send_error(
         const byte_t *_data, uint32_t _size) {
     bool ret(false);
     std::lock_guard<std::mutex> its_lock(mutex_);
-    const endpoint_type its_target(_target->get_address(), _target->get_port());
+
+    const boost::asio::ip::address its_remote_address(tcp_server_endpoint_impl::connection::strip_ipv6_interface_device(_target->get_address()));
+    const endpoint_type its_target(its_remote_address, _target->get_port());
     const auto its_target_iterator(find_or_create_target_unlocked(its_target));
     auto &its_data = its_target_iterator->second;
 
@@ -153,8 +155,11 @@ bool tcp_server_endpoint_impl::send_queued(const target_data_iterator_type _it) 
     bool must_erase(false);
     connection::ptr its_connection;
     {
+        const boost::asio::ip::address its_remote_address(connection::strip_ipv6_interface_device(_it->first.address()));
+        endpoint_type _remote(its_remote_address, _it->first.port());
+
         std::lock_guard<std::mutex> its_lock(connections_mutex_);
-        auto connection_iterator = connections_.find(_it->first);
+        auto connection_iterator = connections_.find(_remote);
         if (connection_iterator != connections_.end()) {
             its_connection = connection_iterator->second;
             if (its_connection) {
@@ -275,8 +280,10 @@ void tcp_server_endpoint_impl::accept_cbk(const connection::ptr& _connection,
         }
         if (!its_error) {
             {
+                const boost::asio::ip::address its_remote_address(connection::strip_ipv6_interface_device(remote.address()));
+                endpoint_type _remote(its_remote_address, remote.port());
                 std::lock_guard<std::mutex> its_lock(connections_mutex_);
-                connections_[remote] = _connection;
+                connections_[_remote] = _connection;
             }
             _connection->start();
         }
@@ -539,6 +546,7 @@ void tcp_server_endpoint_impl::connection::receive_cbk(
                 << (int) recv_buffer_[i] << " ";
     VSOMEIP_INFO << msg.str();
 #endif
+
     std::shared_ptr<routing_host> its_host = its_server->routing_host_.lock();
     if (its_host) {
         if (!_error && 0 < _bytes) {
@@ -814,7 +822,7 @@ void tcp_server_endpoint_impl::connection::calculate_shrink_count() {
 void tcp_server_endpoint_impl::connection::set_remote_info(
         const endpoint_type &_remote) {
     remote_ = _remote;
-    remote_address_ = _remote.address();
+    remote_address_ = strip_ipv6_interface_device(_remote.address());
     remote_port_ = _remote.port();
 }
 
@@ -1031,6 +1039,13 @@ void tcp_server_endpoint_impl::connection::wait_until_sent(const boost::system::
         stop();
     }
     its_server->remove_connection(this);
+}
+
+boost::asio::ip::address tcp_server_endpoint_impl::connection::strip_ipv6_interface_device(const boost::asio::ip
+                                                                                                ::address _address) {
+
+    std::size_t pos = _address.to_string().find('%');
+    return boost::asio::ip::make_address(_address.to_string().substr(0,pos));
 }
 
 }  // namespace vsomeip_v3

--- a/implementation/endpoints/src/udp_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/udp_server_endpoint_impl.cpp
@@ -573,7 +573,10 @@ void udp_server_endpoint_impl::on_message_received(
         if (!_error && 0 < _bytes) {
             std::size_t remaining_bytes = _bytes;
             std::size_t i = 0;
-            const boost::asio::ip::address its_remote_address(_remote.address());
+            // In case of ipv6 and local link addresses the %device is located in the address, which mainly causes
+            // a separate counter on ACK in service discovery.
+            std::size_t pos = _remote.address().to_string().find('%');
+            const boost::asio::ip::address its_remote_address(boost::asio::ip::make_address(_remote.address().to_string().substr(0,pos)));
             const std::uint16_t its_remote_port(_remote.port());
             do {
                 uint64_t read_message_size


### PR DESCRIPTION
1. In case ipv6 is used with local link addresses a second session counter is created for the ACK in someip sd. The  second counter is created with target address and the network device. Due to two counters for someip sd the receiving ECU will detect false reboots. This fixed the issue described in: https://github.com/COVESA/vsomeip/issues/605 

2. In case of a reliable tcp connection with ipv6 and local link addresses the device in the connection object caused a mismatch in the connection assignment. This fixed the issue described in: https://github.com/COVESA/vsomeip/issues/673

If more details are needed, feel free to contact me.