### PR TITLE
Add support for forwarding trace messages to logs

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -83,7 +83,7 @@ cc_library_shared {
         "-DVSOMEIP_VERSION=\"3.4.10\"",
         "-DVSOMEIP_COMPAT_VERSION=\"3.4.10\"",
         "-DVSOMEIP_BASE_PATH=\"/vendor/run/someip/\"",
-        "-DUSE_DLT",
+        "-DTRACE_TO_LOGS",
     ],
 
     ldflags: [

--- a/documentation/vsomeipUserGuide
+++ b/documentation/vsomeipUserGuide
@@ -438,8 +438,12 @@ status. Setting a value greater than zero enables the logging.
 +
 Specifies whether the tracing of the SOME/IP messages is enabled 
 (valid values: _true, false_). Default value is _false_.
-If tracing is enabled, the messages will be forwarded to DLT by 
-the <<traceconnector, Trace Connector>>
+If tracing is enabled, the trace messages will be forwarded to DLT and/or 
+logs by the <<traceconnector, Trace Connector>>, depending on the following 
+build flags:
+* USE_DLT 
+* TRACE_TO_LOGS
+
 +
 ** 'sd_enable'
 +

--- a/examples/routingmanagerd/routingmanagerd.cpp
+++ b/examples/routingmanagerd/routingmanagerd.cpp
@@ -16,9 +16,7 @@
 #include <vsomeip/internal/logger.hpp>
 
 #ifdef USE_DLT
-#ifndef ANDROID
 #include <dlt/dlt.h>
-#endif
 #endif
 
 static std::shared_ptr<vsomeip::application> its_application;
@@ -65,10 +63,8 @@ void routingmanagerd_stop(int _signal) {
  */
 int routingmanagerd_process(bool _is_quiet) {
 #ifdef USE_DLT
-#ifndef ANDROID
     if (!_is_quiet)
         DLT_REGISTER_APP(VSOMEIP_LOG_DEFAULT_APPLICATION_ID, VSOMEIP_LOG_DEFAULT_APPLICATION_NAME);
-#endif
 #else
     (void)_is_quiet;
 #endif

--- a/implementation/logger/include/logger_impl.hpp
+++ b/implementation/logger/include/logger_impl.hpp
@@ -10,9 +10,7 @@
 #include <mutex>
 
 #ifdef USE_DLT
-#ifndef ANDROID
 #include <dlt/dlt.h>
-#endif
 #endif
 
 #include <vsomeip/internal/logger.hpp>
@@ -48,9 +46,7 @@ private:
     mutable std::mutex configuration_mutex_;
 
 #ifdef USE_DLT
-#ifndef ANDROID
     DLT_DECLARE_CONTEXT(dlt_)
-#endif
 #endif
 };
 

--- a/implementation/logger/src/logger_impl.cpp
+++ b/implementation/logger/src/logger_impl.cpp
@@ -25,21 +25,17 @@ logger_impl::init(const std::shared_ptr<configuration> &_configuration) {
 #   define VSOMEIP_LOG_DEFAULT_CONTEXT_ID              "VSIP"
 #   define VSOMEIP_LOG_DEFAULT_CONTEXT_NAME            "vSomeIP context"
 
-#ifndef ANDROID
     std::string its_context_id = runtime::get_property("LogContext");
     if (its_context_id == "")
         its_context_id = VSOMEIP_LOG_DEFAULT_CONTEXT_ID;
 
     DLT_REGISTER_CONTEXT(its_logger->dlt_, its_context_id.c_str(), VSOMEIP_LOG_DEFAULT_CONTEXT_NAME);
 #endif
-#endif
 }
 
 logger_impl::~logger_impl() {
 #ifdef USE_DLT
-#ifndef ANDROID
     DLT_UNREGISTER_CONTEXT(dlt_);
-#endif
 #endif
 }
 
@@ -59,7 +55,6 @@ logger_impl::set_configuration(
 }
 
 #ifdef USE_DLT
-#ifndef ANDROID
 void
 logger_impl::log(level_e _level, const char *_data) {
 
@@ -90,7 +85,6 @@ logger_impl::log(level_e _level, const char *_data) {
 
     DLT_LOG_STRING(dlt_, its_level, _data);
 }
-#endif
 #endif
 
 static std::shared_ptr<logger_impl> *the_logger_ptr__(nullptr);

--- a/implementation/logger/src/message.cpp
+++ b/implementation/logger/src/message.cpp
@@ -192,9 +192,7 @@ message::~message() try {
     }
     if (its_configuration->has_dlt_log()) {
 #ifdef USE_DLT
-#ifndef ANDROID
         its_logger->log(level_, buffer_.data_.str().c_str());
-#endif
 #endif // USE_DLT
     }
 } catch (const std::exception& e) {

--- a/implementation/routing/include/routing_manager_base.hpp
+++ b/implementation/routing/include/routing_manager_base.hpp
@@ -30,7 +30,7 @@
 
 namespace vsomeip_v3 {
 
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
 namespace trace {
 class connector_impl;
 } // namespace trace
@@ -308,7 +308,7 @@ protected:
 
     std::mutex event_registration_mutex_;
 
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
     std::shared_ptr<trace::connector_impl> tc_;
 #endif
 

--- a/implementation/routing/src/routing_manager_base.cpp
+++ b/implementation/routing/src/routing_manager_base.cpp
@@ -13,7 +13,7 @@
 #include "../../protocol/include/send_command.hpp"
 #include "../../security/include/policy_manager_impl.hpp"
 #include "../../security/include/security.hpp"
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
 #include "../../tracing/include/connector_impl.hpp"
 #endif
 #include "../../utility/include/byteorder.hpp"
@@ -26,7 +26,7 @@ routing_manager_base::routing_manager_base(routing_manager_host *_host) :
         io_(host_->get_io()),
         configuration_(host_->get_configuration()),
         debounce_timer(host_->get_io())
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
         , tc_(trace::connector_impl::get())
 #endif
 {
@@ -1320,7 +1320,7 @@ void routing_manager_base::remove_eventgroup_info(service_t _service,
 bool routing_manager_base::send_local_notification(client_t _client,
         const byte_t *_data, uint32_t _size, instance_t _instance,
         bool _reliable, uint8_t _status_check, bool _force) {
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
     bool has_local(false);
 #endif
     bool has_remote(false);
@@ -1338,7 +1338,7 @@ bool routing_manager_base::send_local_notification(client_t _client,
                 has_remote = true;
                 continue;
             }
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
             else {
                 has_local = true;
             }
@@ -1351,7 +1351,7 @@ bool routing_manager_base::send_local_notification(client_t _client,
             }
         }
     }
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
     // Trace the message if a local client but will _not_ be forwarded to the routing manager
     if (has_local && !has_remote) {
         trace::header its_header;

--- a/implementation/routing/src/routing_manager_client.cpp
+++ b/implementation/routing/src/routing_manager_client.cpp
@@ -64,7 +64,7 @@
 #include "../../security/include/security.hpp"
 #include "../../utility/include/byteorder.hpp"
 #include "../../utility/include/utility.hpp"
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
 #include "../../tracing/include/connector_impl.hpp"
 #endif
 
@@ -893,7 +893,7 @@ bool routing_manager_client::send(client_t _client, const byte_t *_data,
             // notify_one
             its_target = ep_mgr_->find_local(_client);
             if (its_target) {
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
                 trace::header its_header;
                 if (its_header.prepare(nullptr, true, _instance))
                     tc_->trace(its_header.data_, VSOMEIP_TRACE_HEADER_SIZE,
@@ -905,14 +905,14 @@ bool routing_manager_client::send(client_t _client, const byte_t *_data,
         }
         // If no direct endpoint could be found
         // or for notifications ~> route to routing_manager_stub
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
         bool message_to_stub(false);
 #endif
         if (!its_target) {
             std::lock_guard<std::mutex> its_lock(sender_mutex_);
             if (sender_) {
                 its_target = sender_;
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
                 message_to_stub = true;
 #endif
             } else {
@@ -933,7 +933,7 @@ bool routing_manager_client::send(client_t _client, const byte_t *_data,
                 send = has_remote_subscribers;
             }
         }
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
         else if (!message_to_stub) {
             trace::header its_header;
             if (its_header.prepare(nullptr, true, _instance))
@@ -1207,7 +1207,7 @@ void routing_manager_client::on_message(
                             cache_event_payload(its_message);
                         }
                     }
-    #ifdef USE_DLT
+    #if defined(USE_DLT) || defined(TRACE_TO_LOGS)
                     if (client_side_logging_
                         && (client_side_logging_filter_.empty()
                             || (1 == client_side_logging_filter_.count(std::make_tuple(its_message->get_service(), ANY_INSTANCE)))

--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -50,7 +50,7 @@
 #include "../../service_discovery/include/service_discovery.hpp"
 #include "../../utility/include/byteorder.hpp"
 #include "../../utility/include/utility.hpp"
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
 #include "../../tracing/include/connector_impl.hpp"
 #endif
 
@@ -61,7 +61,7 @@
 #include "../../e2e_protection/include/e2e/profile/e2e_provider.hpp"
 #endif
 
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
 #include "../../tracing/include/connector_impl.hpp"
 #endif
 
@@ -894,7 +894,7 @@ bool routing_manager_impl::send(client_t _client, const byte_t *_data,
             its_target = find_local(its_client);
         } else if (is_notification && _client && !is_service_discovery) { // Selective notifications!
             if (_client == get_client()) {
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
                 trace::header its_header;
                 if (its_header.prepare(its_target, true, _instance))
                     tc_->trace(its_header.data_, VSOMEIP_TRACE_HEADER_SIZE,
@@ -909,7 +909,7 @@ bool routing_manager_impl::send(client_t _client, const byte_t *_data,
         }
 
         if (its_target) {
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
             if ((is_request && its_client == get_client()) ||
                     (is_response && find_local_client(its_service, _instance) == get_client()) ||
                     (is_notification && find_local_client(its_service, _instance) == VSOMEIP_ROUTING_CLIENT)) {
@@ -962,7 +962,7 @@ bool routing_manager_impl::send(client_t _client, const byte_t *_data,
                     its_target = ep_mgr_impl_->find_or_create_remote_client(
                             its_service, _instance, _reliable);
                     if (its_target) {
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
                         trace::header its_header;
                         if (its_header.prepare(its_target, true, _instance))
                             tc_->trace(its_header.data_, VSOMEIP_TRACE_HEADER_SIZE,
@@ -991,7 +991,7 @@ bool routing_manager_impl::send(client_t _client, const byte_t *_data,
                                     _data[VSOMEIP_METHOD_POS_MAX]);
                             std::shared_ptr<event> its_event = find_event(its_service, _instance, its_method);
                             if (its_event) {
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
                                 bool has_sent(false);
 #endif
                                 std::set<std::shared_ptr<endpoint_definition>> its_targets;
@@ -1042,11 +1042,11 @@ bool routing_manager_impl::send(client_t _client, const byte_t *_data,
                                     } else {
                                         its_udp_server_endpoint->send_to(target, _data, _size);
                                     }
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
                                     has_sent = true;
 #endif
                                 }
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
                                 if (has_sent) {
                                     trace::header its_header;
                                     if (its_header.prepare(nullptr, true, _instance))
@@ -1077,7 +1077,7 @@ bool routing_manager_impl::send(client_t _client, const byte_t *_data,
                             its_target = is_service_discovery ?
                                          (sd_info_ ? sd_info_->get_endpoint(false) : nullptr) : its_info->get_endpoint(_reliable);
                             if (its_target) {
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
                                 trace::header its_header;
                                 if (its_header.prepare(its_target, true, _instance))
                                     tc_->trace(its_header.data_, VSOMEIP_TRACE_HEADER_SIZE,
@@ -1172,7 +1172,7 @@ bool routing_manager_impl::send_to(
                     _target->get_remote_port(), _target->is_reliable());
 
     if (its_endpoint) {
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
         trace::header its_header;
         if (its_header.prepare(its_endpoint, true, _instance))
             tc_->trace(its_header.data_, VSOMEIP_TRACE_HEADER_SIZE,
@@ -1193,7 +1193,7 @@ bool routing_manager_impl::send_via_sd(
                     _target->is_reliable());
 
     if (its_endpoint) {
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
         if (tc_->is_sd_enabled()) {
             trace::header its_header;
             if (its_header.prepare(its_endpoint, true, 0x0))
@@ -1491,7 +1491,7 @@ void routing_manager_impl::on_message(const byte_t *_data, length_t _size,
     uint8_t its_check_status = e2e::profile_interface::generic_check_status::E2E_OK;
     instance_t its_instance(0x0);
     message_type_e its_message_type;
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
     bool is_forwarded(true);
 #endif
     if (_size >= VSOMEIP_SOMEIP_HEADER_SIZE) {
@@ -1620,14 +1620,14 @@ void routing_manager_impl::on_message(const byte_t *_data, length_t _size,
             }
 
             // Common way of message handling
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
             is_forwarded =
 #endif
             on_message(its_service, its_instance, _data, _size, _receiver->is_reliable(),
                     _bound_client, _sec_client, its_check_status, true);
         }
     }
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
     if (is_forwarded) {
         trace::header its_header;
         const boost::asio::ip::address_v4 its_remote_address =
@@ -3279,7 +3279,7 @@ void routing_manager_impl::send_error(return_code_e _return_code,
                                 its_endpoint_def->get_remote_port(),
                                 its_endpoint_def->is_reliable());
                 if (its_endpoint) {
-                    #ifdef USE_DLT
+                    #if defined(USE_DLT) || defined(TRACE_TO_LOGS)
                         trace::header its_header;
                         if (its_header.prepare(its_endpoint, true, _instance))
                             tc_->trace(its_header.data_, VSOMEIP_TRACE_HEADER_SIZE,

--- a/implementation/runtime/src/application_impl.cpp
+++ b/implementation/runtime/src/application_impl.cpp
@@ -309,7 +309,7 @@ bool application_impl::init() {
 
         routing_->init();
 
-#ifdef USE_DLT
+#if defined(USE_DLT) || defined(TRACE_TO_LOGS)
         // Tracing
         std::shared_ptr<trace::connector_impl> its_connector
             = trace::connector_impl::get();

--- a/implementation/tracing/include/connector_impl.hpp
+++ b/implementation/tracing/include/connector_impl.hpp
@@ -7,9 +7,7 @@
 #define VSOMEIP_V3_TRACE_CONNECTOR_HPP_
 
 #ifdef USE_DLT
-#ifndef ANDROID
 #include <dlt/dlt.h>
-#endif
 #endif
 
 #include <mutex>
@@ -72,10 +70,8 @@ private:
     std::shared_ptr<channel_impl> get_channel_impl(const std::string &_id) const;
 
 #ifdef USE_DLT
-#ifndef ANDROID
     std::map<std::string, std::shared_ptr<DltContext>> contexts_;
     mutable std::mutex contexts_mutex_;
-#endif
 #endif
 
 };

--- a/implementation/tracing/src/connector_impl.cpp
+++ b/implementation/tracing/src/connector_impl.cpp
@@ -277,7 +277,7 @@ void connector_impl::trace(const byte_t *_header, uint16_t _header_size,
                     std::string app = runtime::get_property("LogApplication");
                     ALOGI(app.c_str(), ss.str().c_str());
                 #else
-                    VSOMEIP_INFO << ss;
+                    VSOMEIP_INFO << ss.str();
                 #endif
             #endif
         }

--- a/test/common/include/common/vsomeip_app_utilities.hpp
+++ b/test/common/include/common/vsomeip_app_utilities.hpp
@@ -13,9 +13,7 @@
 #include <vsomeip/internal/logger.hpp>
 
 #ifdef USE_DLT
-#ifndef ANDROID
 #include <dlt/dlt.h>
-#endif
 #endif
 
 namespace vsomeip_utilities {

--- a/test/common/src/vsomeip_app_utilities.cpp
+++ b/test/common/src/vsomeip_app_utilities.cpp
@@ -29,18 +29,14 @@ base_logger::base_logger(const char *dlt_application_id, const char *dlt_applica
           _dlt_application_name(dlt_application_name)
 {
 #ifdef USE_DLT
-#ifndef ANDROID
         DLT_REGISTER_APP(_dlt_application_id, _dlt_application_name);
-#endif
 #endif
 }
 
 base_logger::~base_logger()
 {
 #ifdef USE_DLT
-#ifndef ANDROID
     DLT_UNREGISTER_APP();
-#endif
 #endif
 }
 

--- a/test/network_tests/someip_test_globals.hpp
+++ b/test/network_tests/someip_test_globals.hpp
@@ -10,9 +10,7 @@
 #include <vsomeip/internal/logger.hpp>
 
 #ifdef USE_DLT
-#ifndef ANDROID
 #include <dlt/dlt.h>
-#endif
 #endif
 
 namespace vsomeip_test


### PR DESCRIPTION
Initially, support for tracing to DLT was added. Later, support for forwarding trace messages to logs on Android was added. This commit adds support for forwarding trace messages to logs on all platforms by introducing the build flag TRACE_TO_LOGS.

If either USE_DLT or TRACE_TO_LOGS is defined when building vsomeip, support for generating trace messages will be included in the library.

The Android.bp file has been updated to include TRACE_TO_LOGS instead of USE_DLT, which allows removal of a number of additional ifdef guards around DLT-specific code.