### PR TITLE
improve vsomeip sluggish connect (maintain 3.1.x branch)

### DIFF
--- a/implementation/endpoints/include/buffer.hpp
+++ b/implementation/endpoints/include/buffer.hpp
@@ -55,6 +55,9 @@ struct train {
         departure_ = departure_timer_->expires_from_now();
         boost::system::error_code ec;
         departure_timer_->cancel(ec);
+        if (departure_.count() < 0) {
+            departure_ = std::chrono::nanoseconds::zero();
+        }
     }
 };
 

--- a/implementation/endpoints/src/server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/server_endpoint_impl.cpp
@@ -316,29 +316,9 @@ bool server_endpoint_impl<Protocol>::send_intern(
             if (target_train->buffer_->size() + _size > endpoint_impl<Protocol>::max_message_size_) {
                 must_depart = true;
             } else {
-                // STEP 6: Check debouncing time
-                if (its_debouncing > target_train->minimal_max_retention_time_) {
-                    // train's latest departure would already undershot new
-                    // passenger's debounce time
-                    must_depart = true;
-                } else {
-                    if (its_debouncing > target_train->departure_) {
-                        // train departs earlier as the new passenger's debounce
-                        // time allows
-                        must_depart = true;
-                    } else {
-                        // STEP 7: Check maximum retention time
-                        if (its_retention < target_train->minimal_debounce_time_) {
-                            // train's earliest departure would already exceed
-                            // the new passenger's retention time.
-                            must_depart = true;
-                        } else {
-                            if (its_retention < target_train->departure_) {
-                                target_train->departure_ = its_retention;
-                            }
-                        }
+                    if (its_retention < target_train->departure_) {
+                        target_train->departure_ = its_retention;
                     }
-                }
             }
         }
     }

--- a/implementation/endpoints/src/server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/server_endpoint_impl.cpp
@@ -297,10 +297,8 @@ bool server_endpoint_impl<Protocol>::send_intern(
             _data[VSOMEIP_METHOD_POS_MAX]);
 
     std::chrono::nanoseconds its_debouncing(0), its_retention(0);
-    if (its_service != VSOMEIP_SD_SERVICE && its_method != VSOMEIP_SD_METHOD) {
-        get_configured_times_from_endpoint(its_service, its_method,
+    get_configured_times_from_endpoint(its_service, its_method,
                 &its_debouncing, &its_retention);
-    }
 
     // STEP 4: Check if the passenger enters an empty train
     const std::pair<service_t, method_t> its_identifier = std::make_pair(

--- a/implementation/endpoints/src/server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/server_endpoint_impl.cpp
@@ -306,10 +306,6 @@ bool server_endpoint_impl<Protocol>::send_intern(
     if (target_train->passengers_.empty()) {
         target_train->departure_ = its_retention;
     } else {
-        if (target_train->passengers_.end()
-                != target_train->passengers_.find(its_identifier)) {
-            must_depart = true;
-        } else {
             // STEP 5: Check whether the current message fits into the current train
             if (target_train->buffer_->size() + _size > endpoint_impl<Protocol>::max_message_size_) {
                 must_depart = true;
@@ -318,7 +314,6 @@ bool server_endpoint_impl<Protocol>::send_intern(
                         target_train->departure_ = its_retention;
                     }
             }
-        }
     }
 
     // STEP 8: if necessary, send current buffer and create a new one


### PR DESCRIPTION
fixes COVESA/vsomeip#669

As described in issue https://github.com/COVESA/vsomeip/issues/669 the train logic should aggregate Service Discovery, but does not currently. This leads to very low performance on systems offering 1000s of EventGroups.

This PR has similar content to #670 but backported to 3.1.20.3 and containing one additional important fix for that older version. I'm leaving this PR in draft status to gather feedback. The key difference when backporting is:

# Ensure departure timer does not go negative

There is a calculation 3.1.20 in `implementation/endpoints/include/buffer.hpp` that results in a negative number in case the timer is already expired:
```
void update_departure_time_and_stop_departure() {
    departure_ = departure_timer_->expires_from_now();
```
We need to implement a `floor()` so the departure is either in the future, or zero meaning ready to depart, but never negative. Like:
```
departure_ = departure_timer_->expires_from_now();
if (departure_.count() < 0) {
    departure_ = std::chrono::nanoseconds::zero();
}
```
In case the value goes negative then other calculations fail. That large negative number is kept and used for the next calculated departure time, breaking that one too.