### PR TITLE
SOME/IP-TP: Rework handling of missing segments

### DIFF
--- a/implementation/endpoints/include/tp.hpp
+++ b/implementation/endpoints/include/tp.hpp
@@ -30,6 +30,14 @@ typedef std::vector<message_buffer_ptr_t> tp_split_messages_t;
 
 const std::uint8_t TP_FLAG = 0x20;
 
+enum class tp_status_e : std::uint8_t {
+    TPS_ERROR = 0x00,
+    TPS_INCOMPLETE = 0x01,
+    TPS_COMPLETE = 0x02,
+    TPS_DUPLICATE = 0x04,
+    TPS_UNKNOWN = 0xff
+};
+
 class tp {
 public:
     static inline length_t get_offset(tp_header_t _tp_header) {

--- a/implementation/endpoints/include/tp_message.hpp
+++ b/implementation/endpoints/include/tp_message.hpp
@@ -13,6 +13,7 @@
 #include <vsomeip/enumeration_types.hpp>
 
 #include "buffer.hpp"
+#include "tp.hpp"
 
 #if defined(__QNX__)
 #include "../../utility/include/qnx_helper.hpp"
@@ -25,8 +26,7 @@ public:
     tp_message(const byte_t* const _data, std::uint32_t _data_length,
                std::uint32_t _max_message_size);
 
-    bool add_segment(const byte_t* const _data, std::uint32_t _data_length);
-
+    tp_status_e add_segment(const byte_t* const _data, std::uint32_t _data_length);
     message_buffer_t get_message();
 
     std::chrono::steady_clock::time_point get_creation_time() const;


### PR DESCRIPTION
The SOME/IP specification requires the segments of a SOME/IP-TP message to be sent in ascending order. Therefore, whenever we receive a start segment (offset=0), we drop all existing data for the very same message.