### PR TITLE
unset is_sending_ during tce restart

### DIFF
--- a/implementation/endpoints/src/tcp_client_endpoint_impl.cpp
+++ b/implementation/endpoints/src/tcp_client_endpoint_impl.cpp
@@ -125,6 +125,7 @@ void tcp_client_endpoint_impl::restart(bool _force) {
             }
             self->queue_.clear();
             self->queue_size_ = 0;
+            self->is_sending_ = false;
         }
         VSOMEIP_WARNING << "tce::restart: local: " << address_port_local
                 << " remote: " << self->get_address_port_remote();


### PR DESCRIPTION
fixes #668 

During `tcp_client_endpoint_impl::restart()` the `queue_` will be drained, messages printed like

```
tce::restart: dropping message: remote:10.6.0.3:30510 (30fd): [0402.0001.018e] size: 23
```

and if `is_sending_` was set nothing will unset. Later in `connect_cbk()`:

```
auto its_entry = get_front();
if (its_entry.first) {
    is_sending_ = true;
    strand_.dispatch(std::bind(&client_endpoint_impl::send_queued,
            this->shared_from_this(), its_entry));
    VSOMEIP_WARNING << __func__ << ": resume sending to: "
            << get_remote_information();
}
```
there's nothing queued, no reason to call `send_queued`, therefore no callback is going to clear the flag. Flag `is_sending_` remains set "forever" and the train logic remains blocked from sending. From a user perspective the client endpoint would receive notifications but never transmit anything again.

This needs to be cleared during `restart()` when `queue_` gets drained