### PR TITLE
Windows version removing complex data types for API consumption.

### DIFF
--- a/implementation/runtime/include/application_impl.hpp
+++ b/implementation/runtime/include/application_impl.hpp
@@ -63,6 +63,16 @@ public:
     VSOMEIP_EXPORT void stop_offer_service(service_t _service, instance_t _instance,
             major_version_t _major, minor_version_t _minor);
 
+#if defined(WIN32) || defined(WIN64)
+    VSOMEIP_EXPORT void offer_event_std(service_t _service, instance_t _instance,
+            event_t _notifier,
+            uint16_t _groups[], event_type_e _type,
+            std::chrono::milliseconds _cycle, bool _change_resets_cycle,
+            bool _update_on_change,
+            const epsilon_change_func_t &_epsilon_change_func,
+            reliability_type_e _reliability);
+#endif
+
     VSOMEIP_EXPORT void offer_event(service_t _service, instance_t _instance,
             event_t _notifier,
             const std::set<eventgroup_t> &_eventgroups, event_type_e _type,
@@ -80,6 +90,13 @@ public:
             major_version_t _major, minor_version_t _minor);
     VSOMEIP_EXPORT void release_service(
             service_t _service, instance_t _instance);
+
+#if defined(WIN32) || defined(WIN64)
+    VSOMEIP_EXPORT void request_event_std(service_t _service,
+            instance_t _instance, event_t _event,
+            uint16_t _groups[],
+            event_type_e _type, reliability_type_e _reliability);
+#endif
 
     VSOMEIP_EXPORT void request_event(service_t _service,
             instance_t _instance, event_t _event,

--- a/implementation/runtime/include/runtime_impl.hpp
+++ b/implementation/runtime/include/runtime_impl.hpp
@@ -22,6 +22,10 @@ public:
 
     virtual ~runtime_impl();
 
+#if defined(WIN32) || defined(WIN64)
+    std::shared_ptr<application> create_application_std(const char *_name);
+#endif
+
     std::shared_ptr<application> create_application(
             const std::string &_name);
     std::shared_ptr<application> create_application(

--- a/implementation/runtime/src/application_impl.cpp
+++ b/implementation/runtime/src/application_impl.cpp
@@ -1390,6 +1390,21 @@ void application_impl::unregister_message_handler(service_t _service,
     }
 }
 
+#if defined(WIN32) || defined(WIN64)
+void application_impl::offer_event_std(service_t _service, instance_t _instance,
+           event_t _notifier, uint16_t _groups[],
+           event_type_e _type,
+           std::chrono::milliseconds _cycle, bool _change_resets_cycle,
+           bool _update_on_change,
+           const epsilon_change_func_t &_epsilon_change_func,
+           reliability_type_e _reliability) {
+    std::set<eventgroup_t> its_groups;
+    for(uint16_t i = 0; i < sizeof(_groups)/sizeof(_groups[0]); i++)
+        its_groups.insert(_groups[i]);
+    offer_event(_service, _instance, _notifier, its_groups, _type, _cycle, _change_resets_cycle, _update_on_change, _epsilon_change_func, _reliability);
+}
+#endif
+
 void application_impl::offer_event(service_t _service, instance_t _instance,
            event_t _notifier, const std::set<eventgroup_t> &_eventgroups,
            event_type_e _type,
@@ -1429,6 +1444,18 @@ void application_impl::stop_offer_event(service_t _service, instance_t _instance
    if (routing_)
        routing_->unregister_event(client_, _service, _instance, _event, true);
 }
+
+#if defined(WIN32) || defined(WIN64)
+void application_impl::request_event_std(service_t _service, instance_t _instance,
+           event_t _event, uint16_t _groups[],
+           event_type_e _type, reliability_type_e _reliability) {
+       
+        std::set<eventgroup_t> its_groups;
+        for(uint16_t i = 0; i < sizeof(_groups)/sizeof(_groups[0]); i++)
+            its_groups.insert(_groups[i]);
+        request_event(_service, _instance, _event, its_groups, _type,_reliability);
+}
+#endif
 
 void application_impl::request_event(service_t _service, instance_t _instance,
            event_t _event, const std::set<eventgroup_t> &_eventgroups,

--- a/implementation/runtime/src/runtime_impl.cpp
+++ b/implementation/runtime/src/runtime_impl.cpp
@@ -3,6 +3,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include <iostream>
+
 #include <vsomeip/defines.hpp>
 
 #include "../include/application_impl.hpp"
@@ -32,6 +34,13 @@ std::shared_ptr<runtime> runtime_impl::get() {
 
 runtime_impl::~runtime_impl() {
 }
+
+#if defined(WIN32) || defined(WIN64)
+std::shared_ptr<application> runtime_impl::create_application_std(const char *_name)
+{
+    return create_application(std::string(_name), "");
+}
+#endif
 
 std::shared_ptr<application> runtime_impl::create_application(
         const std::string &_name) {

--- a/interface/vsomeip/application.hpp
+++ b/interface/vsomeip/application.hpp
@@ -219,6 +219,19 @@ public:
      * instance's reliability configuration. This parameter has no effect for
      * events of local services.
      */
+
+#if defined(WIN32) || defined(WIN64)
+    // standard data types, for more lossely coupled for linking in windows
+    virtual void offer_event_std(service_t _service, instance_t _instance,
+            event_t _notifier, uint16_t _groups[],
+            event_type_e _type = event_type_e::ET_EVENT,
+            std::chrono::milliseconds _cycle =std::chrono::milliseconds::zero(),
+            bool _change_resets_cycle = false,
+            bool _update_on_change = true,
+            const epsilon_change_func_t &_epsilon_change_func = nullptr,
+            reliability_type_e _reliability = reliability_type_e::RT_UNKNOWN) = 0;
+#endif
+
     virtual void offer_event(service_t _service, instance_t _instance,
             event_t _notifier, const std::set<eventgroup_t> &_eventgroups,
             event_type_e _type = event_type_e::ET_EVENT,
@@ -312,6 +325,15 @@ public:
      * belong to the eventgroup. Otherwise, neither event type nor reliability
      * type are known which might result in missing events.
      */
+    
+#if defined(WIN32) || defined(WIN64)
+    // standard data types, for more lossely coupled for linking in windows
+    virtual void request_event_std(service_t _service, instance_t _instance,
+            event_t _event, uint16_t _groups[],
+            event_type_e _type = event_type_e::ET_EVENT,
+            reliability_type_e _reliability = reliability_type_e::RT_UNKNOWN) = 0;
+#endif
+
     virtual void request_event(service_t _service, instance_t _instance,
             event_t _event, const std::set<eventgroup_t> &_eventgroups,
             event_type_e _type = event_type_e::ET_EVENT,

--- a/interface/vsomeip/runtime.hpp
+++ b/interface/vsomeip/runtime.hpp
@@ -74,6 +74,12 @@ public:
      * \param _name Name of the application on the system.
      *
      */
+#if defined(WIN32) || defined(WIN64)
+    // standard data types, for more lossely coupled for linking in windows
+    virtual std::shared_ptr<application> create_application_std(
+            const char *_name) = 0;
+#endif
+
     virtual std::shared_ptr<application> create_application(
             const std::string &_name = "") = 0;
 


### PR DESCRIPTION
Tightly coupled complex data type memory is corrupted in windows.  Functions created to for lightly coupled standard data types solved memory corruption. Suggestion is at API level to use none complex data types for easier import into other languages/applications. 