### PR TITLE
elminate tcp_client_endpoint restart on SubscribeNack

### DIFF
--- a/implementation/service_discovery/src/service_discovery_impl.cpp
+++ b/implementation/service_discovery/src/service_discovery_impl.cpp
@@ -2510,13 +2510,6 @@ service_discovery_impl::handle_eventgroup_subscription_nack(
                             _service, _instance, _eventgroup, ANY_EVENT,
                             PENDING_SUBSCRIPTION_ID); // TODO: This is a dummy call...
                 }
-
-
-                if (!its_subscription->is_selective()) {
-                    auto its_reliable = its_subscription->get_endpoint(true);
-                    if (its_reliable)
-                        its_reliable->restart();
-                }
             }
         }
     }


### PR DESCRIPTION
fixes #690 

When resuming from suspend-to-ram it's likely that UDP SOME-IP works but the TCP socket got broken. Until a new TCP socket gets established, the remote end responds SubscribeNak. The handler will call restart()

`restart()` will early terminate 5 times total. Thereafter it will call `shutdown_and_close_socket_unlocked`. This is really expensive if the node sends thousands of total requests before a TCP socket gets established.

Options include:
1. do not call `restart()` at all on SubscribeNak. seems safe?
2. fix `restart()` to early-terminate better in this state, more than 5x
3. ensure that SOMEIP-SD is inhibited in this state (suspend routing?)

This commit implements 1 but the others might be alternatives