### PR TITLE
Remove clear_multicast_endpoints() in unsubscribe.

### DIFF
--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -853,8 +853,6 @@ void routing_manager_impl::unsubscribe(
                             PENDING_SUBSCRIPTION_ID);
             }
         }
-        ep_mgr_impl_->clear_multicast_endpoints(_service, _instance);
-
     } else {
         VSOMEIP_ERROR<< "SOME/IP eventgroups require SD to be enabled!";
     }


### PR DESCRIPTION
Author: Aram Khzarjyan <Aram.Khzarjyan@mercedes-benz.com>, MBition GmbH.

 Remove clear_multicast_endpoints() in unsubscribe. #651 
---
The clearing multicast endpoints stops any multicast messages
receiving without recovering if TTLs are not expiring.


---
The program was tested solely for our own use cases, which might differ from yours.

The submission is provided under the main project license (LICENSE file in root of project).

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)