### PR TITLE
Segmentation Fault observed while executing unit test

### DIFF
--- a/test/common/src/utility.cpp
+++ b/test/common/src/utility.cpp
@@ -120,7 +120,10 @@ utility::force_check_credentials(
                 = security.get_child("check_credentials");
             if (credentials.get_value<std::string>().compare(_value)) {
                 security.erase("check_credentials");
-                credentials.put("check_credentials", _value);
+                // "check_credentials" was erased and was trying to write inside freed memory leading to segmentation fault.
+                boost::property_tree::ptree updatedCredentials;
+                updatedCredentials.put("check_credentials", _value);
+                security.add_child("security",updatedCredentials);
             }
         }
         catch(...) {}


### PR DESCRIPTION
"check_credentials" was erased and was trying to write inside freed memory leading to segmentation fault.