### PR TITLE
Fix trace logging truncation

### DIFF
--- a/documentation/vsomeipUserGuide
+++ b/documentation/vsomeipUserGuide
@@ -495,11 +495,13 @@ and less than or equal to "to" are matched.
 +
 *** 'type' (optional)
 +
-Specifies the filter type (valid values: "positive", "negative"). When a positive
-filter is used and a message matches one of the filter rules, the message will be
-traced/forwarded to DLT. With a negative filter messages can be excluded. So when a
-message matches one of the filter rules, the message will not be traced/forwarded to
-DLT. Default value is "positive".
+Specifies the filter type (valid values: "positive", "negative", "header-only"). 
+When a positive filter is used and a message matches one of the filter rules, 
+the message will be traced/forwarded to DLT. With a negative filter messages 
+can be excluded. So when a message matches one of the filter rules, the message 
+will not be traced/forwarded to DLT. Default value is "positive". The value
+"header-only" implies the filter is also considered "positive".
+
 +
 //Applications
 * 'applications (array)'

--- a/implementation/tracing/src/connector_impl.cpp
+++ b/implementation/tracing/src/connector_impl.cpp
@@ -276,7 +276,7 @@ void connector_impl::trace(const byte_t *_header, uint16_t _header_size,
                     ss << ' ' << std::setfill('0') << std::setw(2) << std::hex << int(_header[i]);
                 }
                 if (ftype.second)
-                    _data_size = VSOMEIP_FULL_HEADER_SIZE;
+                    its_data_size = VSOMEIP_FULL_HEADER_SIZE;
                 for(int i = 0; i < its_data_size; i++) {
                     ss << ' ' << std::setfill('0') << std::setw(2) << std::hex << int(_data[i]);
                 }


### PR DESCRIPTION
Tracing configuration supports using the value 'header-only' for filter type. When using 'header-only', only the SOME/IP header will be included in the trace message, not the payload.

This commit fixes an issue where the input parameter '_data_size' was overritten with VSOMEIP_FULL_HEADER_SIZE instead of the local variable 'its_data_size'. The variable 'its_data_size' is used in the loop that prints the bytes of the SOME/IP message.

The documentation has also been updated to reflect the 'header-only' value and it has been clarified that this value is also implies being a 'positive' filter.