### PR TITLE
Initialize the routing running state

### DIFF
--- a/implementation/routing/include/routing_manager_base.hpp
+++ b/implementation/routing/include/routing_manager_base.hpp
@@ -348,7 +348,7 @@ protected:
     std::string env_;
 
     std::mutex routing_state_mutex_;
-    routing_state_e routing_state_;
+    routing_state_e routing_state_{routing_state_e::RS_RUNNING};
 
 private:
     services_t services_;


### PR DESCRIPTION
The routing manager running state appears uninitialised, which can (and has) resulting in routingmanagerd starting up in a suspend state.