### PR TITLE
Fix capturing references to stack variables

### DIFF
--- a/implementation/configuration/src/configuration_impl.cpp
+++ b/implementation/configuration/src/configuration_impl.cpp
@@ -145,6 +145,8 @@ configuration_impl::configuration_impl(const configuration_impl& _other) :
     sd_port_ = _other.sd_port_;
     sd_protocol_ = _other.sd_protocol_;
 
+    is_suppress_events_enabled_ = _other.is_suppress_events_enabled_;
+
     sd_initial_delay_min_ = _other.sd_initial_delay_min_;
     sd_initial_delay_max_ = _other.sd_initial_delay_max_;
     sd_repetitions_base_delay_= _other.sd_repetitions_base_delay_;

--- a/implementation/endpoints/src/tcp_client_endpoint_impl.cpp
+++ b/implementation/endpoints/src/tcp_client_endpoint_impl.cpp
@@ -269,7 +269,7 @@ void tcp_client_endpoint_impl::receive() {
         its_recv_buffer = recv_buffer_;
     }
     auto self = std::dynamic_pointer_cast< tcp_client_endpoint_impl >(shared_from_this());
-    strand_.dispatch([self, &its_recv_buffer](){
+    strand_.dispatch([self, its_recv_buffer](){
         self->receive(its_recv_buffer, 0, 0);
     });
 }
@@ -770,7 +770,7 @@ void tcp_client_endpoint_impl::receive_cbk(
             }
             its_lock.unlock();
             auto self = std::dynamic_pointer_cast< tcp_client_endpoint_impl >(shared_from_this());
-            strand_.dispatch([self, &_recv_buffer, _recv_buffer_size, its_missing_capacity](){
+            strand_.dispatch([self, _recv_buffer, _recv_buffer_size, its_missing_capacity](){
                 self->receive(_recv_buffer, _recv_buffer_size, its_missing_capacity);
             });
         } else {
@@ -798,7 +798,7 @@ void tcp_client_endpoint_impl::receive_cbk(
             } else {
                 its_lock.unlock();
                 auto self = std::dynamic_pointer_cast< tcp_client_endpoint_impl >(shared_from_this());
-                strand_.dispatch([self, &_recv_buffer, _recv_buffer_size, its_missing_capacity](){
+                strand_.dispatch([self, _recv_buffer, _recv_buffer_size, its_missing_capacity](){
                     self->receive(_recv_buffer, _recv_buffer_size, its_missing_capacity);
                 });
             }
@@ -948,7 +948,7 @@ void tcp_client_endpoint_impl::send_cbk(boost::system::error_code const &_error,
                 if (its_entry.first) {
                     auto self = std::dynamic_pointer_cast< tcp_client_endpoint_impl >(shared_from_this());
                     strand_.dispatch(
-                        [self, &its_entry]() { self->send_queued(its_entry);}
+                        [self, its_entry]() mutable { self->send_queued(its_entry);}
                     );
                 }
             }


### PR DESCRIPTION
Capture errors discovered by Aram's team.  I don't have Aram's (@akhzarj ?) contact info so I can't add a `Co-authored-by` tag in the commit