### PR TITLE
main_phase_timer should be stopped along with SD

### DIFF
--- a/implementation/service_discovery/include/service_discovery_impl.hpp
+++ b/implementation/service_discovery/include/service_discovery_impl.hpp
@@ -264,6 +264,7 @@ private:
 
     void start_main_phase_timer();
     void on_main_phase_timer_expired(const boost::system::error_code &_error);
+    void stop_main_phase_timer();
 
 
     void send_uni_or_multicast_offerservice(

--- a/implementation/service_discovery/src/service_discovery_impl.cpp
+++ b/implementation/service_discovery/src/service_discovery_impl.cpp
@@ -3238,7 +3238,7 @@ service_discovery_impl::start_main_phase_timer() {
 
 void
 service_discovery_impl::stop_main_phase_timer() {
-    std::lock_guard<std::mutex> its_lock(main_phase_timer_mutex_);
+    std::scoped_lock<std::mutex> its_lock(main_phase_timer_mutex_);
     boost::system::error_code ec;
     main_phase_timer_.cancel(ec);
 }

--- a/implementation/service_discovery/src/service_discovery_impl.cpp
+++ b/implementation/service_discovery/src/service_discovery_impl.cpp
@@ -206,6 +206,7 @@ service_discovery_impl::stop() {
     is_suspended_ = true;
     stop_ttl_timer();
     stop_last_msg_received_timer();
+    stop_main_phase_timer();
 }
 
 void
@@ -3233,6 +3234,13 @@ service_discovery_impl::start_main_phase_timer() {
     main_phase_timer_.async_wait(
             std::bind(&service_discovery_impl::on_main_phase_timer_expired,
                     this, std::placeholders::_1));
+}
+
+void
+service_discovery_impl::stop_main_phase_timer() {
+    std::lock_guard<std::mutex> its_lock(main_phase_timer_mutex_);
+    boost::system::error_code ec;
+    main_phase_timer_.cancel(ec);
 }
 
 void


### PR DESCRIPTION
If `main_phase_timer` isn't stopped, it might prevent `routingmanagerd` from quitting gracefully. Thread will be blocked on `join()`.

This is a followup on https://github.com/COVESA/vsomeip/pull/559.  The issue is a sporative (through rare) `SIGTERM` on exit from `routingmanagerd`.

The key signature of the crash appears to be:
```
#34 vsomeip_v3::routing_manager_impl::expire_subscriptions (this=0x1962493058, _force=false) at implementation/routing/src/routing_manager_impl.cpp:3307 #35 0x0000004ec2948f2c in vsomeip_v3::sd::service_discovery_impl::expire_subscriptions (_error=..., this=0x19624985c8) at implementation/service_discovery/src/service_discovery_impl.cpp:2828
```

That PR inverted the ownership structure in SD (better explained by @vvcarvalho [here](https://github.com/COVESA/vsomeip/pull/559#issuecomment-1805461783).)  This change however calls a stop on `main_phase_timer` during shutdown.