### PR TITLE
Updating Hello World example CMakeLists

### DIFF
--- a/examples/hello_world/CMakeLists.txt
+++ b/examples/hello_world/CMakeLists.txt
@@ -10,26 +10,29 @@ find_package(Threads REQUIRED)
 
 set(VSOMEIP_NAME "vsomeip3")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
+# create_target("executable")
+function(create_target executable)
+    add_library(vsomeip_hello_world_${executable} INTERFACE)
+    target_sources(vsomeip_hello_world_${executable} INTERFACE
+        "${CMAKE_CURRENT_SOURCE_DIR}/hello_world_${executable}.hpp"
+    )
+    target_compile_features(vsomeip_hello_world_${executable} INTERFACE cxx_std_17)
+
+    target_include_directories(vsomeip_hello_world_${executable} INTERFACE
+        "${CMAKE_CURRENT_SOURCE_DIR}"
+    )
+endfunction()
+
+# link_target("executable")
+function(link_target executable)
+    add_executable (hello_world_${executable} hello_world_${executable}_main.cpp)
+    target_link_libraries(hello_world_${executable} vsomeip_hello_world_${executable} ${VSOMEIP_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+endfunction()
 
 include_directories(${VSOMEIP_INCLUDE_DIRS})
 
-add_library(vsomeip_hello_world_service INTERFACE)
-target_sources(vsomeip_hello_world_service INTERFACE
-    "${CMAKE_CURRENT_SOURCE_DIR}/hello_world_service.hpp"
-)
-target_include_directories(vsomeip_hello_world_service INTERFACE
-    "${CMAKE_CURRENT_SOURCE_DIR}"
-)
-
-add_library(vsomeip_hello_world_client INTERFACE)
-target_sources(vsomeip_hello_world_client INTERFACE
-    "${CMAKE_CURRENT_SOURCE_DIR}/hello_world_client.hpp"
-)
-
-target_include_directories(vsomeip_hello_world_client INTERFACE
-    "${CMAKE_CURRENT_SOURCE_DIR}"
-)
+create_target("service")
+create_target("client")
 
 if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Android")
     # This will get us acces to
@@ -40,9 +43,6 @@ if (NOT ${CMAKE_SYSTEM_NAME} MATCHES "Android")
         message("${VSOMEIP_NAME} was not found. Please specify vsomeip_DIR")
     endif()
 
-    add_executable (hello_world_service hello_world_service_main.cpp)
-    target_link_libraries(hello_world_service vsomeip_hello_world_service ${VSOMEIP_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-
-    add_executable (hello_world_client hello_world_client_main.cpp)
-    target_link_libraries(hello_world_client vsomeip_hello_world_client ${VSOMEIP_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+    link_target("client")
+    link_target("service")
 endif()

--- a/examples/hello_world/CMakeLists.txt
+++ b/examples/hello_world/CMakeLists.txt
@@ -3,7 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required (VERSION 2.8.7)
+cmake_minimum_required (VERSION 3.13)
 project (vSomeIPHelloWorld)
 
 find_package(Threads REQUIRED)
@@ -19,14 +19,15 @@ function(create_target executable)
     target_compile_features(vsomeip_hello_world_${executable} INTERFACE cxx_std_17)
 
     target_include_directories(vsomeip_hello_world_${executable} INTERFACE
-        "${CMAKE_CURRENT_SOURCE_DIR}"
+        ${CMAKE_CURRENT_SOURCE_DIR}
     )
 endfunction()
 
 # link_target("executable")
 function(link_target executable)
-    add_executable (hello_world_${executable} hello_world_${executable}_main.cpp)
-    target_link_libraries(hello_world_${executable} vsomeip_hello_world_${executable} ${VSOMEIP_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+    add_executable(hello_world_${executable})
+    target_sources(hello_world_${executable} PRIVATE hello_world_${executable}_main.cpp)
+    target_link_libraries(hello_world_${executable} PRIVATE vsomeip_hello_world_${executable} vsomeip3 Threads::Threads)
 endfunction()
 
 include_directories(${VSOMEIP_INCLUDE_DIRS})


### PR DESCRIPTION
### Summary
Updated the CMakeLists for the use of target_compile_features function and did a small refactor to avoid duplicate code.

### Details
Suggested from a COVESA comment ([link](https://github.com/COVESA/vsomeip/pull/733#discussion_r1707188114)),
tried to update the setting of c++17 flag.
To use target_compile_features it would lead to more duplicate code.
Instead, two functions were created to reduce that. There is no impact on the code in itself.

### Issue
None