### PR TITLE
Initialize Routing-Manager State. 

### DIFF
--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -4019,6 +4019,7 @@ void routing_manager_impl::start_ip_routing() {
     pending_sd_offers_.clear();
 
     routing_running_ = true;
+    routing_state_ = vsomeip::routing_state_e::RS_RUNNING;
     VSOMEIP_INFO << VSOMEIP_ROUTING_READY_MESSAGE;
 }
 


### PR DESCRIPTION
Author: Aram Khzarjyan <Aram.Khzarjyan@mercedes-benz.com>, MBition GmbH.

 Initialize Routing-Manager State. #653 
---
To avoid undefined behavior the state have to be initialized.

---
The program was tested solely for our own use cases, which might differ from yours.

The submission is provided under the main project license (LICENSE file in root of project).

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)