### PR TITLE
improve vsomeip sluggish connect (master 3.4.x branch)

### DIFF
--- a/implementation/endpoints/src/server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/server_endpoint_impl.cpp
@@ -300,10 +300,8 @@ bool server_endpoint_impl<Protocol>::send_intern(
             _data[VSOMEIP_METHOD_POS_MAX]);
 
     std::chrono::nanoseconds its_debouncing(0), its_retention(0);
-    if (its_service != VSOMEIP_SD_SERVICE && its_method != VSOMEIP_SD_METHOD) {
-        get_configured_times_from_endpoint(its_service, its_method,
+    get_configured_times_from_endpoint(its_service, its_method,
                 &its_debouncing, &its_retention);
-    }
 
     // STEP 4: Check if the passenger enters an empty train
     const std::pair<service_t, method_t> its_identifier

--- a/implementation/endpoints/src/server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/server_endpoint_impl.cpp
@@ -313,30 +313,11 @@ bool server_endpoint_impl<Protocol>::send_intern(
             if (its_data.train_->buffer_->size() + _size > endpoint_impl<Protocol>::max_message_size_) {
                 must_depart = true;
             } else {
-                // STEP 6: Check debouncing time
-                if (its_debouncing > its_data.train_->minimal_max_retention_time_) {
-                    // train's latest departure would already undershot new
-                    // passenger's debounce time
-                    must_depart = true;
-                } else {
-                    if (its_now + its_debouncing > its_data.train_->departure_) {
-                        // train departs earlier as the new passenger's debounce
-                        // time allows
-                        must_depart = true;
-                    } else {
-                        // STEP 7: Check maximum retention time
-                        if (its_retention < its_data.train_->minimal_debounce_time_) {
-                            // train's earliest departure would already exceed
-                            // the new passenger's retention time.
-                            must_depart = true;
-                        } else {
-                            if (its_now + its_retention < its_data.train_->departure_) {
-                                its_data.train_->departure_ = its_now + its_retention;
-                            }
-                        }
+                    if (its_now + its_retention < its_data.train_->departure_) {
+                        its_data.train_->departure_ = its_now + its_retention;
                     }
-                }
-        }
+
+            }
     }
 
     // STEP 8: if necessary, send current buffer and create a new one

--- a/implementation/endpoints/src/server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/server_endpoint_impl.cpp
@@ -311,10 +311,6 @@ bool server_endpoint_impl<Protocol>::send_intern(
     if (its_data.train_->passengers_.empty()) {
         its_data.train_->departure_ = its_now + its_retention;
     } else {
-        if (its_data.train_->passengers_.end()
-                != its_data.train_->passengers_.find(its_identifier)) {
-            must_depart = true;
-        } else {
             // STEP 5: Check whether the current message fits into the current train
             if (its_data.train_->buffer_->size() + _size > endpoint_impl<Protocol>::max_message_size_) {
                 must_depart = true;
@@ -342,7 +338,6 @@ bool server_endpoint_impl<Protocol>::send_intern(
                         }
                     }
                 }
-            }
         }
     }
 


### PR DESCRIPTION
As described in issue #669 the train logic _should_ aggregate Service Discovery, but does not currently. This leads to very low performance on systems offering 1000s of EventGroups.

These changes improve performance on 3.4.x branch. I'm leaving this PR in draft status to gather feedback.

# Allow passengers with same identifier aboard same train

File `implementation/endpoints/src/server_endpoint_impl.cpp` has a test:
```
        if (its_data.train_->passengers_.end()
                != its_data.train_->passengers_.find(its_identifier)) {
            must_depart = true;
        } else
```
this test will “hit” for every single Service Discovery message: Subscribe, SubscribeAck, etc. Each has the same service/identifier, forcing the train to depart immediately, and preventing the train logic from aggregating multiple SD passengers into the same train.

I've eliminated this entire check on my system. The only rationale I can think to keep this logic is debouncing, to have exactly 1 passenger in each train with the "final, debounced EventGroup value". I don't think the code implements this. If this was a design goal then I think it would need to be handled higher in the stack on an EventGroup-by-EventGroup basis, not as a calculation of train departure time.

# Eliminate debounce logic

Debouncing would make sense if it was applied on a message-by-message basis so each gets transmitted “no more often than Xms” dropping all updates except the final one. This way vsomeip events could get low-pass filtered like CAN periodic: some transmitting 20ms, others transmitting 500ms.

The calculation in `implementation/endpoints/src/server_endpoint_impl.cpp` looks wrong because it applies this parameter to decide when an entire multi-passenger train should depart. 

# Apply retention time for Service Discovery

There is conditional logic in both 3.1.20 and 3.4.10 in `implementation/endpoints/src/server_endpoint_impl.cpp` to “always use zero” and skip configured retention time for service discovery:
```
    if (its_service != VSOMEIP_SD_SERVICE && its_method != VSOMEIP_SD_METHOD) {
        get_configured_times_from_endpoint(its_service, its_method,
                &its_debouncing, &its_retention);
    }
```
I've elimianted this override so we can use the configured 5ms for service discovery. The only rationale to keep the original behavior is to minimize latency and respond immediately without waiting. In my case it makes more sense to wait and aggregate because there is really a lot of traffic.

# Current performance

With all of these changes together, my Service Discovery is taking about 300ms end-to-end down from >>2s (usually even exceeding a single SD interval and needing to retry). In this example:

![image-20240305-225902](https://github.com/COVESA/vsomeip/assets/9018512/e48d3737-ec53-485d-97a8-490801d43be6)

there’s nominal 200-400 microseconds gap between packets, sometimes back-to-back and sometimes up to 2ms. Significantly better system load because it’s aggregating packets together into fewer network send calls.