### PR TITLE
Enable subscription expiration

### DIFF
--- a/implementation/routing/include/remote_subscription.hpp
+++ b/implementation/routing/include/remote_subscription.hpp
@@ -99,6 +99,7 @@ public:
     void set_expired();
     bool is_forwarded() const;
     void set_forwarded();
+    void clear_destiny();
 
 private:
     std::atomic<remote_subscription_id_t> id_;

--- a/implementation/routing/src/remote_subscription.cpp
+++ b/implementation/routing/src/remote_subscription.cpp
@@ -357,4 +357,8 @@ void remote_subscription::set_forwarded() {
     this->final_destination_.store(destiny::forward, std::memory_order_release);
 }
 
+void remote_subscription::clear_destiny() {
+    this->final_destination_.store(destiny::none, std::memory_order_release);
+}
+
 } // namespace vsomeip_v3

--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -2991,6 +2991,7 @@ void routing_manager_impl::on_remote_subscribe(
 
             its_update_lock.unlock();
             _callback(_subscription);
+            _subscription->clear_destiny();
             return;
         }
 
@@ -3003,6 +3004,7 @@ void routing_manager_impl::on_remote_subscribe(
                 its_service, its_instance, its_eventgroup, its_major,
                 _subscription->get_clients(), its_id);
     }
+    _subscription->clear_destiny();
 }
 
 void routing_manager_impl::on_remote_unsubscribe(


### PR DESCRIPTION
Summary
Allow subscriptions to expire when a reboot or ttl timeout is detected Details

set_noned() function created in remote_subscription.cpp added set_noned() at the end of routing_manager_impl::on_remote_subscribe to reset the set_forwarded to allow subscriptions to expire in case of reboot and ttl timeout.