### PR TITLE
Never restart stopped TCE

### DIFF
--- a/implementation/endpoints/src/tcp_client_endpoint_impl.cpp
+++ b/implementation/endpoints/src/tcp_client_endpoint_impl.cpp
@@ -976,7 +976,9 @@ void tcp_client_endpoint_impl::send_cbk(boost::system::error_code const &_error,
                 if (its_host) {
                     its_host->on_disconnect(shared_from_this());
                 }
-                restart(true);
+
+                if (!sending_blocked_)
+                    restart(true);
             }
             service_t its_service(0);
             method_t its_method(0);
@@ -1025,7 +1027,9 @@ void tcp_client_endpoint_impl::wait_until_sent(const boost::system::error_code &
 
         std::shared_ptr<endpoint_host> its_ep_host = endpoint_host_.lock();
         its_ep_host->on_disconnect(shared_from_this());
-        restart(true);
+
+        if (!sending_blocked_)
+            restart(true);
     } else {
         std::chrono::milliseconds its_timeout(VSOMEIP_MAX_TCP_SENT_WAIT_TIME);
         boost::system::error_code ec;


### PR DESCRIPTION
Around suspend-to-ram it's likely that SOMEIP-SD and TCP sockets will be impacted by clocks jumping. In case:
- SOMEIP-SD timeout is detected
- clear_client_endpoints clears everything and stops the TCE endpoint
- new OFFER is received

then there's a race condition where:
- add_routing_info ends up creating a new endpoint
- old (stopped) endpoint calls restart which clears sending_blocked_
- new endpoint calls start

and may result in two connected endpoints, depending on execution order. In order to avoid this, never restart a stopped endpoint.