### PR TITLE
Modernize CMake code

### DIFF
--- a/.cmake-format.py
+++ b/.cmake-format.py
@@ -1,0 +1,388 @@
+# ----------------------------------
+# Options affecting listfile parsing
+# ----------------------------------
+with section("parse"):
+    # Specify structure for custom cmake functions
+
+    _target_sources_files = {
+        "kwargs": {
+            "FILE_SET": {
+                "pargs": {"flags": ["HEADERS"]},
+                "kwargs": {
+                    "TYPE": "1",
+                    "BASE_DIRS": "+",
+                    "FILES": "+",
+                },
+            }
+        },
+    }
+
+    _install_type_args = {
+        "pargs": {
+            "nargs": "+",
+            "flags": ["RUNTIME", "ARCHIVE", "LIBRARY", "OBJECTS"],
+        },
+        "kwargs": {
+            "DESTINATION": {"pargs": {"nargs": 1}},
+            "EXPORT": {"pargs": {"nargs": 1}},
+            "NAMESPACE": {"pargs": {"nargs": 1}},
+            "COMPONENT": {"pargs": {"nargs": 1}},
+            "EXCLUDE_FROM_ALL": {"pargs": {"nargs": 0}},
+            "PERMISSIONS": {
+                "pargs": {
+                    "nargs": "+",
+                    "flags": [
+                        "OWNER_READ",
+                        "OWNER_WRITE",
+                        "OWNER_EXECUTE",
+                        "GROUP_READ",
+                        "GROUP_EXECUTE",
+                        "WORLD_READ",
+                        "WORLD_EXECUTE",
+                    ],
+                }
+            },
+        },
+    }
+    _files_install_type_args = _install_type_args.copy()
+    _files_install_type_args["kwargs"]["TYPE"] = {
+        "pargs": {"nargs": 1, "flags": ["SYSCONF", "BIN"]}
+    }
+    _directory_install_type_args = _install_type_args.copy()
+    _directory_install_type_args["kwargs"]["EXCLUDE PATTERN"] = {"pargs": {"nargs": 1}}
+    _directory_install_type_args["kwargs"]["PATTERN"] = {"pargs": {"nargs": 1}}
+
+    additional_commands = {
+        "file": {
+            "kwargs": {
+                "GENERATE": {
+                    "kwargs": {
+                        "OUTPUT": 1,
+                        "CONTENT": 1,
+                        "NEWLINE_STYLE": {
+                            "pargs": {
+                                "nargs": 1,
+                            },
+                        },
+                    }
+                }
+            }
+        },
+        "add_library": {
+            "pargs": {
+                "nargs": "+",
+                "flags": ["SHARED", "STATIC", "EXCLUDE_FROM_ALL"],
+            }
+        },
+        "target_sources": {
+            "pargs": {
+                "nargs",
+                1,
+            },
+            "kwargs": {
+                "PRIVATE": _target_sources_files,
+                "PUBLIC": _target_sources_files,
+            },
+        },
+        "target_link_libraries": {
+            "pargs": "*",
+            "kwargs": {"PUBLIC": "*", "PRIVATE": "*", "INTERFACE": "*"},
+        },
+        "target_include_directories": {
+            "pargs": "*",
+            "flags": ["SYSTEM"],
+            "kwargs": {"PUBLIC": "*", "PRIVATE": "*", "INTERFACE": "*"},
+        },
+        "set_target_properties": {
+            "pargs": "*",
+            "flags": ["PROPERTIES"],
+            "kwargs": {
+                "OUTPUT_NAME": "1",
+                "EXPORT_NAME": "1",
+                "LINKER_LANGUAGE": "1",
+                "CMAKE_CXX_STANDARD_REQUIRED": "1",
+                "COMPILE_DEFINITIONS": "1",
+                "COMPILE_OPTIONS": "1",
+                "VERSION": "1",
+                "SOVERSION": "1",
+            },
+        },
+        "SET_UP_GEN_FILES": {
+            "kwargs": {
+                "ADDITIONAL_OUTPUTS": "+",
+                "FDEPL_FILE": 1,
+                "FIDL_FILE": 1,
+                "INSTALL_HEADERS_DIR": 1,
+                "INTERFACES": "+",
+                "MIDDLEWARE": 1,
+                "OUTPUT_DIR": 1,
+                "TOP_PREFIX": 1,
+                "VAR_PREFIX": 1,
+                "VAR_PREFIXES": "+",
+                "VERSION": 1,
+                "VERSIONS": "+",
+            },
+            "pargs": {
+                "flags": ["DO_CORE_RERUN_WITH_FDEPL", "NO_CLOBBER"],
+                "nargs": "*",
+            },
+        },
+        "CREATE_VSOMEIP_CONFIG_FILE": {
+            "kwargs": {
+                "INSTANCE_ID": "*",
+                "VSOMEIP_JSON_FILE": "*",
+                "KEY": "*",
+                "JSON_GLOBS": "*",
+            }
+        },
+        "install": {
+            "kwargs": {
+                "TARGETS": _install_type_args,
+                "FILES": _files_install_type_args,
+                "DIRECTORY": _directory_install_type_args,
+                "INCLUDES DESTINATION": "*",
+                "FILES_MATCHING": {
+                    "kwargs": {
+                        "PATTERN": "*",
+                        "EXCLUDE PATTERN": "*",
+                    }
+                },
+            },
+        },
+        "list": {
+            # "pargs": "*",
+            "kwargs": {
+                "APPEND": "1",
+                "FILTER": "1",
+                # "INSERT": "1",
+                # "POP_BACK": "1",
+            },
+        },
+    }
+
+    # Override configurations per-command where available
+    override_spec = {}
+
+    # Specify variable tags.
+    vartags = []
+
+    # Specify property tags.
+    proptags = []
+
+# -----------------------------
+# Options affecting formatting.
+# -----------------------------
+with section("format"):
+    # Disable formatting entirely, making cmake-format a no-op
+    disable = False
+
+    # How wide to allow formatted cmake files
+    line_width = 120
+
+    # How many spaces to tab for indent
+    tab_size = 2
+
+    # If true, lines are indented using tab characters (utf-8 0x09) instead of
+    # <tab_size> space characters (utf-8 0x20). In cases where the layout would
+    # require a fractional tab character, the behavior of the  fractional
+    # indentation is governed by <fractional_tab_policy>
+    use_tabchars = False
+
+    # If <use_tabchars> is True, then the value of this variable indicates how
+    # fractional indentions are handled during whitespace replacement. If set to
+    # 'use-space', fractional indentation is left as spaces (utf-8 0x20). If set
+    # to `round-up` fractional indentation is replaced with a single tab character
+    # (utf-8 0x09) effectively shifting the column to the next tabstop
+    fractional_tab_policy = "use-space"
+
+    # If an argument group contains more than this many sub-groups (parg or kwarg
+    # groups) then force it to a vertical layout.
+    max_subgroups_hwrap = 2
+
+    # If a positional argument group contains more than this many arguments, then
+    # force it to a vertical layout.
+    max_pargs_hwrap = 3
+
+    # If a cmdline positional group consumes more than this many lines without
+    # nesting, then invalidate the layout (and nest)
+    max_rows_cmdline = 2
+
+    # If true, separate flow control names from their parentheses with a space
+    separate_ctrl_name_with_space = False
+
+    # If true, separate function names from parentheses with a space
+    separate_fn_name_with_space = False
+
+    # If a statement is wrapped to more than one line, than dangle the closing
+    # parenthesis on its own line.
+    dangle_parens = True
+
+    # If the trailing parenthesis must be 'dangled' on its on line, then align it
+    # to this reference: `prefix`: the start of the statement,  `prefix-indent`:
+    # the start of the statement, plus one indentation  level, `child`: align to
+    # the column of the arguments
+    dangle_align = "prefix"
+
+    # If the statement spelling length (including space and parenthesis) is
+    # smaller than this amount, then force reject nested layouts.
+    min_prefix_chars = 4
+
+    # If the statement spelling length (including space and parenthesis) is larger
+    # than the tab width by more than this amount, then force reject un-nested
+    # layouts.
+    max_prefix_chars = 10
+
+    # If a candidate layout is wrapped horizontally but it exceeds this many
+    # lines, then reject the layout.
+    max_lines_hwrap = 2
+
+    # What style line endings to use in the output.
+    line_ending = "unix"
+
+    # Format command names consistently as 'lower' or 'upper' case
+    command_case = "canonical"
+
+    # Format keywords consistently as 'lower' or 'upper' case
+    keyword_case = "unchanged"
+
+    # A list of command names which should always be wrapped
+    always_wrap = []
+
+    # If true, the argument lists which are known to be sortable will be sorted
+    # lexicographicall
+    enable_sort = True
+
+    # If true, the parsers may infer whether or not an argument list is sortable
+    # (without annotation).
+    autosort = False
+
+    # By default, if cmake-format cannot successfully fit everything into the
+    # desired linewidth it will apply the last, most agressive attempt that it
+    # made. If this flag is True, however, cmake-format will print error, exit
+    # with non-zero status code, and write-out nothing
+    require_valid_layout = False
+
+    # A dictionary mapping layout nodes to a list of wrap decisions. See the
+    # documentation for more information.
+    layout_passes = {}
+
+# ------------------------------------------------
+# Options affecting comment reflow and formatting.
+# ------------------------------------------------
+with section("markup"):
+    # What character to use for bulleted lists
+    bullet_char = "*"
+
+    # What character to use as punctuation after numerals in an enumerated list
+    enum_char = "."
+
+    # If comment markup is enabled, don't reflow the first comment block in each
+    # listfile. Use this to preserve formatting of your copyright/license
+    # statements.
+    first_comment_is_literal = False
+
+    # If comment markup is enabled, don't reflow any comment block which matches
+    # this (regex) pattern. Default is `None` (disabled).
+    literal_comment_pattern = None
+
+    # Regular expression to match preformat fences in comments default=
+    # ``r'^\s*([`~]{3}[`~]*)(.*)$'``
+    fence_pattern = "^\\s*([`~]{3}[`~]*)(.*)$"
+
+    # Regular expression to match rulers in comments default=
+    # ``r'^\s*[^\w\s]{3}.*[^\w\s]{3}$'``
+    ruler_pattern = "^\\s*[^\\w\\s]{3}.*[^\\w\\s]{3}$"
+
+    # If a comment line matches starts with this pattern then it is explicitly a
+    # trailing comment for the preceeding argument. Default is '#<'
+    explicit_trailing_pattern = "#<"
+
+    # If a comment line starts with at least this many consecutive hash
+    # characters, then don't lstrip() them off. This allows for lazy hash rulers
+    # where the first hash char is not separated by space
+    hashruler_min_length = 10
+
+    # If true, then insert a space between the first hash char and remaining hash
+    # chars in a hash ruler, and normalize its length to fill the column
+    canonicalize_hashrulers = True
+
+    # enable comment markup parsing and reflow
+    enable_markup = True
+
+# ----------------------------
+# Options affecting the linter
+# ----------------------------
+with section("lint"):
+    # a list of lint codes to disable
+    disabled_codes = []
+
+    # regular expression pattern describing valid function names
+    function_pattern = "[0-9a-z_]+"
+
+    # regular expression pattern describing valid macro names
+    macro_pattern = "[0-9A-Z_]+"
+
+    # regular expression pattern describing valid names for variables with global
+    # (cache) scope
+    global_var_pattern = "[A-Z][0-9A-Z_]+"
+
+    # regular expression pattern describing valid names for variables with global
+    # scope (but internal semantic)
+    internal_var_pattern = "_[A-Z][0-9A-Z_]+"
+
+    # regular expression pattern describing valid names for variables with local
+    # scope
+    local_var_pattern = "[a-z][a-z0-9_]+"
+
+    # regular expression pattern describing valid names for privatedirectory
+    # variables
+    private_var_pattern = "_[0-9a-z_]+"
+
+    # regular expression pattern describing valid names for public directory
+    # variables
+    public_var_pattern = "[A-Z][0-9A-Z_]+"
+
+    # regular expression pattern describing valid names for function/macro
+    # arguments and loop variables.
+    argument_var_pattern = "[a-z][a-z0-9_]+"
+
+    # regular expression pattern describing valid names for keywords used in
+    # functions or macros
+    keyword_pattern = "[A-Z][0-9A-Z_]+"
+
+    # In the heuristic for C0201, how many conditionals to match within a loop in
+    # before considering the loop a parser.
+    max_conditionals_custom_parser = 2
+
+    # Require at least this many newlines between statements
+    min_statement_spacing = 1
+
+    # Require no more than this many newlines between statements
+    max_statement_spacing = 2
+    max_returns = 6
+    max_branches = 12
+    max_arguments = 5
+    max_localvars = 15
+    max_statements = 50
+
+# -------------------------------
+# Options affecting file encoding
+# -------------------------------
+with section("encode"):
+    # If true, emit the unicode byte-order mark (BOM) at the start of the file
+    emit_byteorder_mark = False
+
+    # Specify the encoding of the input file. Defaults to utf-8
+    input_encoding = "utf-8"
+
+    # Specify the encoding of the output file. Defaults to utf-8. Note that cmake
+    # only claims to support utf-8 so be careful when using anything else
+    output_encoding = "utf-8"
+
+# -------------------------------------
+# Miscellaneous configurations options.
+# -------------------------------------
+with section("misc"):
+    # A dictionary containing any per-command configuration overrides. Currently
+    # only `command_case` is supported.
+    per_command = {}

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,12 @@
+/Makefile
+/.vscode
+/.cache
+/compile_commands.json
+/.ninja
 /CMakeFiles
 /build*/*
+/*bld*
+/*stage
 /examples/hello_world/build
 /.vscode/
 /.settings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain
 # one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required(VERSION 3.13)
+cmake_minimum_required(VERSION 3.15)
 project(vsomeip)
 
 set(VSOMEIP_NAME vsomeip3)
@@ -15,7 +15,6 @@ set(VSOMEIP_HOTFIX_VERSION 0)
 
 set(VSOMEIP_VERSION ${VSOMEIP_MAJOR_VERSION}.${VSOMEIP_MINOR_VERSION}.${VSOMEIP_PATCH_VERSION})
 set(PACKAGE_VERSION ${VSOMEIP_VERSION}) # Used in documentation/doxygen.in
-set(CMAKE_VERBOSE_MAKEFILE off)
 
 if(NOT GTEST_ROOT)
   if(DEFINED ENV{GTEST_ROOT})
@@ -36,17 +35,19 @@ endif()
 # see http://www.cmake.org/Wiki/CMake/Tutorials/How_to_create_a_ProjectConfig.cmake_file
 # ######################################################################################################################
 
+include(GNUInstallDirs)
+
 # Offer the user the choice of overriding the installation directories
 set(INSTALL_LIB_DIR
-    lib
+    ${CMAKE_INSTALL_LIBDIR}
     CACHE PATH "Installation directory for libraries"
 )
 set(INSTALL_BIN_DIR
-    bin
+    ${CMAKE_INSTALL_BINDIR}
     CACHE PATH "Installation directory for executables"
 )
 set(INSTALL_INCLUDE_DIR
-    include
+    ${CMAKE_INSTALL_INCLUDEDIR}
     CACHE PATH "Installation directory for header files"
 )
 
@@ -62,21 +63,16 @@ set(INSTALL_CMAKE_DIR
 )
 
 # Make relative paths absolute (needed later on)
-foreach(
-  p
-  LIB
-  BIN
-  INCLUDE
-  CMAKE
-)
+foreach(p LIB BIN INCLUDE CMAKE)
   set(var INSTALL_${p}_DIR)
   if(NOT IS_ABSOLUTE "${${var}}")
     set(ABSOLUTE_${var} "${CMAKE_INSTALL_PREFIX}/${${var}}") # Add all targets to the build-tree export set
   endif()
 endforeach()
 
-# ######################################################################################################################
+# #####################################################################
 # Set a default build type if none was specified
+# This is a CMake anti-pattern.
 set(default_build_type "RelWithDebInfo")
 if(NOT CMAKE_BUILD_TYPE)
   message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
@@ -97,92 +93,165 @@ endif()
 
 set(CMAKE_CXX_STANDARD 17)
 
+# Threads
+find_package(Threads REQUIRED)
+
 # OS
+add_library(OS_INTERFACE INTERFACE IMPORTED)
+add_library(RT_INTERFACE INTERFACE IMPORTED)
+add_library(DL_INTERFACE INTERFACE IMPORTED)
+add_library(STACKTRACE_INTERFACE INTERFACE IMPORTED)
+
+# Boost
+find_package(
+  Boost 1.65 REQUIRED
+  COMPONENTS system thread filesystem
+  OPTIONAL_COMPONENTS stacktrace_basic stacktrace_backtrace stacktrace_addr2line
+)
+
+include(CMakeDependentOption)
+cmake_dependent_option(ENABLE_WERROR "Enable -Werror flag" ON "CMAKE_SYSTEM_NAME MATCHES LINUX" OFF)
+if (ENABLE_WERROR)
+  message(STATUS "Enabling -Werror flag")
+  add_compile_options(-Werror)
+endif()
+
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-  set(DL_LIBRARY "dl")
+  set(OS "LINUX")
+  target_link_libraries(DL_INTERFACE INTERFACE dl)
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+  add_definitions(-D_GLIBCXX_USE_NANOSLEEP -D_FORTIFY_SOURCE=2)
+  add_compile_options(
+    -Wall
+    -Wextra
+    -Wformat
+    -Wformat-security
+    -Wconversion
+    -Wformat
+    -Werror=format-security
+    -Wpedantic
+    -fexceptions
+    -fstrict-aliasing
+    -fstack-protector-strong
+    -fasynchronous-unwind-tables
+    -fno-omit-frame-pointer
+  )
+
+  target_link_libraries(OS_INTERFACE INTERFACE Threads::Threads)
 
   if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # This is only relevant for GCC and causes warnings on Clang
-    set(EXPORTSYMBOLS "-Wl,-export-dynamic -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exportmap.gcc")
-    set(OS_CXX_FLAGS "${OS_CXX_FLAGS} -pie -Wno-tsan -Wl,-z,relro,-z,now")
+    add_link_options(
+      -Wl,-z,relro,-z,now -Wl,-export-dynamic -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exportmap.gcc
+    )
   endif()
-
-  set(NO_DEPRECATED "")
-  set(OPTIMIZE "")
-  set(OS_CXX_FLAGS
-      "${OS_CXX_FLAGS} -D_GLIBCXX_USE_NANOSLEEP -pthread -O -Wall -Wextra -Wformat -Wformat-security -Wconversion -fexceptions -fstrict-aliasing -fstack-protector-strong -fasynchronous-unwind-tables -fno-omit-frame-pointer -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Wpedantic -Werror -fPIE"
-  )
+  add_link_options(-Wl,--wrap=socket,--wrap=accept,--wrap=open)
 
   # force all use of std::mutex and std::recursive_mutex to use runtime init instead of static initialization so mutexes
   # can be hooked to enable PI as needed
   add_definitions(-D_GTHREAD_USE_MUTEX_INIT_FUNC -D_GTHREAD_USE_RECURSIVE_MUTEX_INIT_FUNC)
-endif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-  set(DL_LIBRARY "")
-  set(EXPORTSYMBOLS "")
-  set(NO_DEPRECATED "-Wno-deprecated")
-  set(OPTIMIZE "")
-  set(OS_CXX_FLAGS "-pthread")
-endif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+  # For backtraces to work, define the following in your toolchain:
+  # -DBOOST_STACKTRACE_BACKTRACE_INCLUDE_FILE="/usr/lib/gcc/x86_64-linux-gnu/11/include/backtrace.h" (this is hardcoded
+  # here as it does not necessarily represent yours system)
+  target_compile_definitions(
+    STACKTRACE_INTERFACE INTERFACE -DBOOST_STACKTRACE_USE_BACKTRACE -DBOOST_STACKTRACE_USE_ADDR2LINE
+  )
+  target_link_libraries(
+    STACKTRACE_INTERFACE INTERFACE Boost::stacktrace_addr2line Boost::stacktrace_backtrace backtrace
+  )
 
-# ###########################################My lib link flags####################################
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+  set(OS "FREEBSD")
+  add_compile_options(-Wno-deprecated)
+  target_link_libraries(OS_INTERFACE INTERFACE Threads::Threads)
+
+elseif(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
+  set(OS "QNX")
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+  add_compile_options(
+    -fexceptions
+    -fstrict-aliasing
+    -fstack-protector
+    -fasynchronous-unwind-tables
+    -fno-omit-frame-pointer
+  )
+  add_link_options(-Wl,-export-dynamic)
+  add_link_options(-Wl,--wrap=socket,--wrap=accept,--wrap=open)
+
+  target_link_libraries(OS_INTERFACE INTERFACE slog2)
+
+  # QNX specific socket lib
+  set(VSOMEIP_SOCKET_LIB "socket" CACHE "Default socket library for QNX" STRING)
+  target_link_libraries(RT_INTERFACE INTERFACE $<$<PLATFORM_ID:QNX>:${VSOMEIP_SOCKET_LIB}>)
+
+  # Boost::stacktrace_addr2line is not available on QNX libbacktrace.so is not installed on target by default
+  target_link_libraries(
+    STACKTRACE_INTERFACE INTERFACE Boost::stacktrace_basic
+  )
+endif()
+
+if(${OS})
+  add_definitions(-D${OS})
+endif()
+
+# ###################################My lib link flags##############################
 # Options
-# ######################################################################################################################
+# ##################################################################################
 
 # DLT
-if(DISABLE_DLT)
-  set(VSOMEIP_ENABLE_DLT 0)
+set(USE_DLT
+    FALSE
+    CACHE BOOL "Use dlt-daemon (automotive-dlt) runtime"
+)
+if(USE_DLT)
+  find_package(automotive-dlt)
+  if(automotive-dlt_FOUND)
+    message(STATUS "automotive-dlt found and will be linked")
+  endif()
 else()
-  set(VSOMEIP_ENABLE_DLT 1)
+  message(STATUS "Not linking automotive-dlt")
 endif()
 
 # Signal handling
+option(ENABLE_SIGNAL_HANDLING "Enable signal handling (SIGTERM, SIGINT, etc)" OFF)
 if(ENABLE_SIGNAL_HANDLING)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVSOMEIP_ENABLE_SIGNAL_HANDLING")
+  add_definitions(-DVSOMEIP_ENABLE_SIGNAL_HANDLING)
 endif()
 
+# Sanitizers
 if(NOT MSVC)
-  # Sanitizers
-
   if(ENABLE_UNDEFINED_SANITIZER)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined")
+    add_compile_options(-fsanitize=undefined)
   endif()
 
   if(ENABLE_THREAD_SANITIZER)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread")
+    add_compile_options(-fsanitize=thread)
   endif()
 
   if(ENABLE_LEAK_SANITIZER)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=leak")
+    add_compile_options(-fsanitize=leak)
   endif()
 
   if(ENABLE_ADDRESS_SANITIZER)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+    add_compile_options(-fsanitize=address)
   endif()
 
   if(ENABLE_PROFILING)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pg")
+    add_compile_options(-pg)
   endif()
-endif(NOT MSVC)
+endif()
 
 # Compatibility
-if(ENABLE_COMPAT)
-  set(VSOMEIP_ENABLE_COMPAT 1)
-else()
-  set(VSOMEIP_ENABLE_COMPAT 0)
-endif()
+option(VSOMEIP_ENABLE_COMPAT "Enable compatibility layer" OFF)
 
 # Multiple routing managers
-if(ENABLE_MULTIPLE_ROUTING_MANAGERS)
-  set(VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS 1)
-else()
-  set(VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS 0)
-endif()
+option(ENABLE_MULTIPLE_ROUTING_MANAGERS "Enable multiple routing managers" OFF)
 
 # Security / Policy handling
+option(DISABLE_SECURITY "Disable security features")
 if(DISABLE_SECURITY)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVSOMEIP_DISABLE_SECURITY")
+  add_definitions(-DVSOMEIP_DISABLE_SECURITY)
 endif()
 
 # Suppress deprecation warnings for vSomeIP interfaces
@@ -195,31 +264,8 @@ add_definitions(-DVSOMEIP_INTERNAL_SUPPRESS_DEPRECATED)
 # Threads
 find_package(Threads REQUIRED)
 
-# Boost
-find_package(
-  Boost 1.55
-  COMPONENTS system thread filesystem
-  REQUIRED
-)
-if(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
-  include_directories(${Boost_INCLUDE_DIR})
-else()
-  include_directories(SYSTEM ${Boost_INCLUDE_DIR})
-endif()
-
-if(Boost_FOUND)
-  if(Boost_LIBRARY_DIR)
-    message(STATUS "Boost_LIBRARY_DIR not empty using it: ${Boost_LIBRARY_DIR}")
-  else()
-    if(BOOST_LIBRARYDIR)
-      message(
-        STATUS "Boost_LIBRARY_DIR empty but BOOST_LIBRARYDIR is set setting Boost_LIBRARY_DIR to: ${BOOST_LIBRARYDIR}"
-      )
-      set(Boost_LIBRARY_DIR ${BOOST_LIBRARYDIR})
-    endif()
-  endif()
-else()
-  message(STATUS "Boost was not found!")
+if(NOT Boost_FOUND)
+  message(FATAL_ERROR "Boost was not found!")
 endif()
 
 # cmake 3.15 introduced a new variable and a new format for the old one
@@ -231,44 +277,28 @@ endif()
 
 message(STATUS "Using boost version: ${VSOMEIP_BOOST_VERSION}")
 
-if(${VSOMEIP_BOOST_VERSION} LESS 106600)
-  include_directories(SYSTEM implementation/helper)
-endif()
-
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVSOMEIP_BOOST_VERSION=${VSOMEIP_BOOST_VERSION}")
+add_definitions(-DVSOMEIP_BOOST_VERSION=${VSOMEIP_BOOST_VERSION})
 
 find_package(PkgConfig)
-
-# DLT
-if(VSOMEIP_ENABLE_DLT EQUAL 1)
-  pkg_check_modules(DLT "automotive-dlt >= 2.11")
-  if(DLT_FOUND)
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_DLT")
-  endif(DLT_FOUND)
-endif()
 
 # SystemD
 pkg_check_modules(SystemD "libsystemd")
 
-if(NOT SystemD_FOUND)
+if(NOT SystemD_FOUND OR ${CMAKE_SYSTEM_NAME} MATCHES "Android")
   message(STATUS "Systemd was not found, watchdog disabled!")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWITHOUT_SYSTEMD")
-endif(NOT SystemD_FOUND)
+  add_definitions(-DWITHOUT_SYSTEMD)
+else()
+  target_link_libraries(OS_INTERFACE INTERFACE ${SystemD_LIBRARIES})
+endif()
 
 # Multiple routing managers
-if(VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS EQUAL 1)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS")
+if(ENABLE_MULTIPLE_ROUTING_MANAGERS)
+  add_definitions(-DVSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS)
 endif()
 
 # ######################################################################################################################
 # Directories
 # ######################################################################################################################
-
-include_directories(interface)
-
-include_directories(SYSTEM ${DLT_INCLUDE_DIRS})
-
-link_directories(${DLT_LIBDIR})
 
 if(${VSOMEIP_HOTFIX_VERSION} EQUAL 0)
   add_definitions(-DVSOMEIP_VERSION="${VSOMEIP_VERSION}")
@@ -287,41 +317,42 @@ if(MSVC)
   )
   # Disable warning C4250 since it warns that the compiler is correctly following the C++ Standard. It's a
   # "We-Are-Doing-Things-By-The-Book" notice, not a real warning.
-  set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS -D_WIN32_WINNT=${BOOST_WINDOWS_VERSION} -DWIN32 -DBOOST_ASIO_DISABLE_IOCP /EHsc /std:c++14 /wd4250"
+  add_compile_options(/EHsc /std:c++latest /wd4250)
+  add_definitions(
+    -D_CRT_SECURE_NO_WARNINGS
+    -D_SCL_SECURE_NO_WARNINGS
+    -D_WINSOCK_DEPRECATED_NO_WARNINGS
+    -D_WIN32_WINNT=${BOOST_WINDOWS_VERSION}
+    -DWIN32
+    -DBOOST_ASIO_DISABLE_IOCP
   )
-  set(USE_RT "")
   link_directories(${Boost_LIBRARY_DIR_DEBUG})
-elseif(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
-  set(USE_RT "")
 else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OS_CXX_FLAGS} -g ${OPTIMIZE} -std=c++17 ${NO_DEPRECATED} ${EXPORTSYMBOLS}")
-  set(USE_RT "rt")
+  target_link_libraries(RT_INTERFACE INTERFACE rt)
 endif()
 
 # ######################################################################################################################
 # Configuration library
 # ######################################################################################################################
-file(GLOB ${VSOMEIP_NAME}-cfg_SRC "implementation/configuration/src/*.cpp")
-list(SORT ${VSOMEIP_NAME}-cfg_SRC)
-if(VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS EQUAL 0)
-  add_library(${VSOMEIP_NAME}-cfg SHARED ${${VSOMEIP_NAME}-cfg_SRC})
+file(GLOB vsomeip3_cfg_SRC "implementation/configuration/src/*.cpp")
+list(SORT vsomeip3_cfg_SRC)
+if(NOT ENABLE_MULTIPLE_ROUTING_MANAGERS)
+  add_library(vsomeip3-cfg SHARED)
+  target_sources(vsomeip3-cfg PRIVATE ${vsomeip3_cfg_SRC})
   set_target_properties(
-    ${VSOMEIP_NAME}-cfg PROPERTIES
+    vsomeip3-cfg PROPERTIES
     VERSION ${VSOMEIP_VERSION}
     SOVERSION ${VSOMEIP_MAJOR_VERSION}
+    EXPORT_NAME vsomeip3-cfg
   )
-  if(MSVC)
-    set_target_properties(${VSOMEIP_NAME}-cfg PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION_PLUGIN")
-  endif()
+  target_compile_definitions(vsomeip3-cfg PUBLIC $<$<CXX_COMPILER_ID:MSVC>:VSOMEIP_DLL_COMPILATION_PLUGIN>)
 
   target_link_libraries(
-    ${VSOMEIP_NAME}-cfg
-    ${VSOMEIP_NAME}
-    ${Boost_LIBRARIES}
-    ${USE_RT}
-    ${DL_LIBRARY}
-    ${SystemD_LIBRARIES}
+    vsomeip3-cfg
+    PRIVATE vsomeip3
+            RT_INTERFACE
+            DL_INTERFACE
+            OS_INTERFACE
   )
 endif()
 
@@ -330,7 +361,7 @@ endif()
 # ######################################################################################################################
 file(
   GLOB
-  ${VSOMEIP_NAME}_SRC
+  vsomeip3_SRC
   "implementation/endpoints/src/*.cpp"
   "implementation/logger/src/*.cpp"
   "implementation/tracing/src/*.cpp"
@@ -342,9 +373,10 @@ file(
   "implementation/security/src/*.cpp"
   "implementation/utility/src/*.cpp"
 )
-if(VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS EQUAL 1)
-  list(APPEND ${VSOMEIP_NAME}_SRC "implementation/configuration/src/configuration_impl.cpp")
+if(ENABLE_MULTIPLE_ROUTING_MANAGERS)
+  list(APPEND vsomeip3_SRC "implementation/configuration/src/configuration_impl.cpp")
 endif()
+list(SORT vsomeip3_SRC)
 
 if(WIN32)
   list(
@@ -355,39 +387,44 @@ if(WIN32)
   )
 endif()
 
-list(SORT ${VSOMEIP_NAME}_SRC)
-
-add_library(${VSOMEIP_NAME} SHARED ${${VSOMEIP_NAME}_SRC})
-set_target_properties(
-  ${VSOMEIP_NAME} PROPERTIES
-  VERSION ${VSOMEIP_VERSION}
-  SOVERSION ${VSOMEIP_MAJOR_VERSION}
+add_library(vsomeip3 SHARED)
+target_sources(vsomeip3 PRIVATE ${vsomeip3_SRC})
+target_include_directories(
+  vsomeip3
+  PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/interface>
+         $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/implementation/configuration/include>
+  INTERFACE $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>
 )
-if(MSVC)
-  set_target_properties(${VSOMEIP_NAME} PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION")
-else()
-  set_target_properties(
-    ${VSOMEIP_NAME}
-    PROPERTIES
-    LINK_FLAGS
-    "-Wl,-wrap,socket -Wl,-wrap,accept -Wl,-wrap,open"
+if(${VSOMEIP_BOOST_VERSION} LESS 106600)
+  target_include_directories(
+    vsomeip3 SYSTEM
+    PUBLIC # The vsomeip boost helpers are a SYSTEM include to suppress warnings. These warnings should likely be
+           # addressed though
+           $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/implementation/helper>
   )
 endif()
-target_include_directories(
-  ${VSOMEIP_NAME} INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/interface> $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-                            $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>
+target_compile_definitions(vsomeip3 PUBLIC _GNU_SOURCE $<$<CXX_COMPILER_ID:MSVC>:VSOMEIP_DLL_COMPILATION>)
+target_include_directories(vsomeip3 SYSTEM PUBLIC $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}>)
+target_link_libraries(vsomeip3 PRIVATE STACKTRACE_INTERFACE)
+set_target_properties(
+  vsomeip3 PROPERTIES
+  SOVERSION ${VSOMEIP_MAJOR_VERSION}
+  VERSION ${VSOMEIP_VERSION}
+  OUTPUT_NAME ${VSOMEIP_NAME}
+  EXPORT_NAME vsomeip3
 )
+
 # PRIVATE means the listed libraries won't be included in the "link interface", meaning the exported
 # ${VSOMEIP_NAME}Targets.cmake targets won't try to link against them (which shouldn't be required). ${Boost_LIBRARIES}
 # includes absolute build host paths as of writing, which also makes this important as it breaks the build.
 target_link_libraries(
-  ${VSOMEIP_NAME}
-  PRIVATE ${Boost_LIBRARIES}
-          ${USE_RT}
-          ${DL_LIBRARY}
-          ${DLT_LIBRARIES}
-          ${SystemD_LIBRARIES}
-          ${CMAKE_THREAD_LIBS_INIT}
+  vsomeip3
+  PRIVATE Boost::filesystem
+          Boost::thread
+          RT_INTERFACE
+          DL_INTERFACE
+          OS_INTERFACE
+          Threads::Threads
 )
 
 if(NOT WIN32)
@@ -397,98 +434,89 @@ endif()
 # ######################################################################################################################
 # Service Discovery library
 # ######################################################################################################################
-file(GLOB ${VSOMEIP_NAME}-sd_SRC "implementation/service_discovery/src/*.cpp")
-list(SORT ${VSOMEIP_NAME}-sd_SRC)
+file(GLOB vsomeip3_sd_SRC "implementation/service_discovery/src/*.cpp")
+list(SORT vsomeip3_sd_SRC)
 
-add_library(${VSOMEIP_NAME}-sd SHARED ${${VSOMEIP_NAME}-sd_SRC})
+add_library(vsomeip3-sd SHARED)
+target_sources(vsomeip3-sd PRIVATE ${vsomeip3_sd_SRC})
 set_target_properties(
-  ${VSOMEIP_NAME}-sd PROPERTIES
+  vsomeip3-sd PROPERTIES
   VERSION ${VSOMEIP_VERSION}
   SOVERSION ${VSOMEIP_MAJOR_VERSION}
 )
-if(MSVC)
-  set_target_properties(${VSOMEIP_NAME}-sd PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION_PLUGIN")
-endif()
-
+target_compile_definitions(vsomeip3-sd PUBLIC $<$<CXX_COMPILER_ID:MSVC>:VSOMEIP_DLL_COMPILATION_PLUGIN>)
 target_link_libraries(
-  ${VSOMEIP_NAME}-sd
-  ${VSOMEIP_NAME}
-  ${Boost_LIBRARIES}
-  ${USE_RT}
-  ${DL_LIBRARY}
-  ${SystemD_LIBRARIES}
-  ${CMAKE_THREAD_LIBS_INIT}
+  vsomeip3-sd
+  PUBLIC vsomeip3
+  PRIVATE RT_INTERFACE
+          DL_INTERFACE
+          OS_INTERFACE
+          Threads::Threads
 )
 
 # ######################################################################################################################
 # E2E library
 # ######################################################################################################################
-file(GLOB_RECURSE ${VSOMEIP_NAME}-e2e_SRC "implementation/e2e_protection/src/*.cpp")
-list(SORT ${VSOMEIP_NAME}-e2e_SRC)
+file(GLOB_RECURSE vsomeip3_e2e_SRC "implementation/e2e_protection/src/*.cpp")
+list(SORT vsomeip3_e2e_SRC)
 
-add_library(${VSOMEIP_NAME}-e2e SHARED ${${VSOMEIP_NAME}-e2e_SRC})
+add_library(vsomeip3-e2e SHARED)
+target_sources(vsomeip3-e2e PRIVATE ${vsomeip3_e2e_SRC})
 set_target_properties(
-  ${VSOMEIP_NAME}-e2e PROPERTIES
+  vsomeip3-e2e PROPERTIES
   VERSION ${VSOMEIP_VERSION}
   SOVERSION ${VSOMEIP_MAJOR_VERSION}
+  OUTPUT_NAME ${VSOMEIP_NAME}-e2e
+  EXPORT_NAME vsomeip3-e2e
 )
-if(MSVC)
-  set_target_properties(${VSOMEIP_NAME}-e2e PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION_PLUGIN")
-endif()
-
+target_compile_definitions(vsomeip3-e2e PUBLIC $<$<CXX_COMPILER_ID:MSVC>:VSOMEIP_DLL_COMPILATION_PLUGIN>)
 target_link_libraries(
-  ${VSOMEIP_NAME}-e2e
-  ${VSOMEIP_NAME}
-  ${Boost_LIBRARIES}
-  ${USE_RT}
-  ${DL_LIBRARY}
-  ${SystemD_LIBRARIES}
+  vsomeip3-e2e
+  PUBLIC vsomeip3
+  PRIVATE RT_INTERFACE DL_INTERFACE OS_INTERFACE
 )
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
-  target_link_libraries(${VSOMEIP_NAME}-e2e socket)
-endif()
 # ######################################################################################################################
 # Compatibility library
 # ######################################################################################################################
-if(VSOMEIP_ENABLE_COMPAT EQUAL 1)
+if(ENABLE_COMPAT)
   set(VSOMEIP_COMPAT_MAJOR_VERSION 2)
   set(VSOMEIP_COMPAT_VERSION ${VSOMEIP_COMPAT_MAJOR_VERSION}.99.99)
 
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVSOMEIP_ENABLE_COMPAT")
+  add_definitions(-DVSOMEIP_ENABLE_COMPAT)
 
   file(
     GLOB_RECURSE
-    ${VSOMEIP_COMPAT_NAME}_SRC
+    vsomeip3_compat_SRC
     "implementation/compat/logging/src/*.cpp"
     "implementation/compat/message/src/*.cpp"
     "implementation/compat/runtime/src/*.cpp"
   )
-  list(SORT ${VSOMEIP_COMPAT_NAME}_SRC)
+  list(SORT vsomeip3_compat_SRC)
 
-  add_library(${VSOMEIP_COMPAT_NAME} SHARED ${${VSOMEIP_COMPAT_NAME}_SRC})
+  add_library(vsomeip3-compat SHARED ${vsomeip3_compat_SRC})
+  target_compile_definitions(vsomeip3-compat PUBLIC $<$<CXX_COMPILER_ID:MSVC>:VSOMEIP_DLL_COMPILATION_PLUGIN>)
   set_target_properties(
-    ${VSOMEIP_COMPAT_NAME} PROPERTIES
+    vsomeip3-compat PROPERTIES
     VERSION ${VSOMEIP_COMPAT_VERSION}
     SOVERSION ${VSOMEIP_COMPAT_MAJOR_VERSION}
+    OUTPUT_NAME ${VSOMEIP_COMPAT_NAME}
+    EXPORT_NAME vsomeip3-compat
   )
-  if(MSVC)
-    set_target_properties(${VSOMEIP_COMPAT_NAME} PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION_PLUGIN")
-  endif()
-
   target_include_directories(
-    ${VSOMEIP_COMPAT_NAME}
+    vsomeip3-compat
     PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/interface/compat>
            $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> # for generated files in build mode
+           $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/implementation/configuration/include>
            $<INSTALL_INTERFACE:include/compat> # for clients in install mode
   )
   target_link_libraries(
-    ${VSOMEIP_COMPAT_NAME}
-    PRIVATE ${VSOMEIP_NAME}
+    vsomeip3-compat
+    PRIVATE vsomeip3
             ${Boost_LIBRARIES}
-            ${USE_RT}
-            ${DL_LIBRARY}
-            ${SystemD_LIBRARIES}
+            RT_INTERFACE
+            DL_INTERFACE
+            OS_INTERFACE
   )
 
 endif()
@@ -509,13 +537,14 @@ set(EXAMPLE_CONFIG_FILES
 # Configuration parameters
 # ######################################################################################################################
 if(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
-  set(VSOMEIP_BASE_PATH "/var")
+  set(VSOMEIP_BASE_PATH_DEFAULT "/var")
 else()
-  set(VSOMEIP_BASE_PATH "/tmp")
+  set(VSOMEIP_BASE_PATH_DEFAULT "/tmp")
 endif()
-if(BASE_PATH)
-  set(VSOMEIP_BASE_PATH ${BASE_PATH})
-endif()
+set(VSOMEIP_BASE_PATH
+    ${VSOMEIP_BASE_PATH_DEFAULT}
+    CACHE PATH "Base path for vsomeip sockets"
+)
 
 set(VSOMEIP_DIAGNOSIS_ADDRESS "0x01")
 if(DIAGNOSIS_ADDRESS)
@@ -590,23 +619,22 @@ foreach(file ${vsomeip_INCLUDE})
 endforeach()
 
 install(
-  TARGETS ${VSOMEIP_NAME}
+  TARGETS vsomeip3
           # IMPORTANT: Add the vsomeip library to the "export-set"
-          EXPORT
-          ${VSOMEIP_NAME}Targets
+          EXPORT vsomeip3Targets
           RUNTIME
           DESTINATION "${INSTALL_BIN_DIR}"
-          COMPONENT
+          COMPONENT bin
           LIBRARY
           DESTINATION "${INSTALL_LIB_DIR}"
-          COMPONENT
+          COMPONENT shlib
           ARCHIVE
           DESTINATION "${INSTALL_LIB_DIR}"
           COMPONENT dev
 )
 
 install(
-  TARGETS ${VSOMEIP_NAME}-e2e LIBRARY
+  TARGETS vsomeip3-e2e LIBRARY
           DESTINATION "${INSTALL_LIB_DIR}"
           COMPONENT shlib
           RUNTIME
@@ -614,9 +642,9 @@ install(
           COMPONENT bin
 )
 
-if(VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS EQUAL 0)
+if(NOT ENABLE_MULTIPLE_ROUTING_MANAGERS)
   install(
-    TARGETS ${VSOMEIP_NAME}-cfg LIBRARY
+    TARGETS vsomeip3-cfg LIBRARY
             DESTINATION "${INSTALL_LIB_DIR}"
             COMPONENT shlib
             RUNTIME
@@ -626,7 +654,7 @@ if(VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS EQUAL 0)
 endif()
 
 install(
-  TARGETS ${VSOMEIP_NAME}-sd LIBRARY
+  TARGETS vsomeip3-sd LIBRARY
           DESTINATION "${INSTALL_LIB_DIR}"
           COMPONENT shlib
           RUNTIME
@@ -634,11 +662,10 @@ install(
           COMPONENT bin
 )
 
-if(VSOMEIP_ENABLE_COMPAT EQUAL 1)
+if(ENABLE_COMPAT)
   install(
-    TARGETS ${VSOMEIP_COMPAT_NAME}
-            EXPORT
-            vsomeipTargets
+    TARGETS vsomeip3-compat
+            EXPORT vsomeipTargets
             LIBRARY
             DESTINATION "${INSTALL_LIB_DIR}"
             COMPONENT shlib
@@ -647,13 +674,13 @@ if(VSOMEIP_ENABLE_COMPAT EQUAL 1)
             COMPONENT bin
   )
 
-  export(TARGETS ${VSOMEIP_COMPAT_NAME} FILE "${PROJECT_BINARY_DIR}/vsomeipTargets.cmake")
-  export(PACKAGE ${VSOMEIP_COMPAT_NAME})
+  export(TARGETS vsomeip3-compat FILE "${PROJECT_BINARY_DIR}/vsomeipTargets.cmake")
+  export(PACKAGE vsomeip3-compat)
 
   configure_file(vsomeipConfig.cmake.in "${PROJECT_BINARY_DIR}/vsomeipConfig.cmake" @ONLY)
   configure_file(vsomeipConfigVersion.cmake.in "${PROJECT_BINARY_DIR}/vsomeipConfigVersion.cmake" @ONLY)
 
-  set(COMPAT_INSTALL_CMAKE_DIR "lib/cmake/${VSOMEIP_COMPAT_NAME}")
+  set(COMPAT_INSTALL_CMAKE_DIR "lib/cmake/vsomeip3-compat")
 
   install(
     EXPORT
@@ -682,24 +709,24 @@ install(
 )
 
 # Add all targets to the build-tree export set
-export(TARGETS ${VSOMEIP_NAME} FILE "${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}Targets.cmake")
+export(TARGETS vsomeip3 FILE "${PROJECT_BINARY_DIR}/vsomeip3Targets.cmake")
 
 # Export the package for use from the build-tree (this registers the build-tree with a global CMake-registry)
-export(PACKAGE ${VSOMEIP_NAME})
+export(PACKAGE vsomeip3)
 
-# Create the ${VSOMEIP_NAME}Config.cmake and ${VSOMEIP_NAME}ConfigVersion files
-configure_file(${VSOMEIP_NAME}Config.cmake.in "${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}Config.cmake" @ONLY)
-configure_file(${VSOMEIP_NAME}ConfigVersion.cmake.in "${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}ConfigVersion.cmake" @ONLY)
+# Create the vsomeip3Config.cmake and vsomeip3ConfigVersion files
+configure_file(vsomeip3Config.cmake.in "${PROJECT_BINARY_DIR}/vsomeip3Config.cmake" @ONLY)
+configure_file(vsomeip3ConfigVersion.cmake.in "${PROJECT_BINARY_DIR}/vsomeip3ConfigVersion.cmake" @ONLY)
 
 # configure internal.hpp for correct version number
 configure_file(
   "${PROJECT_SOURCE_DIR}/implementation/configuration/include/internal.hpp.in"
-  "${PROJECT_SOURCE_DIR}/implementation/configuration/include/internal.hpp"
+  "${PROJECT_BINARY_DIR}/implementation/configuration/include/internal.hpp"
 )
 
-# Install the ${VSOMEIP_NAME}Config.cmake and ${VSOMEIP_NAME}ConfigVersion.cmake
+# Install the vsomeip3Config.cmake and vsomeip3ConfigVersion.cmake
 install(
-  FILES "${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}Config.cmake" "${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}ConfigVersion.cmake"
+  FILES "${PROJECT_BINARY_DIR}/vsomeip3Config.cmake" "${PROJECT_BINARY_DIR}/vsomeip3ConfigVersion.cmake"
         DESTINATION "${INSTALL_CMAKE_DIR}"
         COMPONENT dev
 )
@@ -707,7 +734,7 @@ install(
 # Install the export set for use with the install-tree
 install(
   EXPORT
-  ${VSOMEIP_NAME}Targets
+  vsomeip3Targets
   DESTINATION
   "${INSTALL_CMAKE_DIR}"
   COMPONENT
@@ -778,8 +805,8 @@ endif()
 # ######################################################################################################################
 # create pkg-config file
 if(NOT WIN32)
-  configure_file(${VSOMEIP_NAME}.pc.in ${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}.pc @ONLY)
-  install(FILES ${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}.pc DESTINATION lib/pkgconfig)
+  configure_file(vsomeip3.pc.in ${PROJECT_BINARY_DIR}/vsomeip3.pc @ONLY)
+  install(FILES ${PROJECT_BINARY_DIR}/vsomeip3.pc DESTINATION lib/pkgconfig)
 endif()
 
 # ######################################################################################################################
@@ -797,6 +824,7 @@ add_custom_target(examples)
 add_subdirectory(examples EXCLUDE_FROM_ALL)
 
 # ######################################################################################################################
+
 # add test directory
 enable_testing()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,10 +21,14 @@ if(NOT GTEST_ROOT)
   if(DEFINED ENV{GTEST_ROOT})
     set(GTEST_ROOT $ENV{GTEST_ROOT})
   else()
-    set(GTEST_ROOT
-        "n/a"
-        CACHE STRING "Path to root folder of googletest. Must be set for building the tests."
+    include(FetchContent)
+    FetchContent_Declare(
+      googletest
+      GIT_REPOSITORY https://github.com/google/googletest.git
+      GIT_TAG v1.14.0
     )
+    FetchContent_Populate(googletest)
+    set(GTEST_ROOT ${googletest_SOURCE_DIR})
   endif()
 endif()
 
@@ -105,11 +109,8 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
   set(NO_DEPRECATED "")
   set(OPTIMIZE "")
-  if(NOT DEFINED _FORTIFY_SOURCE)
-    set(_FORTIFY_SOURCE 2)
-  endif()
   set(OS_CXX_FLAGS
-      "${OS_CXX_FLAGS} -D_GLIBCXX_USE_NANOSLEEP -pthread -O -Wall -Wextra -Wformat -Wformat-security -Wconversion -fexceptions -fstrict-aliasing -fstack-protector-strong -fasynchronous-unwind-tables -fno-omit-frame-pointer -D_FORTIFY_SOURCE=${_FORTIFY_SOURCE} -Wformat -Wformat-security -Wpedantic -Werror -fPIE"
+      "${OS_CXX_FLAGS} -D_GLIBCXX_USE_NANOSLEEP -pthread -O -Wall -Wextra -Wformat -Wformat-security -Wconversion -fexceptions -fstrict-aliasing -fstack-protector-strong -fasynchronous-unwind-tables -fno-omit-frame-pointer -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Wpedantic -Werror -fPIE"
   )
 
   # force all use of std::mutex and std::recursive_mutex to use runtime init instead of static initialization so mutexes
@@ -287,14 +288,14 @@ if(MSVC)
   # Disable warning C4250 since it warns that the compiler is correctly following the C++ Standard. It's a
   # "We-Are-Doing-Things-By-The-Book" notice, not a real warning.
   set(CMAKE_CXX_FLAGS
-      "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS -D_WIN32_WINNT=${BOOST_WINDOWS_VERSION} -DWIN32 -DBOOST_ASIO_DISABLE_IOCP /EHsc /wd4250"
+      "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS -D_WIN32_WINNT=${BOOST_WINDOWS_VERSION} -DWIN32 -DBOOST_ASIO_DISABLE_IOCP /EHsc /std:c++14 /wd4250"
   )
   set(USE_RT "")
   link_directories(${Boost_LIBRARY_DIR_DEBUG})
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
   set(USE_RT "")
 else()
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OS_CXX_FLAGS} -g ${OPTIMIZE} ${NO_DEPRECATED} ${EXPORTSYMBOLS}")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OS_CXX_FLAGS} -g ${OPTIMIZE} -std=c++17 ${NO_DEPRECATED} ${EXPORTSYMBOLS}")
   set(USE_RT "rt")
 endif()
 
@@ -310,7 +311,6 @@ if(VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS EQUAL 0)
     VERSION ${VSOMEIP_VERSION}
     SOVERSION ${VSOMEIP_MAJOR_VERSION}
   )
-  target_compile_features(${VSOMEIP_NAME}-cfg PRIVATE cxx_std_17)
   if(MSVC)
     set_target_properties(${VSOMEIP_NAME}-cfg PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION_PLUGIN")
   endif()
@@ -363,7 +363,6 @@ set_target_properties(
   VERSION ${VSOMEIP_VERSION}
   SOVERSION ${VSOMEIP_MAJOR_VERSION}
 )
-target_compile_features(${VSOMEIP_NAME} PRIVATE cxx_std_17)
 if(MSVC)
   set_target_properties(${VSOMEIP_NAME} PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION")
 else()
@@ -402,7 +401,6 @@ file(GLOB ${VSOMEIP_NAME}-sd_SRC "implementation/service_discovery/src/*.cpp")
 list(SORT ${VSOMEIP_NAME}-sd_SRC)
 
 add_library(${VSOMEIP_NAME}-sd SHARED ${${VSOMEIP_NAME}-sd_SRC})
-target_compile_features(${VSOMEIP_NAME}-sd PRIVATE cxx_std_17)
 set_target_properties(
   ${VSOMEIP_NAME}-sd PROPERTIES
   VERSION ${VSOMEIP_VERSION}
@@ -429,7 +427,6 @@ file(GLOB_RECURSE ${VSOMEIP_NAME}-e2e_SRC "implementation/e2e_protection/src/*.c
 list(SORT ${VSOMEIP_NAME}-e2e_SRC)
 
 add_library(${VSOMEIP_NAME}-e2e SHARED ${${VSOMEIP_NAME}-e2e_SRC})
-target_compile_features(${VSOMEIP_NAME}-e2e PRIVATE cxx_std_17)
 set_target_properties(
   ${VSOMEIP_NAME}-e2e PROPERTIES
   VERSION ${VSOMEIP_VERSION}
@@ -470,7 +467,6 @@ if(VSOMEIP_ENABLE_COMPAT EQUAL 1)
   list(SORT ${VSOMEIP_COMPAT_NAME}_SRC)
 
   add_library(${VSOMEIP_COMPAT_NAME} SHARED ${${VSOMEIP_COMPAT_NAME}_SRC})
-  target_compile_features(${VSOMEIP_COMPAT_NAME} PRIVATE cxx_std_17)
   set_target_properties(
     ${VSOMEIP_COMPAT_NAME} PROPERTIES
     VERSION ${VSOMEIP_COMPAT_VERSION}
@@ -596,7 +592,8 @@ endforeach()
 install(
   TARGETS ${VSOMEIP_NAME}
           # IMPORTANT: Add the vsomeip library to the "export-set"
-          EXPORT ${VSOMEIP_NAME}Targets
+          EXPORT
+          ${VSOMEIP_NAME}Targets
           RUNTIME
           DESTINATION "${INSTALL_BIN_DIR}"
           COMPONENT
@@ -640,7 +637,8 @@ install(
 if(VSOMEIP_ENABLE_COMPAT EQUAL 1)
   install(
     TARGETS ${VSOMEIP_COMPAT_NAME}
-            EXPORT vsomeipTargets
+            EXPORT
+            vsomeipTargets
             LIBRARY
             DESTINATION "${INSTALL_LIB_DIR}"
             COMPONENT shlib

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,202 +1,238 @@
-# Copyright (C) 2015-2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright (C) 2015-2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG) This Source Code Form is subject to the
+# terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required (VERSION 3.13)
-project (vsomeip)
+cmake_minimum_required(VERSION 3.13)
+project(vsomeip)
 
-set (VSOMEIP_NAME vsomeip3)
-set (VSOMEIP_COMPAT_NAME vsomeip)
+set(VSOMEIP_NAME vsomeip3)
+set(VSOMEIP_COMPAT_NAME vsomeip)
 
-set (VSOMEIP_MAJOR_VERSION 3)
-set (VSOMEIP_MINOR_VERSION 4)
-set (VSOMEIP_PATCH_VERSION 10)
-set (VSOMEIP_HOTFIX_VERSION 0)
+set(VSOMEIP_MAJOR_VERSION 3)
+set(VSOMEIP_MINOR_VERSION 4)
+set(VSOMEIP_PATCH_VERSION 10)
+set(VSOMEIP_HOTFIX_VERSION 0)
 
-set (VSOMEIP_VERSION ${VSOMEIP_MAJOR_VERSION}.${VSOMEIP_MINOR_VERSION}.${VSOMEIP_PATCH_VERSION})
-set (PACKAGE_VERSION ${VSOMEIP_VERSION}) # Used in documentation/doxygen.in
-set (CMAKE_VERBOSE_MAKEFILE off)
+set(VSOMEIP_VERSION ${VSOMEIP_MAJOR_VERSION}.${VSOMEIP_MINOR_VERSION}.${VSOMEIP_PATCH_VERSION})
+set(PACKAGE_VERSION ${VSOMEIP_VERSION}) # Used in documentation/doxygen.in
+set(CMAKE_VERBOSE_MAKEFILE off)
 
-if (NOT GTEST_ROOT)
-    if (DEFINED ENV{GTEST_ROOT})
-        set(GTEST_ROOT $ENV{GTEST_ROOT})
-    else()
-        set(GTEST_ROOT "n/a" CACHE STRING "Path to root folder of googletest. Must be set for building the tests.")
-    endif()
+if(NOT GTEST_ROOT)
+  if(DEFINED ENV{GTEST_ROOT})
+    set(GTEST_ROOT $ENV{GTEST_ROOT})
+  else()
+    set(GTEST_ROOT
+        "n/a"
+        CACHE STRING "Path to root folder of googletest. Must be set for building the tests."
+    )
+  endif()
 endif()
 
-###################################################################################################
+# ######################################################################################################################
 # see http://www.cmake.org/Wiki/CMake/Tutorials/How_to_create_a_ProjectConfig.cmake_file
-###################################################################################################
+# ######################################################################################################################
 
 # Offer the user the choice of overriding the installation directories
-set (INSTALL_LIB_DIR lib CACHE PATH "Installation directory for libraries")
-set (INSTALL_BIN_DIR bin CACHE PATH "Installation directory for executables")
-set (INSTALL_INCLUDE_DIR include CACHE PATH "Installation directory for header files")
+set(INSTALL_LIB_DIR
+    lib
+    CACHE PATH "Installation directory for libraries"
+)
+set(INSTALL_BIN_DIR
+    bin
+    CACHE PATH "Installation directory for executables"
+)
+set(INSTALL_INCLUDE_DIR
+    include
+    CACHE PATH "Installation directory for header files"
+)
 
-if (WIN32 AND NOT CYGWIN)
-    set (DEF_INSTALL_CMAKE_DIR CMake)
-else ()
-    set (DEF_INSTALL_CMAKE_DIR lib/cmake/${VSOMEIP_NAME})
-endif ()
+if(WIN32 AND NOT CYGWIN)
+  set(DEF_INSTALL_CMAKE_DIR CMake)
+else()
+  set(DEF_INSTALL_CMAKE_DIR lib/cmake/${VSOMEIP_NAME})
+endif()
 
-set (INSTALL_CMAKE_DIR ${DEF_INSTALL_CMAKE_DIR} CACHE PATH "Installation directory for CMake files")
+set(INSTALL_CMAKE_DIR
+    ${DEF_INSTALL_CMAKE_DIR}
+    CACHE PATH "Installation directory for CMake files"
+)
 
 # Make relative paths absolute (needed later on)
-foreach (p LIB BIN INCLUDE CMAKE)
-    set (var INSTALL_${p}_DIR)
-    if (NOT IS_ABSOLUTE "${${var}}")
-        set (ABSOLUTE_${var} "${CMAKE_INSTALL_PREFIX}/${${var}}") # Add all targets to the build-tree export set
-    endif ()
-endforeach ()
+foreach(
+  p
+  LIB
+  BIN
+  INCLUDE
+  CMAKE
+)
+  set(var INSTALL_${p}_DIR)
+  if(NOT IS_ABSOLUTE "${${var}}")
+    set(ABSOLUTE_${var} "${CMAKE_INSTALL_PREFIX}/${${var}}") # Add all targets to the build-tree export set
+  endif()
+endforeach()
 
-###################################################################################################
+# ######################################################################################################################
 # Set a default build type if none was specified
 set(default_build_type "RelWithDebInfo")
 if(NOT CMAKE_BUILD_TYPE)
   message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
-  set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE STRING "Choose the type of build." FORCE)
+  set(CMAKE_BUILD_TYPE
+      "${default_build_type}"
+      CACHE STRING "Choose the type of build." FORCE
+  )
   # Set the possible values of build type for cmake-gui
-  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+  set_property(
+    CACHE CMAKE_BUILD_TYPE
+    PROPERTY STRINGS
+             "Debug"
+             "Release"
+             "MinSizeRel"
+             "RelWithDebInfo"
+  )
 endif()
 
 set(CMAKE_CXX_STANDARD 17)
 
 # OS
-if (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-    set(DL_LIBRARY "dl")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  set(DL_LIBRARY "dl")
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # This is only relevant for GCC and causes warnings on Clang
     set(EXPORTSYMBOLS "-Wl,-export-dynamic -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/exportmap.gcc")
     set(OS_CXX_FLAGS "${OS_CXX_FLAGS} -pie -Wno-tsan -Wl,-z,relro,-z,now")
-endif()
-
-    set(NO_DEPRECATED "")
-    set(OPTIMIZE "")
-  if(NOT DEFINED _FORTIFY_SOURCE)
-      set(_FORTIFY_SOURCE 2)
   endif()
-    set(OS_CXX_FLAGS "${OS_CXX_FLAGS} -D_GLIBCXX_USE_NANOSLEEP -pthread -O -Wall -Wextra -Wformat -Wformat-security -Wconversion -fexceptions -fstrict-aliasing -fstack-protector-strong -fasynchronous-unwind-tables -fno-omit-frame-pointer -D_FORTIFY_SOURCE=${_FORTIFY_SOURCE} -Wformat -Wformat-security -Wpedantic -Werror -fPIE")
 
-    # force all use of std::mutex and std::recursive_mutex to use runtime init
-    # instead of static initialization so mutexes can be hooked to enable PI as needed
-    add_definitions(-D_GTHREAD_USE_MUTEX_INIT_FUNC -D_GTHREAD_USE_RECURSIVE_MUTEX_INIT_FUNC)
-endif (${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  set(NO_DEPRECATED "")
+  set(OPTIMIZE "")
+  if(NOT DEFINED _FORTIFY_SOURCE)
+    set(_FORTIFY_SOURCE 2)
+  endif()
+  set(OS_CXX_FLAGS
+      "${OS_CXX_FLAGS} -D_GLIBCXX_USE_NANOSLEEP -pthread -O -Wall -Wextra -Wformat -Wformat-security -Wconversion -fexceptions -fstrict-aliasing -fstack-protector-strong -fasynchronous-unwind-tables -fno-omit-frame-pointer -D_FORTIFY_SOURCE=${_FORTIFY_SOURCE} -Wformat -Wformat-security -Wpedantic -Werror -fPIE"
+  )
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-    set(DL_LIBRARY "")
-    set(EXPORTSYMBOLS "")
-    set(NO_DEPRECATED "-Wno-deprecated")
-    set(OPTIMIZE "")
-    set(OS_CXX_FLAGS "-pthread")
-endif (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+  # force all use of std::mutex and std::recursive_mutex to use runtime init instead of static initialization so mutexes
+  # can be hooked to enable PI as needed
+  add_definitions(-D_GTHREAD_USE_MUTEX_INIT_FUNC -D_GTHREAD_USE_RECURSIVE_MUTEX_INIT_FUNC)
+endif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 
-############################################My lib link flags####################################
+if(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+  set(DL_LIBRARY "")
+  set(EXPORTSYMBOLS "")
+  set(NO_DEPRECATED "-Wno-deprecated")
+  set(OPTIMIZE "")
+  set(OS_CXX_FLAGS "-pthread")
+endif(${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+
+# ###########################################My lib link flags####################################
 # Options
-################################################################################
+# ######################################################################################################################
 
 # DLT
-if (DISABLE_DLT)
-set (VSOMEIP_ENABLE_DLT 0)
-else ()
-set (VSOMEIP_ENABLE_DLT 1)
-endif ()
+if(DISABLE_DLT)
+  set(VSOMEIP_ENABLE_DLT 0)
+else()
+  set(VSOMEIP_ENABLE_DLT 1)
+endif()
 
 # Signal handling
-if (ENABLE_SIGNAL_HANDLING)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVSOMEIP_ENABLE_SIGNAL_HANDLING")
-endif ()
+if(ENABLE_SIGNAL_HANDLING)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVSOMEIP_ENABLE_SIGNAL_HANDLING")
+endif()
 
-if (NOT MSVC)
-    # Sanitizers
+if(NOT MSVC)
+  # Sanitizers
 
-    if (ENABLE_UNDEFINED_SANITIZER)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined")
-    endif ()
+  if(ENABLE_UNDEFINED_SANITIZER)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined")
+  endif()
 
-    if (ENABLE_THREAD_SANITIZER)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread")
-    endif ()
+  if(ENABLE_THREAD_SANITIZER)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread")
+  endif()
 
-    if (ENABLE_LEAK_SANITIZER)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=leak")
-    endif ()
+  if(ENABLE_LEAK_SANITIZER)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=leak")
+  endif()
 
-    if (ENABLE_ADDRESS_SANITIZER)
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
-    endif ()
+  if(ENABLE_ADDRESS_SANITIZER)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+  endif()
 
-    if (ENABLE_PROFILING)
-        set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pg")
-    endif ()
-endif (NOT MSVC)
+  if(ENABLE_PROFILING)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pg")
+  endif()
+endif(NOT MSVC)
 
 # Compatibility
-if (ENABLE_COMPAT)
-set (VSOMEIP_ENABLE_COMPAT 1)
-else ()
-set (VSOMEIP_ENABLE_COMPAT 0)
-endif ()
+if(ENABLE_COMPAT)
+  set(VSOMEIP_ENABLE_COMPAT 1)
+else()
+  set(VSOMEIP_ENABLE_COMPAT 0)
+endif()
 
 # Multiple routing managers
-if (ENABLE_MULTIPLE_ROUTING_MANAGERS)
-set (VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS 1)
-else ()
-set (VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS 0)
-endif ()
+if(ENABLE_MULTIPLE_ROUTING_MANAGERS)
+  set(VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS 1)
+else()
+  set(VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS 0)
+endif()
 
 # Security / Policy handling
-if (DISABLE_SECURITY)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVSOMEIP_DISABLE_SECURITY")
-endif ()
+if(DISABLE_SECURITY)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVSOMEIP_DISABLE_SECURITY")
+endif()
 
 # Suppress deprecation warnings for vSomeIP interfaces
 add_definitions(-DVSOMEIP_INTERNAL_SUPPRESS_DEPRECATED)
 
-################################################################################
+# ######################################################################################################################
 # Dependencies
-################################################################################
+# ######################################################################################################################
 
 # Threads
 find_package(Threads REQUIRED)
 
 # Boost
-find_package( Boost 1.55 COMPONENTS system thread filesystem REQUIRED )
+find_package(
+  Boost 1.55
+  COMPONENTS system thread filesystem
+  REQUIRED
+)
 if(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
-    include_directories(${Boost_INCLUDE_DIR} )
+  include_directories(${Boost_INCLUDE_DIR})
 else()
-    include_directories(SYSTEM ${Boost_INCLUDE_DIR} )
+  include_directories(SYSTEM ${Boost_INCLUDE_DIR})
 endif()
 
 if(Boost_FOUND)
   if(Boost_LIBRARY_DIR)
-    MESSAGE( STATUS "Boost_LIBRARY_DIR not empty using it: ${Boost_LIBRARY_DIR}" )
+    message(STATUS "Boost_LIBRARY_DIR not empty using it: ${Boost_LIBRARY_DIR}")
   else()
     if(BOOST_LIBRARYDIR)
-      MESSAGE( STATUS "Boost_LIBRARY_DIR empty but BOOST_LIBRARYDIR is set setting Boost_LIBRARY_DIR to: ${BOOST_LIBRARYDIR}" )
+      message(
+        STATUS "Boost_LIBRARY_DIR empty but BOOST_LIBRARYDIR is set setting Boost_LIBRARY_DIR to: ${BOOST_LIBRARYDIR}"
+      )
       set(Boost_LIBRARY_DIR ${BOOST_LIBRARYDIR})
     endif()
   endif()
 else()
-  MESSAGE( STATUS "Boost was not found!")
+  message(STATUS "Boost was not found!")
 endif()
 
 # cmake 3.15 introduced a new variable and a new format for the old one
-if (DEFINED Boost_VERSION_MACRO)
+if(DEFINED Boost_VERSION_MACRO)
   set(VSOMEIP_BOOST_VERSION ${Boost_VERSION_MACRO})
 else()
   set(VSOMEIP_BOOST_VERSION ${Boost_VERSION})
 endif()
 
-message( STATUS "Using boost version: ${VSOMEIP_BOOST_VERSION}" )
+message(STATUS "Using boost version: ${VSOMEIP_BOOST_VERSION}")
 
-if (${VSOMEIP_BOOST_VERSION} LESS 106600)
-include_directories(SYSTEM
-    implementation/helper
-)
-endif ()
+if(${VSOMEIP_BOOST_VERSION} LESS 106600)
+  include_directories(SYSTEM implementation/helper)
+endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVSOMEIP_BOOST_VERSION=${VSOMEIP_BOOST_VERSION}")
 
@@ -204,203 +240,266 @@ find_package(PkgConfig)
 
 # DLT
 if(VSOMEIP_ENABLE_DLT EQUAL 1)
-pkg_check_modules(DLT "automotive-dlt >= 2.11")
-if(DLT_FOUND)
-     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_DLT")
-endif(DLT_FOUND)
+  pkg_check_modules(DLT "automotive-dlt >= 2.11")
+  if(DLT_FOUND)
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_DLT")
+  endif(DLT_FOUND)
 endif()
 
 # SystemD
 pkg_check_modules(SystemD "libsystemd")
 
 if(NOT SystemD_FOUND)
-MESSAGE( STATUS "Systemd was not found, watchdog disabled!")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWITHOUT_SYSTEMD")
+  message(STATUS "Systemd was not found, watchdog disabled!")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DWITHOUT_SYSTEMD")
 endif(NOT SystemD_FOUND)
 
 # Multiple routing managers
-if (VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS EQUAL 1)
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS")
-endif ()
+if(VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS EQUAL 1)
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS")
+endif()
 
-################################################################################
+# ######################################################################################################################
 # Directories
-################################################################################
+# ######################################################################################################################
 
-include_directories(
-    interface
-)
+include_directories(interface)
 
-include_directories(SYSTEM
-    ${DLT_INCLUDE_DIRS}
-)
+include_directories(SYSTEM ${DLT_INCLUDE_DIRS})
 
-link_directories(
-    ${DLT_LIBDIR}
-)
+link_directories(${DLT_LIBDIR})
 
-if (${VSOMEIP_HOTFIX_VERSION} EQUAL 0)
-add_definitions(-DVSOMEIP_VERSION="${VSOMEIP_VERSION}")
+if(${VSOMEIP_HOTFIX_VERSION} EQUAL 0)
+  add_definitions(-DVSOMEIP_VERSION="${VSOMEIP_VERSION}")
 else()
-add_definitions(-DVSOMEIP_VERSION="${VSOMEIP_VERSION}.${VSOMEIP_HOTFIX_VERSION}")
+  add_definitions(-DVSOMEIP_VERSION="${VSOMEIP_VERSION}.${VSOMEIP_HOTFIX_VERSION}")
 endif()
 
-if (MSVC)
-    message("using MSVC Compiler")
-    # add_definitions(-DVSOMEIP_DLL_COMPILATION) now it is controlled per target
-    SET(BOOST_WINDOWS_VERSION "0x600" CACHE STRING "Set the same Version as the Version with which Boost was built, otherwise there will be errors. (normaly 0x600 is for Windows 7 and 0x501 is for Windows XP)")
-    # Disable warning C4250 since it warns that the compiler is correctly following the C++ Standard. It's a "We-Are-Doing-Things-By-The-Book" notice, not a real warning.
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS -D_WIN32_WINNT=${BOOST_WINDOWS_VERSION} -DWIN32 -DBOOST_ASIO_DISABLE_IOCP /EHsc /wd4250")
-    set(USE_RT "")
-    link_directories(${Boost_LIBRARY_DIR_DEBUG})
+if(MSVC)
+  message("using MSVC Compiler")
+  # add_definitions(-DVSOMEIP_DLL_COMPILATION) now it is controlled per target
+  set(BOOST_WINDOWS_VERSION
+      "0x600"
+      CACHE
+        STRING
+        "Set the same Version as the Version with which Boost was built, otherwise there will be errors. (normaly 0x600 is for Windows 7 and 0x501 is for Windows XP)"
+  )
+  # Disable warning C4250 since it warns that the compiler is correctly following the C++ Standard. It's a
+  # "We-Are-Doing-Things-By-The-Book" notice, not a real warning.
+  set(CMAKE_CXX_FLAGS
+      "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -D_SCL_SECURE_NO_WARNINGS -D_WINSOCK_DEPRECATED_NO_WARNINGS -D_WIN32_WINNT=${BOOST_WINDOWS_VERSION} -DWIN32 -DBOOST_ASIO_DISABLE_IOCP /EHsc /wd4250"
+  )
+  set(USE_RT "")
+  link_directories(${Boost_LIBRARY_DIR_DEBUG})
 elseif(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
-    set(USE_RT "")
+  set(USE_RT "")
 else()
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OS_CXX_FLAGS} -g ${OPTIMIZE} ${NO_DEPRECATED} ${EXPORTSYMBOLS}")
-    set(USE_RT "rt")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OS_CXX_FLAGS} -g ${OPTIMIZE} ${NO_DEPRECATED} ${EXPORTSYMBOLS}")
+  set(USE_RT "rt")
 endif()
 
-################################################################################
+# ######################################################################################################################
 # Configuration library
-################################################################################
-file(GLOB ${VSOMEIP_NAME}-cfg_SRC
-    "implementation/configuration/src/*.cpp"
-)
+# ######################################################################################################################
+file(GLOB ${VSOMEIP_NAME}-cfg_SRC "implementation/configuration/src/*.cpp")
 list(SORT ${VSOMEIP_NAME}-cfg_SRC)
-if (VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS EQUAL 0)
-    add_library(${VSOMEIP_NAME}-cfg SHARED ${${VSOMEIP_NAME}-cfg_SRC})
-    set_target_properties (${VSOMEIP_NAME}-cfg PROPERTIES VERSION ${VSOMEIP_VERSION} SOVERSION ${VSOMEIP_MAJOR_VERSION})
-    target_compile_features(${VSOMEIP_NAME}-cfg PRIVATE cxx_std_17)
-    if (MSVC)
-        set_target_properties(${VSOMEIP_NAME}-cfg PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION_PLUGIN")
-    endif()
+if(VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS EQUAL 0)
+  add_library(${VSOMEIP_NAME}-cfg SHARED ${${VSOMEIP_NAME}-cfg_SRC})
+  set_target_properties(
+    ${VSOMEIP_NAME}-cfg PROPERTIES
+    VERSION ${VSOMEIP_VERSION}
+    SOVERSION ${VSOMEIP_MAJOR_VERSION}
+  )
+  target_compile_features(${VSOMEIP_NAME}-cfg PRIVATE cxx_std_17)
+  if(MSVC)
+    set_target_properties(${VSOMEIP_NAME}-cfg PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION_PLUGIN")
+  endif()
 
-    target_link_libraries(${VSOMEIP_NAME}-cfg ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${SystemD_LIBRARIES})
-endif ()
-
-################################################################################
-# Base library
-################################################################################
-file(GLOB ${VSOMEIP_NAME}_SRC
-    "implementation/endpoints/src/*.cpp"
-    "implementation/logger/src/*.cpp"
-    "implementation/tracing/src/*.cpp"
-    "implementation/message/src/*.cpp"
-    "implementation/plugin/src/*.cpp"
-    "implementation/protocol/src/*.cpp"
-    "implementation/routing/src/*.cpp"
-    "implementation/runtime/src/*.cpp"
-    "implementation/security/src/*.cpp"
-    "implementation/utility/src/*.cpp"
-)
-if (VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS EQUAL 1)
-list(APPEND ${VSOMEIP_NAME}_SRC "implementation/configuration/src/configuration_impl.cpp")
+  target_link_libraries(
+    ${VSOMEIP_NAME}-cfg
+    ${VSOMEIP_NAME}
+    ${Boost_LIBRARIES}
+    ${USE_RT}
+    ${DL_LIBRARY}
+    ${SystemD_LIBRARIES}
+  )
 endif()
 
-if (WIN32)
-list(FILTER ${VSOMEIP_NAME}_SRC EXCLUDE REGEX ".*uds.*")
+# ######################################################################################################################
+# Base library
+# ######################################################################################################################
+file(
+  GLOB
+  ${VSOMEIP_NAME}_SRC
+  "implementation/endpoints/src/*.cpp"
+  "implementation/logger/src/*.cpp"
+  "implementation/tracing/src/*.cpp"
+  "implementation/message/src/*.cpp"
+  "implementation/plugin/src/*.cpp"
+  "implementation/protocol/src/*.cpp"
+  "implementation/routing/src/*.cpp"
+  "implementation/runtime/src/*.cpp"
+  "implementation/security/src/*.cpp"
+  "implementation/utility/src/*.cpp"
+)
+if(VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS EQUAL 1)
+  list(APPEND ${VSOMEIP_NAME}_SRC "implementation/configuration/src/configuration_impl.cpp")
+endif()
+
+if(WIN32)
+  list(
+    FILTER ${VSOMEIP_NAME}_SRC
+           EXCLUDE
+           REGEX
+           ".*uds.*"
+  )
 endif()
 
 list(SORT ${VSOMEIP_NAME}_SRC)
 
 add_library(${VSOMEIP_NAME} SHARED ${${VSOMEIP_NAME}_SRC})
-set_target_properties (${VSOMEIP_NAME} PROPERTIES VERSION ${VSOMEIP_VERSION} SOVERSION ${VSOMEIP_MAJOR_VERSION})
+set_target_properties(
+  ${VSOMEIP_NAME} PROPERTIES
+  VERSION ${VSOMEIP_VERSION}
+  SOVERSION ${VSOMEIP_MAJOR_VERSION}
+)
 target_compile_features(${VSOMEIP_NAME} PRIVATE cxx_std_17)
-if (MSVC)
-    set_target_properties(${VSOMEIP_NAME} PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION")
-else ()
-    set_target_properties(${VSOMEIP_NAME} PROPERTIES LINK_FLAGS "-Wl,-wrap,socket -Wl,-wrap,accept -Wl,-wrap,open")
-endif ()
-target_include_directories(${VSOMEIP_NAME} INTERFACE
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/interface>
-    $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
-    $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>)
-# PRIVATE means the listed libraries won't be included in the "link interface",
-# meaning the exported ${VSOMEIP_NAME}Targets.cmake targets won't try to link against
-# them (which shouldn't be required). ${Boost_LIBRARIES} includes absolute
-# build host paths as of writing, which also makes this important as it breaks
-# the build.
-target_link_libraries(${VSOMEIP_NAME} PRIVATE ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${DLT_LIBRARIES} ${SystemD_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+if(MSVC)
+  set_target_properties(${VSOMEIP_NAME} PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION")
+else()
+  set_target_properties(
+    ${VSOMEIP_NAME}
+    PROPERTIES
+    LINK_FLAGS
+    "-Wl,-wrap,socket -Wl,-wrap,accept -Wl,-wrap,open"
+  )
+endif()
+target_include_directories(
+  ${VSOMEIP_NAME} INTERFACE $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/interface> $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}>
+                            $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>
+)
+# PRIVATE means the listed libraries won't be included in the "link interface", meaning the exported
+# ${VSOMEIP_NAME}Targets.cmake targets won't try to link against them (which shouldn't be required). ${Boost_LIBRARIES}
+# includes absolute build host paths as of writing, which also makes this important as it breaks the build.
+target_link_libraries(
+  ${VSOMEIP_NAME}
+  PRIVATE ${Boost_LIBRARIES}
+          ${USE_RT}
+          ${DL_LIBRARY}
+          ${DLT_LIBRARIES}
+          ${SystemD_LIBRARIES}
+          ${CMAKE_THREAD_LIBS_INIT}
+)
 
 if(NOT WIN32)
-    target_link_options(${VSOMEIP_NAME} PRIVATE "LINKER:-as-needed")
+  target_link_options(${VSOMEIP_NAME} PRIVATE "LINKER:-as-needed")
 endif()
 
-################################################################################
+# ######################################################################################################################
 # Service Discovery library
-################################################################################
-file(GLOB ${VSOMEIP_NAME}-sd_SRC
-    "implementation/service_discovery/src/*.cpp"
-)
+# ######################################################################################################################
+file(GLOB ${VSOMEIP_NAME}-sd_SRC "implementation/service_discovery/src/*.cpp")
 list(SORT ${VSOMEIP_NAME}-sd_SRC)
 
 add_library(${VSOMEIP_NAME}-sd SHARED ${${VSOMEIP_NAME}-sd_SRC})
 target_compile_features(${VSOMEIP_NAME}-sd PRIVATE cxx_std_17)
-set_target_properties (${VSOMEIP_NAME}-sd PROPERTIES VERSION ${VSOMEIP_VERSION} SOVERSION ${VSOMEIP_MAJOR_VERSION})
-if (MSVC)
-    set_target_properties(${VSOMEIP_NAME}-sd PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION_PLUGIN")
-endif ()
-
-target_link_libraries(${VSOMEIP_NAME}-sd ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${SystemD_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-
-
-################################################################################
-# E2E library
-################################################################################
-file(GLOB_RECURSE ${VSOMEIP_NAME}-e2e_SRC
-    "implementation/e2e_protection/src/*.cpp"
+set_target_properties(
+  ${VSOMEIP_NAME}-sd PROPERTIES
+  VERSION ${VSOMEIP_VERSION}
+  SOVERSION ${VSOMEIP_MAJOR_VERSION}
 )
+if(MSVC)
+  set_target_properties(${VSOMEIP_NAME}-sd PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION_PLUGIN")
+endif()
+
+target_link_libraries(
+  ${VSOMEIP_NAME}-sd
+  ${VSOMEIP_NAME}
+  ${Boost_LIBRARIES}
+  ${USE_RT}
+  ${DL_LIBRARY}
+  ${SystemD_LIBRARIES}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
+
+# ######################################################################################################################
+# E2E library
+# ######################################################################################################################
+file(GLOB_RECURSE ${VSOMEIP_NAME}-e2e_SRC "implementation/e2e_protection/src/*.cpp")
 list(SORT ${VSOMEIP_NAME}-e2e_SRC)
 
 add_library(${VSOMEIP_NAME}-e2e SHARED ${${VSOMEIP_NAME}-e2e_SRC})
 target_compile_features(${VSOMEIP_NAME}-e2e PRIVATE cxx_std_17)
-set_target_properties (${VSOMEIP_NAME}-e2e PROPERTIES VERSION ${VSOMEIP_VERSION} SOVERSION ${VSOMEIP_MAJOR_VERSION})
-if (MSVC)
-    set_target_properties(${VSOMEIP_NAME}-e2e PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION_PLUGIN")
-endif ()
+set_target_properties(
+  ${VSOMEIP_NAME}-e2e PROPERTIES
+  VERSION ${VSOMEIP_VERSION}
+  SOVERSION ${VSOMEIP_MAJOR_VERSION}
+)
+if(MSVC)
+  set_target_properties(${VSOMEIP_NAME}-e2e PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION_PLUGIN")
+endif()
 
-target_link_libraries(${VSOMEIP_NAME}-e2e ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${SystemD_LIBRARIES})
+target_link_libraries(
+  ${VSOMEIP_NAME}-e2e
+  ${VSOMEIP_NAME}
+  ${Boost_LIBRARIES}
+  ${USE_RT}
+  ${DL_LIBRARY}
+  ${SystemD_LIBRARIES}
+)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
-    target_link_libraries(${VSOMEIP_NAME}-e2e socket)
+  target_link_libraries(${VSOMEIP_NAME}-e2e socket)
 endif()
-################################################################################
+# ######################################################################################################################
 # Compatibility library
-################################################################################
-if (VSOMEIP_ENABLE_COMPAT EQUAL 1)
-set (VSOMEIP_COMPAT_MAJOR_VERSION 2)
-set (VSOMEIP_COMPAT_VERSION ${VSOMEIP_COMPAT_MAJOR_VERSION}.99.99)
+# ######################################################################################################################
+if(VSOMEIP_ENABLE_COMPAT EQUAL 1)
+  set(VSOMEIP_COMPAT_MAJOR_VERSION 2)
+  set(VSOMEIP_COMPAT_VERSION ${VSOMEIP_COMPAT_MAJOR_VERSION}.99.99)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVSOMEIP_ENABLE_COMPAT")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVSOMEIP_ENABLE_COMPAT")
 
-file(GLOB_RECURSE ${VSOMEIP_COMPAT_NAME}_SRC
+  file(
+    GLOB_RECURSE
+    ${VSOMEIP_COMPAT_NAME}_SRC
     "implementation/compat/logging/src/*.cpp"
     "implementation/compat/message/src/*.cpp"
     "implementation/compat/runtime/src/*.cpp"
-)
-list(SORT ${VSOMEIP_COMPAT_NAME}_SRC)
+  )
+  list(SORT ${VSOMEIP_COMPAT_NAME}_SRC)
 
-add_library(${VSOMEIP_COMPAT_NAME} SHARED ${${VSOMEIP_COMPAT_NAME}_SRC})
-target_compile_features(${VSOMEIP_COMPAT_NAME} PRIVATE cxx_std_17)
-set_target_properties (${VSOMEIP_COMPAT_NAME} PROPERTIES VERSION ${VSOMEIP_COMPAT_VERSION} SOVERSION ${VSOMEIP_COMPAT_MAJOR_VERSION})
-if (MSVC)
+  add_library(${VSOMEIP_COMPAT_NAME} SHARED ${${VSOMEIP_COMPAT_NAME}_SRC})
+  target_compile_features(${VSOMEIP_COMPAT_NAME} PRIVATE cxx_std_17)
+  set_target_properties(
+    ${VSOMEIP_COMPAT_NAME} PROPERTIES
+    VERSION ${VSOMEIP_COMPAT_VERSION}
+    SOVERSION ${VSOMEIP_COMPAT_MAJOR_VERSION}
+  )
+  if(MSVC)
     set_target_properties(${VSOMEIP_COMPAT_NAME} PROPERTIES COMPILE_DEFINITIONS "VSOMEIP_DLL_COMPILATION_PLUGIN")
-endif ()
+  endif()
 
-target_include_directories(
+  target_include_directories(
     ${VSOMEIP_COMPAT_NAME}
-    PUBLIC
-    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/interface/compat>
-    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> # for generated files in build mode
-    $<INSTALL_INTERFACE:include/compat> # for clients in install mode
-)
-target_link_libraries(${VSOMEIP_COMPAT_NAME} PRIVATE ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${SystemD_LIBRARIES})
+    PUBLIC $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/interface/compat>
+           $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}> # for generated files in build mode
+           $<INSTALL_INTERFACE:include/compat> # for clients in install mode
+  )
+  target_link_libraries(
+    ${VSOMEIP_COMPAT_NAME}
+    PRIVATE ${VSOMEIP_NAME}
+            ${Boost_LIBRARIES}
+            ${USE_RT}
+            ${DL_LIBRARY}
+            ${SystemD_LIBRARIES}
+  )
 
-endif ()
+endif()
 
-################################################################################
+# ######################################################################################################################
 # Configuration files
-################################################################################
+# ######################################################################################################################
 set(EXAMPLE_CONFIG_FILES
     "config/vsomeip.json"
     "config/vsomeip-local.json"
@@ -410,51 +509,57 @@ set(EXAMPLE_CONFIG_FILES
     "config/vsomeip-udp-service.json"
 )
 
-################################################################################
+# ######################################################################################################################
 # Configuration parameters
-################################################################################
+# ######################################################################################################################
 if(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
-    set (VSOMEIP_BASE_PATH "/var")
+  set(VSOMEIP_BASE_PATH "/var")
 else()
-    set (VSOMEIP_BASE_PATH "/tmp")
+  set(VSOMEIP_BASE_PATH "/tmp")
 endif()
-if (BASE_PATH)
-set (VSOMEIP_BASE_PATH ${BASE_PATH})
-endif ()
+if(BASE_PATH)
+  set(VSOMEIP_BASE_PATH ${BASE_PATH})
+endif()
 
-set (VSOMEIP_DIAGNOSIS_ADDRESS "0x01")
-if (DIAGNOSIS_ADDRESS)
-set (VSOMEIP_DIAGNOSIS_ADDRESS ${DIAGNOSIS_ADDRESS})
-endif ()
+set(VSOMEIP_DIAGNOSIS_ADDRESS "0x01")
+if(DIAGNOSIS_ADDRESS)
+  set(VSOMEIP_DIAGNOSIS_ADDRESS ${DIAGNOSIS_ADDRESS})
+endif()
 
-set (VSOMEIP_UNICAST_ADDRESS "127.0.0.1")
-if (UNICAST_ADDRESS)
-set (VSOMEIP_UNICAST_ADDRESS ${UNICAST_ADDRESS})
-endif ()
+set(VSOMEIP_UNICAST_ADDRESS "127.0.0.1")
+if(UNICAST_ADDRESS)
+  set(VSOMEIP_UNICAST_ADDRESS ${UNICAST_ADDRESS})
+endif()
 
-set (VSOMEIP_ROUTING_READY_MESSAGE "SOME/IP routing ready.")
-if (ROUTING_READY_MESSAGE)
-set (VSOMEIP_ROUTING_READY_MESSAGE ${ROUTING_READY_MESSAGE})
-endif ()
+set(VSOMEIP_ROUTING_READY_MESSAGE "SOME/IP routing ready.")
+if(ROUTING_READY_MESSAGE)
+  set(VSOMEIP_ROUTING_READY_MESSAGE ${ROUTING_READY_MESSAGE})
+endif()
 
-set (VSOMEIP_LOCAL_TCP_PORT_WAIT_TIME 100)
-if (LOCAL_TCP_PORT_WAIT_TIME)
-set (VSOMEIP_LOCAL_TCP_PORT_WAIT_TIME ${LOCAL_TCP_PORT_WAIT_TIME})
-endif ()
+set(VSOMEIP_LOCAL_TCP_PORT_WAIT_TIME 100)
+if(LOCAL_TCP_PORT_WAIT_TIME)
+  set(VSOMEIP_LOCAL_TCP_PORT_WAIT_TIME ${LOCAL_TCP_PORT_WAIT_TIME})
+endif()
 
-set (VSOMEIP_LOCAL_TCP_PORT_MAX_WAIT_TIME 10000)
-if (LOCAL_TCP_PORT_MAX_WAIT_TIME)
-if (${LOCAL_TCP_PORT_MAX_WAIT_TIME} GREATER ${LOCAL_TCP_PORT_WAIT_TIME})
-set (VSOMEIP_LOCAL_TCP_PORT_MAX_WAIT_TIME ${LOCAL_TCP_PORT_MAX_WAIT_TIME})
-else ()
-set (VSOMEIP_LOCAL_TCP_PORT_MAX_WAIT_TIME ${LOCAL_TCP_PORT_WAIT_TIME})
-endif ()
-endif ()
+set(VSOMEIP_LOCAL_TCP_PORT_MAX_WAIT_TIME 10000)
+if(LOCAL_TCP_PORT_MAX_WAIT_TIME)
+  if(${LOCAL_TCP_PORT_MAX_WAIT_TIME} GREATER ${LOCAL_TCP_PORT_WAIT_TIME})
+    set(VSOMEIP_LOCAL_TCP_PORT_MAX_WAIT_TIME ${LOCAL_TCP_PORT_MAX_WAIT_TIME})
+  else()
+    set(VSOMEIP_LOCAL_TCP_PORT_MAX_WAIT_TIME ${LOCAL_TCP_PORT_WAIT_TIME})
+  endif()
+endif()
 
-set(DEFAULT_CONFIGURATION_FOLDER "/etc/vsomeip" CACHE PATH "Default configuration folder")
+set(DEFAULT_CONFIGURATION_FOLDER
+    "/etc/vsomeip"
+    CACHE PATH "Default configuration folder"
+)
 message(STATUS "Default configuration folder: ${DEFAULT_CONFIGURATION_FOLDER}")
 
-set(DEFAULT_CONFIGURATION_FILE "/etc/vsomeip.json" CACHE FILEPATH "Default configuration file")
+set(DEFAULT_CONFIGURATION_FILE
+    "/etc/vsomeip.json"
+    CACHE FILEPATH "Default configuration file"
+)
 message(STATUS "Default configuration file: ${DEFAULT_CONFIGURATION_FILE}")
 
 message("Predefined base path: ${VSOMEIP_BASE_PATH}")
@@ -462,219 +567,253 @@ message("Predefined unicast address: ${VSOMEIP_UNICAST_ADDRESS}")
 message("Predefined diagnosis address: ${VSOMEIP_DIAGNOSIS_ADDRESS}")
 message("Predefined wait times for internal communication ports (TCP):\
  ${VSOMEIP_LOCAL_TCP_PORT_WAIT_TIME}\
- (max=${VSOMEIP_LOCAL_TCP_PORT_MAX_WAIT_TIME})")
+ (max=${VSOMEIP_LOCAL_TCP_PORT_MAX_WAIT_TIME})"
+)
 
-################################################################################
+# ######################################################################################################################
 # Installation
-################################################################################
+# ######################################################################################################################
 set(INCLUDE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/interface/vsomeip")
 
-file (GLOB_RECURSE vsomeip_INCLUDE RELATIVE ${INCLUDE_PATH} "interface/*.h*"  )
-list (SORT vsomeip_INCLUDE)
+file(
+  GLOB_RECURSE
+  vsomeip_INCLUDE
+  RELATIVE
+  ${INCLUDE_PATH}
+  "interface/*.h*"
+)
+list(SORT vsomeip_INCLUDE)
 
-foreach ( file ${vsomeip_INCLUDE} )
-    get_filename_component( dir ${file} DIRECTORY )
-    install( FILES "${INCLUDE_PATH}/${file}" DESTINATION "${INSTALL_INCLUDE_DIR}/vsomeip/${dir}" COMPONENT dev)
+foreach(file ${vsomeip_INCLUDE})
+  get_filename_component(dir ${file} DIRECTORY)
+  install(
+    FILES "${INCLUDE_PATH}/${file}"
+          DESTINATION "${INSTALL_INCLUDE_DIR}/vsomeip/${dir}"
+          COMPONENT dev
+  )
 endforeach()
 
-install (
-    TARGETS ${VSOMEIP_NAME}
-    # IMPORTANT: Add the vsomeip library to the "export-set"
-    EXPORT ${VSOMEIP_NAME}Targets
-    RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT
-    LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT
-    ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
-    COMPONENT dev
+install(
+  TARGETS ${VSOMEIP_NAME}
+          # IMPORTANT: Add the vsomeip library to the "export-set"
+          EXPORT ${VSOMEIP_NAME}Targets
+          RUNTIME
+          DESTINATION "${INSTALL_BIN_DIR}"
+          COMPONENT
+          LIBRARY
+          DESTINATION "${INSTALL_LIB_DIR}"
+          COMPONENT
+          ARCHIVE
+          DESTINATION "${INSTALL_LIB_DIR}"
+          COMPONENT dev
 )
 
-install (
-    TARGETS ${VSOMEIP_NAME}-e2e
-    LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT shlib
-    RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
+install(
+  TARGETS ${VSOMEIP_NAME}-e2e LIBRARY
+          DESTINATION "${INSTALL_LIB_DIR}"
+          COMPONENT shlib
+          RUNTIME
+          DESTINATION "${INSTALL_BIN_DIR}"
+          COMPONENT bin
 )
 
-if (VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS EQUAL 0)
-install (
-    TARGETS ${VSOMEIP_NAME}-cfg
-    LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT shlib
-    RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
-)
-endif ()
+if(VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS EQUAL 0)
+  install(
+    TARGETS ${VSOMEIP_NAME}-cfg LIBRARY
+            DESTINATION "${INSTALL_LIB_DIR}"
+            COMPONENT shlib
+            RUNTIME
+            DESTINATION "${INSTALL_BIN_DIR}"
+            COMPONENT bin
+  )
+endif()
 
-install (
-    TARGETS ${VSOMEIP_NAME}-sd
-    LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT shlib
-    RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
+install(
+  TARGETS ${VSOMEIP_NAME}-sd LIBRARY
+          DESTINATION "${INSTALL_LIB_DIR}"
+          COMPONENT shlib
+          RUNTIME
+          DESTINATION "${INSTALL_BIN_DIR}"
+          COMPONENT bin
 )
 
-if (VSOMEIP_ENABLE_COMPAT EQUAL 1)
-install (
+if(VSOMEIP_ENABLE_COMPAT EQUAL 1)
+  install(
     TARGETS ${VSOMEIP_COMPAT_NAME}
-    EXPORT vsomeipTargets
-    LIBRARY DESTINATION "${INSTALL_LIB_DIR}" COMPONENT shlib
-    RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
-)
+            EXPORT vsomeipTargets
+            LIBRARY
+            DESTINATION "${INSTALL_LIB_DIR}"
+            COMPONENT shlib
+            RUNTIME
+            DESTINATION "${INSTALL_BIN_DIR}"
+            COMPONENT bin
+  )
 
-export (TARGETS ${VSOMEIP_COMPAT_NAME} FILE "${PROJECT_BINARY_DIR}/vsomeipTargets.cmake")
-export (PACKAGE ${VSOMEIP_COMPAT_NAME})
+  export(TARGETS ${VSOMEIP_COMPAT_NAME} FILE "${PROJECT_BINARY_DIR}/vsomeipTargets.cmake")
+  export(PACKAGE ${VSOMEIP_COMPAT_NAME})
 
-configure_file (vsomeipConfig.cmake.in "${PROJECT_BINARY_DIR}/vsomeipConfig.cmake" @ONLY)
-configure_file (vsomeipConfigVersion.cmake.in "${PROJECT_BINARY_DIR}/vsomeipConfigVersion.cmake" @ONLY)
+  configure_file(vsomeipConfig.cmake.in "${PROJECT_BINARY_DIR}/vsomeipConfig.cmake" @ONLY)
+  configure_file(vsomeipConfigVersion.cmake.in "${PROJECT_BINARY_DIR}/vsomeipConfigVersion.cmake" @ONLY)
 
-set (COMPAT_INSTALL_CMAKE_DIR "lib/cmake/${VSOMEIP_COMPAT_NAME}")
+  set(COMPAT_INSTALL_CMAKE_DIR "lib/cmake/${VSOMEIP_COMPAT_NAME}")
 
-install (
-    EXPORT vsomeipTargets
-    DESTINATION "${COMPAT_INSTALL_CMAKE_DIR}"
-    COMPONENT dev
-)
+  install(
+    EXPORT
+    vsomeipTargets
+    DESTINATION
+    "${COMPAT_INSTALL_CMAKE_DIR}"
+    COMPONENT
+    dev
+  )
 
-install (
-    FILES
-    "${PROJECT_BINARY_DIR}/vsomeipConfig.cmake"
-    "${PROJECT_BINARY_DIR}/vsomeipConfigVersion.cmake"
-    DESTINATION "${COMPAT_INSTALL_CMAKE_DIR}"
-    COMPONENT dev
-)
+  install(
+    FILES "${PROJECT_BINARY_DIR}/vsomeipConfig.cmake" "${PROJECT_BINARY_DIR}/vsomeipConfigVersion.cmake"
+          DESTINATION "${COMPAT_INSTALL_CMAKE_DIR}"
+          COMPONENT dev
+  )
 
-configure_file(vsomeip.pc.in ${PROJECT_BINARY_DIR}/vsomeip.pc @ONLY)
-install(FILES ${PROJECT_BINARY_DIR}/vsomeip.pc DESTINATION lib/pkgconfig)
+  configure_file(vsomeip.pc.in ${PROJECT_BINARY_DIR}/vsomeip.pc @ONLY)
+  install(FILES ${PROJECT_BINARY_DIR}/vsomeip.pc DESTINATION lib/pkgconfig)
 
-endif ()
+endif()
 
-install (
-  FILES ${EXAMPLE_CONFIG_FILES} DESTINATION etc/vsomeip COMPONENT config
+install(
+  FILES ${EXAMPLE_CONFIG_FILES}
+        DESTINATION etc/vsomeip
+        COMPONENT config
 )
 
 # Add all targets to the build-tree export set
-export (TARGETS ${VSOMEIP_NAME} FILE "${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}Targets.cmake")
+export(TARGETS ${VSOMEIP_NAME} FILE "${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}Targets.cmake")
 
-# Export the package for use from the build-tree
-# (this registers the build-tree with a global CMake-registry)
-export (PACKAGE ${VSOMEIP_NAME})
+# Export the package for use from the build-tree (this registers the build-tree with a global CMake-registry)
+export(PACKAGE ${VSOMEIP_NAME})
 
 # Create the ${VSOMEIP_NAME}Config.cmake and ${VSOMEIP_NAME}ConfigVersion files
-configure_file (${VSOMEIP_NAME}Config.cmake.in "${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}Config.cmake" @ONLY)
-configure_file (${VSOMEIP_NAME}ConfigVersion.cmake.in "${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}ConfigVersion.cmake" @ONLY)
+configure_file(${VSOMEIP_NAME}Config.cmake.in "${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}Config.cmake" @ONLY)
+configure_file(${VSOMEIP_NAME}ConfigVersion.cmake.in "${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}ConfigVersion.cmake" @ONLY)
 
 # configure internal.hpp for correct version number
-configure_file (
-   "${PROJECT_SOURCE_DIR}/implementation/configuration/include/internal.hpp.in"
-   "${PROJECT_SOURCE_DIR}/implementation/configuration/include/internal.hpp"
+configure_file(
+  "${PROJECT_SOURCE_DIR}/implementation/configuration/include/internal.hpp.in"
+  "${PROJECT_SOURCE_DIR}/implementation/configuration/include/internal.hpp"
 )
 
 # Install the ${VSOMEIP_NAME}Config.cmake and ${VSOMEIP_NAME}ConfigVersion.cmake
-install (
-    FILES
-    "${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}Config.cmake"
-    "${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}ConfigVersion.cmake"
-    DESTINATION "${INSTALL_CMAKE_DIR}"
-    COMPONENT dev
+install(
+  FILES "${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}Config.cmake" "${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}ConfigVersion.cmake"
+        DESTINATION "${INSTALL_CMAKE_DIR}"
+        COMPONENT dev
 )
 
 # Install the export set for use with the install-tree
-install (
-    EXPORT ${VSOMEIP_NAME}Targets
-    DESTINATION "${INSTALL_CMAKE_DIR}"
-    COMPONENT dev
+install(
+  EXPORT
+  ${VSOMEIP_NAME}Targets
+  DESTINATION
+  "${INSTALL_CMAKE_DIR}"
+  COMPONENT
+  dev
 )
 
-##############################################################################
+# ######################################################################################################################
 # build documentation
-##############################################################################
+# ######################################################################################################################
 add_custom_target(doc)
 
 find_package(Doxygen)
-if (NOT DOXYGEN_FOUND)
-    message(WARNING "Doxygen is not installed. Documentation can not be built.")
+if(NOT DOXYGEN_FOUND)
+  message(WARNING "Doxygen is not installed. Documentation can not be built.")
 else()
-    # set configuration variables for doxygen.in
-    set(PROJECT "vsomeip")
-    set(DOCDIR documentation)
-    set(SRCDIR .)
-    set(GENERATE_HTML YES)
-    set(GENERATE_HTMLHELP NO)
-    set(GENERATE_CHI NO)
-    set(GENERATE_LATEX NO)
-    set(GENERATE_PDF NO)
-    set(GENERATE_RTF NO)
-    set(GENERATE_MAN NO)
-    set(GENERATE_XML NO)
-    set(HAVE_DOT YES)
+  # set configuration variables for doxygen.in
+  set(PROJECT "vsomeip")
+  set(DOCDIR documentation)
+  set(SRCDIR .)
+  set(GENERATE_HTML YES)
+  set(GENERATE_HTMLHELP NO)
+  set(GENERATE_CHI NO)
+  set(GENERATE_LATEX NO)
+  set(GENERATE_PDF NO)
+  set(GENERATE_RTF NO)
+  set(GENERATE_MAN NO)
+  set(GENERATE_XML NO)
+  set(HAVE_DOT YES)
 
-    if(HAVE_DOT)
-        # Note: the @DOT_PATH@ variable won't be used in doxygen.in as doxygen
-        # somehow manages to strip the last slash from the path and therfore no
-        # graphs are generated. Therefore dot should be available in your $PATH
-        FIND_PROGRAM(DOT_PATH dot)
-        if ("${DOT_PATH}" STREQUAL "DOT_PATH-NOTFOUND")
-            message(WARNING "dot (graphviz) is not installed. Graphs in documentation can't be generated.")
-        else()
-            message("dot found")
-        endif()
+  if(HAVE_DOT)
+    # Note: the @DOT_PATH@ variable won't be used in doxygen.in as doxygen somehow manages to strip the last slash from
+    # the path and therfore no graphs are generated. Therefore dot should be available in your $PATH
+    find_program(DOT_PATH dot)
+    if("${DOT_PATH}" STREQUAL "DOT_PATH-NOTFOUND")
+      message(WARNING "dot (graphviz) is not installed. Graphs in documentation can't be generated.")
+    else()
+      message("dot found")
     endif()
+  endif()
 
-    configure_file(documentation/doxygen.in ${PROJECT_BINARY_DIR}/Doxyfile @ONLY)
-    add_custom_target(doxygen-doc
-                      COMMAND ${DOXYGEN_EXECUTABLE} ${PROJECT_BINARY_DIR}/Doxyfile
-                      SOURCES ${PROJECT_BINARY_DIR}/Doxyfile)
+  configure_file(documentation/doxygen.in ${PROJECT_BINARY_DIR}/Doxyfile @ONLY)
+  add_custom_target(
+    doxygen-doc
+    COMMAND ${DOXYGEN_EXECUTABLE} ${PROJECT_BINARY_DIR}/Doxyfile
+    SOURCES ${PROJECT_BINARY_DIR}/Doxyfile
+  )
 
-    add_dependencies(doc doxygen-doc)
+  add_dependencies(doc doxygen-doc)
 endif()
 
 find_program(ASCIIDOC_PATH asciidoc)
 find_program(SOURCE_HIGHLIGHT_PATH source-highlight)
-if ("${ASCIIDOC_PATH}" STREQUAL "ASCIIDOC_PATH-NOTFOUND")
-    message(WARNING "asciidoc is not installed. Readme can not be built.")
+if("${ASCIIDOC_PATH}" STREQUAL "ASCIIDOC_PATH-NOTFOUND")
+  message(WARNING "asciidoc is not installed. Readme can not be built.")
 elseif("${SOURCE_HIGHLIGHT_PATH}" STREQUAL "SOURCE_HIGHLIGHT_PATH-NOTFOUND")
-    message(WARNING "source-highlight is not installed. Readme can not be built.")
+  message(WARNING "source-highlight is not installed. Readme can not be built.")
 else()
-    message("asciidoc found")
-    message("source-highlight found")
-    add_custom_command(TARGET doc
-                       POST_BUILD
-                       COMMAND asciidoc
-                               -a version=${VSOMEIP_VERSION}
-                               -b html
-                               -o documentation/vsomeipUserGuide.html
-                               ${PROJECT_SOURCE_DIR}/documentation/vsomeipUserGuide)
+  message("asciidoc found")
+  message("source-highlight found")
+  add_custom_command(
+    TARGET doc
+    POST_BUILD
+    COMMAND asciidoc -a version=${VSOMEIP_VERSION} -b html -o documentation/vsomeipUserGuide.html
+            ${PROJECT_SOURCE_DIR}/documentation/vsomeipUserGuide
+  )
 endif()
 
-##############################################################################
+# ######################################################################################################################
 # create pkg-config file
 if(NOT WIN32)
-        configure_file(${VSOMEIP_NAME}.pc.in ${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}.pc @ONLY)
-        install(FILES ${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}.pc DESTINATION lib/pkgconfig)
+  configure_file(${VSOMEIP_NAME}.pc.in ${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}.pc @ONLY)
+  install(FILES ${PROJECT_BINARY_DIR}/${VSOMEIP_NAME}.pc DESTINATION lib/pkgconfig)
 endif()
 
-##############################################################################
+# ######################################################################################################################
 # build routing manager daemon (Non-Windows only)
-if (NOT MSVC)
-add_subdirectory( examples/routingmanagerd )
+if(NOT MSVC)
+  add_subdirectory(examples/routingmanagerd)
 endif()
 
 # build tools
-add_custom_target( tools )
-add_subdirectory( tools )
+add_custom_target(tools)
+add_subdirectory(tools)
 
 # build examples
-add_custom_target( examples )
-add_subdirectory( examples EXCLUDE_FROM_ALL )
+add_custom_target(examples)
+add_subdirectory(examples EXCLUDE_FROM_ALL)
 
-##############################################################################
+# ######################################################################################################################
 # add test directory
 enable_testing()
 
-add_subdirectory( test EXCLUDE_FROM_ALL )
+add_subdirectory(test EXCLUDE_FROM_ALL)
 
-if (${CMAKE_SYSTEM_NAME} MATCHES "QNX")
-    install(DIRECTORY ${PROJECT_BINARY_DIR}/test/
-        DESTINATION bin/vsomeip_tests/test
-        PATTERN "CMakeFiles" EXCLUDE
-        PATTERN "*.cmake" EXCLUDE
-        PATTERN "Makefile" EXCLUDE
-    )
+if(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
+  install(
+    DIRECTORY ${PROJECT_BINARY_DIR}/test/
+              DESTINATION bin/vsomeip_tests/test
+              PATTERN "CMakeFiles" EXCLUDE
+              PATTERN "*.cmake" EXCLUDE
+              PATTERN "Makefile" EXCLUDE
+  )
 
-    install(FILES ${PROJECT_BINARY_DIR}/examples/routingmanagerd/routingmanagerd
-        DESTINATION bin/vsomeip_tests/examples/routingmanagerd)
+  install(FILES ${PROJECT_BINARY_DIR}/examples/routingmanagerd/routingmanagerd
+                DESTINATION bin/vsomeip_tests/examples/routingmanagerd
+  )
 endif()

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,7 +1,8 @@
-# Copyright (C) 2015-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright (C) 2015-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG) This Source Code Form is subject to the
+# terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
+
+cmake_minimum_required(VERSION 3.15)
 
 set(EXAMPLE_CONFIG_FILES
     "../config/vsomeip.json"
@@ -14,22 +15,53 @@ set(EXAMPLE_CONFIG_FILES
 
 # Examples
 add_executable(request-sample request-sample.cpp ${EXAMPLE_CONFIG_FILES})
-target_link_libraries(request-sample ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${DL_LIBRARY})
-
-add_executable(response-sample response-sample.cpp ${EXAMPLE_CONFIG_FILES})
-target_link_libraries(response-sample ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${DL_LIBRARY})
-
-add_executable(subscribe-sample subscribe-sample.cpp ${EXAMPLE_CONFIG_FILES})
-target_link_libraries(subscribe-sample ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${DL_LIBRARY})
-
-add_executable(notify-sample notify-sample.cpp ${EXAMPLE_CONFIG_FILES})
-target_link_libraries(notify-sample ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${DL_LIBRARY})
-
-add_dependencies(examples request-sample response-sample subscribe-sample notify-sample)
-
-install (
-    TARGETS request-sample response-sample subscribe-sample notify-sample
-    RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
+target_link_libraries(
+  request-sample
+  vsomeip3
+  ${Boost_LIBRARIES}
+  DL_INTERFACE
 )
 
-###################################################################################################
+add_executable(response-sample response-sample.cpp ${EXAMPLE_CONFIG_FILES})
+target_link_libraries(
+  response-sample
+  vsomeip3
+  ${Boost_LIBRARIES}
+  DL_INTERFACE
+)
+
+add_executable(subscribe-sample subscribe-sample.cpp ${EXAMPLE_CONFIG_FILES})
+target_link_libraries(
+  subscribe-sample
+  vsomeip3
+  ${Boost_LIBRARIES}
+  DL_INTERFACE
+)
+
+add_executable(notify-sample notify-sample.cpp ${EXAMPLE_CONFIG_FILES})
+target_link_libraries(
+  notify-sample
+  vsomeip3
+  ${Boost_LIBRARIES}
+  DL_INTERFACE
+)
+
+add_dependencies(
+  examples
+  request-sample
+  response-sample
+  subscribe-sample
+  notify-sample
+)
+
+install(
+  TARGETS request-sample
+          response-sample
+          subscribe-sample
+          notify-sample
+          RUNTIME
+          DESTINATION "${INSTALL_BIN_DIR}"
+          COMPONENT bin
+)
+
+# ######################################################################################################################

--- a/examples/hello_world/CMakeLists.txt
+++ b/examples/hello_world/CMakeLists.txt
@@ -1,10 +1,9 @@
-# Copyright (C) 2015-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright (C) 2015-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG) This Source Code Form is subject to the
+# terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required (VERSION 2.8.7)
-project (vSomeIPHelloWorld)
+cmake_minimum_required(VERSION 2.8.7)
+project(vSomeIPHelloWorld)
 
 find_package(Threads REQUIRED)
 
@@ -15,34 +14,39 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
 include_directories(${VSOMEIP_INCLUDE_DIRS})
 
 add_library(vsomeip_hello_world_service INTERFACE)
-target_sources(vsomeip_hello_world_service INTERFACE
-    "${CMAKE_CURRENT_SOURCE_DIR}/hello_world_service.hpp"
-)
-target_include_directories(vsomeip_hello_world_service INTERFACE
-    "${CMAKE_CURRENT_SOURCE_DIR}"
-)
+target_sources(vsomeip_hello_world_service INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/hello_world_service.hpp")
+target_include_directories(vsomeip_hello_world_service INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
 
 add_library(vsomeip_hello_world_client INTERFACE)
-target_sources(vsomeip_hello_world_client INTERFACE
-    "${CMAKE_CURRENT_SOURCE_DIR}/hello_world_client.hpp"
+target_sources(vsomeip_hello_world_client INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/hello_world_client.hpp")
+
+target_include_directories(vsomeip_hello_world_client INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+
+if(NOT
+   ${CMAKE_SYSTEM_NAME}
+   MATCHES
+   "Android"
 )
+  # This will get us acces to VSOMEIP_INCLUDE_DIRS - include directories for vSomeIP VSOMEIP_LIBRARIES    - libraries to
+  # link against
+  find_package(${VSOMEIP_NAME})
+  if(NOT ${VSOMEIP_NAME}_FOUND)
+    message("${VSOMEIP_NAME} was not found. Please specify vsomeip_DIR")
+  endif()
 
-target_include_directories(vsomeip_hello_world_client INTERFACE
-    "${CMAKE_CURRENT_SOURCE_DIR}"
-)
+  add_executable(hello_world_service hello_world_service_main.cpp)
+  target_link_libraries(
+    hello_world_service
+    vsomeip_hello_world_service
+    ${VSOMEIP_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+  )
 
-if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Android")
-    # This will get us acces to
-    #   VSOMEIP_INCLUDE_DIRS - include directories for vSomeIP
-    #   VSOMEIP_LIBRARIES    - libraries to link against
-    find_package(${VSOMEIP_NAME})
-    if (NOT ${VSOMEIP_NAME}_FOUND)
-        message("${VSOMEIP_NAME} was not found. Please specify vsomeip_DIR")
-    endif()
-
-    add_executable (hello_world_service hello_world_service_main.cpp)
-    target_link_libraries(hello_world_service vsomeip_hello_world_service ${VSOMEIP_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-
-    add_executable (hello_world_client hello_world_client_main.cpp)
-    target_link_libraries(hello_world_client vsomeip_hello_world_client ${VSOMEIP_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+  add_executable(hello_world_client hello_world_client_main.cpp)
+  target_link_libraries(
+    hello_world_client
+    vsomeip_hello_world_client
+    ${VSOMEIP_LIBRARIES}
+    ${CMAKE_THREAD_LIBS_INIT}
+  )
 endif()

--- a/examples/hello_world/CMakeLists.txt
+++ b/examples/hello_world/CMakeLists.txt
@@ -2,23 +2,31 @@
 # terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain
 # one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.15)
 project(vSomeIPHelloWorld)
 
 find_package(Threads REQUIRED)
 
-set(VSOMEIP_NAME "vsomeip3")
+include(GNUInstallDirs)
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+set(INSTALL_BIN_DIR
+    ${CMAKE_INSTALL_BINDIR}
+    CACHE STRING "Installation directory for executables"
+)
 
-include_directories(${VSOMEIP_INCLUDE_DIRS})
+add_library(vsomeip_hello_world_example INTERFACE)
+target_compile_features(vsomeip_hello_world_example INTERFACE cxx_std_17)
+if(ENABLE_SIGNAL_HANDLING)
+  target_compile_definitions(vsomeip_hello_world_example INTERFACE VSOMEIP_ENABLE_SIGNAL_HANDLING)
+endif()
 
 add_library(vsomeip_hello_world_service INTERFACE)
 target_sources(vsomeip_hello_world_service INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/hello_world_service.hpp")
-target_include_directories(vsomeip_hello_world_service INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_link_libraries(vsomeip_hello_world_service INTERFACE vsomeip_hello_world_example)
 
 add_library(vsomeip_hello_world_client INTERFACE)
 target_sources(vsomeip_hello_world_client INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/hello_world_client.hpp")
+target_link_libraries(vsomeip_hello_world_client INTERFACE vsomeip_hello_world_example)
 
 target_include_directories(vsomeip_hello_world_client INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
 
@@ -27,26 +35,24 @@ if(NOT
    MATCHES
    "Android"
 )
-  # This will get us acces to VSOMEIP_INCLUDE_DIRS - include directories for vSomeIP VSOMEIP_LIBRARIES    - libraries to
-  # link against
-  find_package(${VSOMEIP_NAME})
-  if(NOT ${VSOMEIP_NAME}_FOUND)
-    message("${VSOMEIP_NAME} was not found. Please specify vsomeip_DIR")
+  # This will get us acces to the vsomeip target, along with VSOMEIP_INCLUDE_DIRS - include directories for vSomeIP
+  # VSOMEIP_LIBRARIES    - libraries to link against
+  if(NOT TARGET vsomeip3)
+    find_package(vsomeip3)
+    if(NOT vsomeip3_FOUND)
+      message("vsomeip was not found. Please specify vsomeip_DIR")
+    endif()
   endif()
 
   add_executable(hello_world_service hello_world_service_main.cpp)
-  target_link_libraries(
-    hello_world_service
-    vsomeip_hello_world_service
-    ${VSOMEIP_LIBRARIES}
-    ${CMAKE_THREAD_LIBS_INIT}
-  )
+  target_link_libraries(hello_world_service PUBLIC vsomeip_hello_world_service vsomeip3 Threads::Threads)
 
   add_executable(hello_world_client hello_world_client_main.cpp)
-  target_link_libraries(
-    hello_world_client
-    vsomeip_hello_world_client
-    ${VSOMEIP_LIBRARIES}
-    ${CMAKE_THREAD_LIBS_INIT}
+  target_link_libraries(hello_world_client PUBLIC vsomeip_hello_world_client vsomeip3 Threads::Threads)
+
+  install(
+    TARGETS hello_world_client hello_world_service RUNTIME
+            DESTINATION "${INSTALL_BIN_DIR}"
+            COMPONENT example-hello_world
   )
 endif()

--- a/examples/routingmanagerd/CMakeLists.txt
+++ b/examples/routingmanagerd/CMakeLists.txt
@@ -1,25 +1,30 @@
-# Copyright (C) 2015-2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright (C) 2015-2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG) This Source Code Form is subject to the
+# terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
 
 # Daemon
 add_executable(routingmanagerd routingmanagerd.cpp)
-target_link_libraries(routingmanagerd ${VSOMEIP_NAME} ${Boost_LIBRARIES} ${DL_LIBRARY} ${DLT_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(
+  routingmanagerd
+  ${VSOMEIP_NAME}
+  ${Boost_LIBRARIES}
+  ${DL_LIBRARY}
+  ${DLT_LIBRARIES}
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 if(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
-    target_link_libraries(routingmanagerd socket)
+  target_link_libraries(routingmanagerd socket)
 endif()
 add_dependencies(routingmanagerd ${VSOMEIP_NAME})
 
 option(VSOMEIP_INSTALL_ROUTINGMANAGERD "Whether or not to install the routing manager daemon.")
 
-if (VSOMEIP_INSTALL_ROUTINGMANAGERD)
-    install (
-        TARGETS routingmanagerd
-        RUNTIME DESTINATION "${INSTALL_BIN_DIR}" COMPONENT bin
-    )
+if(VSOMEIP_INSTALL_ROUTINGMANAGERD)
+  install(
+    TARGETS routingmanagerd RUNTIME
+            DESTINATION "${INSTALL_BIN_DIR}"
+            COMPONENT bin
+  )
 endif()
 
-
-
-###################################################################################################
+# ######################################################################################################################

--- a/examples/routingmanagerd/CMakeLists.txt
+++ b/examples/routingmanagerd/CMakeLists.txt
@@ -2,22 +2,29 @@
 # terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain
 # one at http://mozilla.org/MPL/2.0/.
 
-# Daemon
-add_executable(routingmanagerd routingmanagerd.cpp)
-target_link_libraries(
-  routingmanagerd
-  ${VSOMEIP_NAME}
-  ${Boost_LIBRARIES}
-  ${DL_LIBRARY}
-  ${DLT_LIBRARIES}
-  ${CMAKE_THREAD_LIBS_INIT}
-)
-if(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
-  target_link_libraries(routingmanagerd socket)
-endif()
-add_dependencies(routingmanagerd ${VSOMEIP_NAME})
+cmake_minimum_required(VERSION 3.15)
 
 option(VSOMEIP_INSTALL_ROUTINGMANAGERD "Whether or not to install the routing manager daemon.")
+
+# Daemon
+add_executable(routingmanagerd)
+target_sources(routingmanagerd PRIVATE routingmanagerd.cpp)
+
+if(TARGET Genivi::dlt)
+  target_compile_definitions(routingmanagerd PRIVATE USE_DLT)
+  target_link_libraries(routingmanagerd PRIVATE Genivi::dlt)
+endif()
+
+target_link_libraries(
+  routingmanagerd
+  PRIVATE vsomeip3
+          Boost::system
+          STACKTRACE_INTERFACE
+          OS_INTERFACE
+          DL_INTERFACE
+          RT_INTERFACE
+          Threads::Threads
+)
 
 if(VSOMEIP_INSTALL_ROUTINGMANAGERD)
   install(

--- a/test/benchmark_tests/CMakeLists.txt
+++ b/test/benchmark_tests/CMakeLists.txt
@@ -1,31 +1,41 @@
-# Copyright (C) 2015-2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright (C) 2015-2023 Bayerische Motoren Werke Aktiengesellschaft (BMW AG) This Source Code Form is subject to the
+# terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
 
-project ("benchmark_tests_bin" LANGUAGES CXX)
+project("benchmark_tests_bin" LANGUAGES CXX)
 
-file (GLOB SRCS main.cpp **/*.cpp)
+file(
+  GLOB
+  SRCS
+  main.cpp
+  **/*.cpp
+  ../common/utility.cpp
+)
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 
 find_package(Threads REQUIRED)
-find_package(Boost 1.55 COMPONENTS filesystem system REQUIRED)
+find_package(
+  Boost 1.65
+  COMPONENTS filesystem system
+  REQUIRED
+)
 
 # ----------------------------------------------------------------------------
 # Executable and libraries to link
 # ----------------------------------------------------------------------------
-add_executable (${PROJECT_NAME} ${SRCS} )
-target_link_libraries (
-    ${PROJECT_NAME}
-    vsomeip3
-    vsomeip3-cfg
-    Threads::Threads
-    ${Boost_LIBRARIES}
-    ${DL_LIBRARY}
-    benchmark::benchmark
-    gtest
-    vsomeip_utilities
+add_executable(vsomeip3-benchmark-tests)
+target_sources(vsomeip3-benchmark-tests PRIVATE ${SRCS})
+target_link_libraries(
+  vsomeip3-benchmark-tests
+  PRIVATE vsomeip3
+          vsomeip3-cfg
+          Threads::Threads
+          Boost::filesystem
+          Boost::system
+          benchmark::benchmark
+          gtest
+          DL_INTERFACE
 )
 
-add_dependencies(build_benchmark_tests ${PROJECT_NAME})
+add_dependencies(build_benchmark_tests vsomeip3-benchmark-tests)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -2,14 +2,18 @@
 # terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain
 # one at http://mozilla.org/MPL/2.0/.
 
+cmake_minimum_required(VERSION 3.15)
+
 # vsomeip_ctrl
 add_executable(vsomeip_ctrl EXCLUDE_FROM_ALL vsomeip_ctrl.cpp)
 target_link_libraries(
   vsomeip_ctrl
-  vsomeip3
-  ${Boost_LIBRARIES}
-  ${DL_LIBRARY}
-  ${CMAKE_THREAD_LIBS_INIT}
+  PUBLIC vsomeip3
+  PRIVATE Boost::filesystem DL_INTERFACE Threads::Threads
 )
 
-# ######################################################################################################################
+install(
+  TARGETS vsomeip_ctrl RUNTIME
+          COMPONENT vsomeip_ctrl
+          EXCLUDE_FROM_ALL
+)

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,16 +1,15 @@
-# Copyright (C) 2016-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
-# This Source Code Form is subject to the terms of the Mozilla Public
-# License, v. 2.0. If a copy of the MPL was not distributed with this
-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+# Copyright (C) 2016-2017 Bayerische Motoren Werke Aktiengesellschaft (BMW AG) This Source Code Form is subject to the
+# terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, You can obtain
+# one at http://mozilla.org/MPL/2.0/.
 
 # vsomeip_ctrl
 add_executable(vsomeip_ctrl EXCLUDE_FROM_ALL vsomeip_ctrl.cpp)
-target_link_libraries(vsomeip_ctrl
-    vsomeip3
-    ${Boost_LIBRARIES}
-    ${DL_LIBRARY}
-    ${CMAKE_THREAD_LIBS_INIT}
+target_link_libraries(
+  vsomeip_ctrl
+  vsomeip3
+  ${Boost_LIBRARIES}
+  ${DL_LIBRARY}
+  ${CMAKE_THREAD_LIBS_INIT}
 )
 
-###################################################################################################
-
+# ######################################################################################################################


### PR DESCRIPTION
# Status

For the moment this is still a WIP.  I would love community feedback on this PR so that we can produce a modern CMake setup that functions well for everyone.

I suspect the cleanest way to organize the commits would be to squash them.

# Description

## General CMakeLists improvements - cmake v2→v3

- Included a `.cmake-format` file, and ran applied it to the main `CMakeList` files in this project.
  - The format file does a poor job on `if` and `foreach` blocks, but I believe overall it does a better job that the default settings.  The main benefit is a consistent format
- Use targets instead of lib/include variables in CMake
- Write `internal.hpp` to build directory instead of source to prevent needless rebuilds
- Remove hard coded `CMAKE_VERBOSE_MAKEFILE`, this should be injected by the user if so desired
- "wrap"ing (ld's `--wrap` option) the "socket" symbol, see `wrappers.cpp`
- Added install directive to `vsomeip/example/hello_world` and `vsomeip_ctrl`
- Platform conditional socket lib linkage
- hello_world code uses ENABLE_SIGNALS, but its setting was missing in CMake
- Improve setup for boost stacktrace, really only helps on Linux and requires the `backtrace.h` file
- Added QNX platform section, though the credential code changes for QNX are not included in this commit.
- Use a CACHE variable for `VSOMEIP_BASE_PATH`.  Upstream defaults this to `/var` for QNX which is a very bad choice.

## Misc
- Added more ignore rules to for common IDEs