### PR TITLE
When testing a cycle event, calling application_impl::stop_offer_event is invalid. #666

### DIFF
--- a/implementation/routing/src/event.cpp
+++ b/implementation/routing/src/event.cpp
@@ -797,7 +797,7 @@ event::start_cycle() {
             && std::chrono::milliseconds::zero() != cycle_) {
         cycle_timer_.expires_from_now(cycle_);
         auto its_handler =
-                std::bind(&event::update_cbk, shared_from_this(),
+                std::bind(&event::update_cbk, this,
                         std::placeholders::_1);
         cycle_timer_.async_wait(its_handler);
     }


### PR DESCRIPTION
When testing a cycle event, calling application_impl::stop_offer_event is invalid. #666

See bug#666 for details of the issue.