### PR TITLE
Fix Multi-Routing-Managers in one Process (#603)

### DIFF
--- a/implementation/service_discovery/src/service_discovery_impl.cpp
+++ b/implementation/service_discovery/src/service_discovery_impl.cpp
@@ -2752,11 +2752,11 @@ service_discovery_impl::check_ipv4_address(
     //Check unallowed ipv4 address
     bool is_valid = true;
 
-    static const boost::asio::ip::address_v4::bytes_type its_unicast_address =
+    const boost::asio::ip::address_v4::bytes_type its_unicast_address =
             unicast_.to_v4().to_bytes();
     const boost::asio::ip::address_v4::bytes_type endpoint_address =
             its_address.to_v4().to_bytes();
-    static const boost::asio::ip::address_v4::bytes_type its_netmask =
+    const boost::asio::ip::address_v4::bytes_type its_netmask =
             configuration_->get_netmask().to_v4().to_bytes();
 
     //same address as unicast address of DUT not allowed


### PR DESCRIPTION
Author: Aram Khzarjyan <Aram.Khzarjyan@mercedes-benz.com>, MBition GmbH.

 Fix Multi-Routing-Managers in one Process (#603) #654 
---
Removing statics (singletons) enables to run
multiple routing Managers in one process.

---
The program was tested solely for our own use cases, which might differ from yours.

The submission is provided under the main project license (LICENSE file in root of project).

[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)