### PR TITLE
Fix for Find messages received with Unicast Flag set to 0 (multicast) shall be ignored

### DIFF
--- a/implementation/service_discovery/src/service_discovery_impl.cpp
+++ b/implementation/service_discovery/src/service_discovery_impl.cpp
@@ -1664,7 +1664,7 @@ service_discovery_impl::send_multicast_offer_service(
 
     insert_offer_service(its_messages, _info);
 
-    serialize_and_send(its_messages, current_remote_address_);
+    serialize_and_send(its_messages, sd_multicast_address_);
 }
 
 void
@@ -3255,7 +3255,7 @@ service_discovery_impl::send_uni_or_multicast_offerservice(
             send_multicast_offer_service(_info);
         }
     } else { // SID_SD_826
-        send_unicast_offer_service(_info);
+        send_multicast_offer_service(_info);
     }
 }
 

--- a/implementation/service_discovery/src/service_discovery_impl.cpp
+++ b/implementation/service_discovery/src/service_discovery_impl.cpp
@@ -1652,7 +1652,9 @@ service_discovery_impl::send_unicast_offer_service(
 
     insert_offer_service(its_messages, _info);
 
-    serialize_and_send(its_messages, current_remote_address_);
+    // send message as multicast offer service the same way it is sent
+    // on the repetition phase to preserve the session id
+    send(its_messages);
 }
 
 void
@@ -3254,8 +3256,9 @@ service_discovery_impl::send_uni_or_multicast_offerservice(
         } else { // SIP_SD_90
             send_multicast_offer_service(_info);
         }
-    } else { // SID_SD_826
-        send_multicast_offer_service(_info);
+    } else {
+        // SIP_SD_91
+        // Find messages received with Unicast Flag set to 0 (multicast), shall be ignored        
     }
 }
 


### PR DESCRIPTION
Fix for Find messages received with Unicast Flag set to 0 (multicast) shall be answered with a multicast response