### PR TITLE
Fix two destruction order issues causing segfaults during shutdown

### DIFF
--- a/implementation/runtime/include/application_impl.hpp
+++ b/implementation/runtime/include/application_impl.hpp
@@ -34,6 +34,10 @@
 #include <vsomeip/export.hpp>
 #include <vsomeip/application.hpp>
 
+#ifndef VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS
+#include <vsomeip/internal/plugin_manager.hpp>
+#endif
+
 #ifdef ANDROID
 #include "../../configuration/include/internal_android.hpp"
 #else
@@ -381,6 +385,10 @@ private:
 
     std::string path_;
     std::shared_ptr<configuration> configuration_;
+
+#ifndef VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS
+    std::shared_ptr<plugin_manager> plugin_manager_;
+#endif
 
     boost::asio::io_context io_;
     std::set<std::shared_ptr<std::thread> > io_threads_;

--- a/implementation/runtime/src/application_impl.cpp
+++ b/implementation/runtime/src/application_impl.cpp
@@ -51,6 +51,9 @@ std::mutex application_impl::app_counter_mutex__;
 application_impl::application_impl(const std::string& _name, const std::string& _path) :
     runtime_(runtime::get()), client_(VSOMEIP_CLIENT_UNSET), session_(0), is_initialized_(false),
     name_(_name), path_(_path),
+#ifndef VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS
+    plugin_manager_(plugin_manager::get()),
+#endif
     work_(std::make_shared<
             boost::asio::executor_work_guard<boost::asio::io_context::executor_type>>(
             io_.get_executor())),
@@ -71,7 +74,7 @@ application_impl::~application_impl() {
 
 #ifndef VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS
     if(configuration_) {
-        auto its_plugin = plugin_manager::get()->get_plugin(
+        auto its_plugin = plugin_manager_->get_plugin(
                 plugin_type_e::CONFIGURATION_PLUGIN, VSOMEIP_CFG_LIBRARY);
         if (its_plugin) {
             auto its_configuration_plugin
@@ -142,7 +145,7 @@ bool application_impl::init() {
         // TODO: Add loading of custom configuration module
     } else { // load default module
 #ifndef VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS
-        auto its_plugin = plugin_manager::get()->get_plugin(
+        auto its_plugin = plugin_manager_->get_plugin(
                 plugin_type_e::CONFIGURATION_PLUGIN, VSOMEIP_CFG_LIBRARY);
         if (its_plugin) {
             auto its_configuration_plugin
@@ -354,7 +357,7 @@ bool application_impl::init() {
         auto its_app_plugin_info = its_plugins.find(plugin_type_e::APPLICATION_PLUGIN);
         if (its_app_plugin_info != its_plugins.end()) {
             for (auto its_library : its_app_plugin_info->second) {
-                auto its_application_plugin = plugin_manager::get()->get_plugin(
+                auto its_application_plugin = plugin_manager_->get_plugin(
                         plugin_type_e::APPLICATION_PLUGIN, its_library);
                 if (its_application_plugin) {
                     VSOMEIP_INFO << "Client 0x" << std::hex << get_client()
@@ -486,7 +489,7 @@ void application_impl::start() {
     auto its_app_plugin_info = its_plugins.find(plugin_type_e::APPLICATION_PLUGIN);
     if (its_app_plugin_info != its_plugins.end()) {
         for (const auto& its_library : its_app_plugin_info->second) {
-            auto its_application_plugin = plugin_manager::get()->get_plugin(
+            auto its_application_plugin = plugin_manager_->get_plugin(
                     plugin_type_e::APPLICATION_PLUGIN, its_library);
             if (its_application_plugin) {
                 std::dynamic_pointer_cast<application_plugin>(its_application_plugin)->
@@ -562,7 +565,7 @@ void application_impl::stop() {
         auto its_app_plugin_info = its_plugins.find(plugin_type_e::APPLICATION_PLUGIN);
         if (its_app_plugin_info != its_plugins.end()) {
             for (const auto& its_library : its_app_plugin_info->second) {
-                auto its_application_plugin = plugin_manager::get()->get_plugin(
+                auto its_application_plugin = plugin_manager_->get_plugin(
                         plugin_type_e::APPLICATION_PLUGIN, its_library);
                 if (its_application_plugin) {
                     std::dynamic_pointer_cast<application_plugin>(its_application_plugin)->
@@ -2251,8 +2254,10 @@ void application_impl::shutdown() {
     }
 
     try {
-        if (routing_)
+        if (routing_) {
             routing_->stop();
+            routing_.reset();
+        }
     } catch (const std::exception &e) {
         VSOMEIP_ERROR << "application_impl::" << __func__ << ": stopping routing, "
                 << " catched exception: " << e.what();


### PR DESCRIPTION
1. `application_impl::~application_impl` calls the `plugin_manager` when `VSOMEIP_ENABLE_MULTIPLE_ROUTING_MANAGERS` is not defined. Therefore it should hold a `shared_ptr` to it instead of calling `plugin_manager::get()` in the destructor, in order to prevent the global `the_plugin_manager__` instance being destroyed before it is.
2. `routing_manager_impl::~routing_manager_impl` calls `utility` functions. Therefore destroy the `routing_` instance in `application_impl::shutdown` to ensure that this happens before the `utility` global variables are destroyed.