### PR TITLE
Support handling multiple services with the same service and instance IDs but different major version.

### DIFF
--- a/implementation/compat/runtime/include/application_impl.hpp
+++ b/implementation/compat/runtime/include/application_impl.hpp
@@ -33,41 +33,41 @@ public:
     void start();
     void stop();
 
-    void offer_service(service_t _service, instance_t _instance,
+    void offer_service(service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor);
-    void stop_offer_service(service_t _service, instance_t _instance,
+    void stop_offer_service(service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor);
 
-    void offer_event(service_t _service, instance_t _instance, event_t _event,
+    void offer_event(service_t _service, unique_version_t _unique, event_t _event,
             const std::set<eventgroup_t> &_eventgroups, bool _is_field);
-    void stop_offer_event(service_t _service, instance_t _instance,
+    void stop_offer_event(service_t _service, unique_version_t _unique,
             event_t _event);
 
-    void request_service(service_t _service, instance_t _instance,
+    void request_service(service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor,
             bool _use_exclusive_proxy);
-    void release_service(service_t _service, instance_t _instance);
+    void release_service(service_t _service, unique_version_t _unique);
 
-    void request_event(service_t _service, instance_t _instance,
+    void request_event(service_t _service, unique_version_t _unique,
             event_t _event, const std::set<eventgroup_t> &_eventgroups,
             bool _is_field);
-    void release_event(service_t _service, instance_t _instance,
+    void release_event(service_t _service, unique_version_t _unique,
             event_t _event);
 
-    void subscribe(service_t _service, instance_t _instance,
+    void subscribe(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, major_version_t _major,
             subscription_type_e _subscription_type,
             event_t _event);
-    void unsubscribe(service_t _service, instance_t _instance,
+    void unsubscribe(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup);
 
-    bool is_available(service_t _service, instance_t _instance,
+    bool is_available(service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor) const;
 
     void send(std::shared_ptr<message> _message, bool _flush);
-    void notify(service_t _service, instance_t _instance,
+    void notify(service_t _service, unique_version_t _unique,
                 event_t _event, std::shared_ptr<payload> _payload) const;
-    void notify_one(service_t _service, instance_t _instance,
+    void notify_one(service_t _service, unique_version_t _unique,
                 event_t _event, std::shared_ptr<payload> _payload,
                 client_t _client) const;
 
@@ -75,10 +75,10 @@ public:
     void unregister_state_handler();
 
     void register_message_handler(service_t _service,
-            instance_t _instance, method_t _method,
+            unique_version_t _unique, method_t _method,
             message_handler_t _handler);
     void unregister_message_handler(service_t _service,
-            instance_t _instance, method_t _method);
+            unique_version_t _unique, method_t _method);
 
     void register_availability_handler(service_t _service,
             instance_t _instance, availability_handler_t _handler,
@@ -88,60 +88,60 @@ public:
             major_version_t _major, minor_version_t _minor);
 
     void register_subscription_handler(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup,
+            unique_version_t _unique, eventgroup_t _eventgroup,
             subscription_handler_t _handler);
     void unregister_subscription_handler(service_t _service,
-                instance_t _instance, eventgroup_t _eventgroup);
+                unique_version_t _unique, eventgroup_t _eventgroup);
 
     void register_subscription_error_handler(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup,
+            unique_version_t _unique, eventgroup_t _eventgroup,
             error_handler_t _handler);
     void unregister_subscription_error_handler(service_t _service,
-                instance_t _instance, eventgroup_t _eventgroup);
+                unique_version_t _unique, eventgroup_t _eventgroup);
 
     void clear_all_handler();
 
     bool is_routing() const;
 
     void offer_event(service_t _service,
-            instance_t _instance, event_t _event,
+            unique_version_t _unique, event_t _event,
             const std::set<eventgroup_t> &_eventgroups,
             bool _is_field,
             std::chrono::milliseconds _cycle,
             bool _change_resets_cycle,
             const epsilon_change_func_t &_epsilon_change_func);
 
-    void notify(service_t _service, instance_t _instance,
+    void notify(service_t _service, unique_version_t _unique,
             event_t _event, std::shared_ptr<payload> _payload,
             bool _force) const;
 
-    void notify_one(service_t _service, instance_t _instance,
+    void notify_one(service_t _service, unique_version_t _unique,
             event_t _event, std::shared_ptr<payload> _payload,
             client_t _client, bool _force) const;
 
     bool are_available(available_t &_available,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor) const;
 
-    void notify(service_t _service, instance_t _instance,
+    void notify(service_t _service, unique_version_t _unique,
             event_t _event, std::shared_ptr<payload> _payload,
             bool _force, bool _flush) const;
 
-    void notify_one(service_t _service, instance_t _instance,
+    void notify_one(service_t _service, unique_version_t _unique,
                 event_t _event, std::shared_ptr<payload> _payload,
                 client_t _client, bool _force, bool _flush) const;
 
     void set_routing_state(routing_state_e _routing_state);
 
-    void unsubscribe(service_t _service, instance_t _instance,
+    void unsubscribe(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, event_t _event);
 
     void register_subscription_status_handler(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup, event_t _event,
+            unique_version_t _unique, eventgroup_t _eventgroup, event_t _event,
             subscription_status_handler_t _handler);
 
     void register_subscription_status_handler(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup, event_t _event,
+            unique_version_t _unique, eventgroup_t _eventgroup, event_t _event,
             subscription_status_handler_t _handler, bool _is_selective);
 
     void get_offered_services_async(
@@ -151,7 +151,7 @@ public:
             watchdog_handler_t _handler, std::chrono::seconds _interval);
 
     virtual void register_async_subscription_handler(
-            service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+            service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
             async_subscription_handler_t _handler);
 
     virtual void set_offer_acceptance_required(
@@ -172,7 +172,7 @@ public:
             routing_state_handler_t _handler);
 
     virtual bool update_service_configuration(
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             std::uint16_t _port, bool _reliable,
             bool _magic_cookies_enabled, bool _offer);
 
@@ -186,14 +186,14 @@ public:
 
 private:
     bool is_selective_event(
-            vsomeip::service_t _service, vsomeip::instance_t _instance,
+            vsomeip::service_t _service, vsomeip::unique_version_t _unique,
             const std::set<vsomeip::eventgroup_t> &_eventgroups);
 
 private:
     std::shared_ptr<vsomeip_v3::application> impl_;
 
     std::map<service_t,
-        std::map<instance_t, std::set<eventgroup_t> > > eventgroups_;
+        std::map<unique_version_t, std::set<eventgroup_t> > > eventgroups_;
     std::mutex eventgroups_mutex_;
 };
 

--- a/implementation/compat/runtime/src/application_impl.cpp
+++ b/implementation/compat/runtime/src/application_impl.cpp
@@ -68,21 +68,21 @@ application_impl::stop() {
 }
 
 void
-application_impl::offer_service(service_t _service, instance_t _instance,
+application_impl::offer_service(service_t _service, unique_version_t _unique,
         major_version_t _major, minor_version_t _minor) {
 
-    impl_->offer_service(_service, _instance, _major, _minor);
+    impl_->offer_service(_service, _unique, _major, _minor);
 }
 
 void
-application_impl::stop_offer_service(service_t _service, instance_t _instance,
+application_impl::stop_offer_service(service_t _service, unique_version_t _unique,
         major_version_t _major, minor_version_t _minor) {
 
-    impl_->stop_offer_service(_service, _instance, _major, _minor);
+    impl_->stop_offer_service(_service, _unique, _major, _minor);
 }
 
 void
-application_impl::offer_event(service_t _service, instance_t _instance,
+application_impl::offer_event(service_t _service, unique_version_t _unique,
         event_t _event, const std::set<eventgroup_t> &_eventgroups,
         bool _is_field) {
 
@@ -96,76 +96,76 @@ application_impl::offer_event(service_t _service, instance_t _instance,
         // Note: The check can be done on the eventgroup(s) as selective
         // events own an exclusive eventgroup.
         const bool is_selective
-            = is_selective_event(_service, _instance, _eventgroups);
+            = is_selective_event(_service, _unique, _eventgroups);
 
         if (is_selective)
             its_type = vsomeip_v3::event_type_e::ET_SELECTIVE_EVENT;
     }
 
-    impl_->offer_event(_service, _instance, _event, _eventgroups, its_type);
+    impl_->offer_event(_service, _unique, _event, _eventgroups, its_type);
 }
 
 void
-application_impl::stop_offer_event(service_t _service, instance_t _instance,
+application_impl::stop_offer_event(service_t _service, unique_version_t _unique,
         event_t _event) {
 
-    impl_->stop_offer_event(_service, _instance, _event);
+    impl_->stop_offer_event(_service, _unique, _event);
 }
 
 void
-application_impl::request_service(service_t _service, instance_t _instance,
+application_impl::request_service(service_t _service, unique_version_t _unique,
         major_version_t _major, minor_version_t _minor,
         bool _use_exclusive_proxy) {
 
     (void)_use_exclusive_proxy;
-    impl_->request_service(_service, _instance, _major, _minor);
+    impl_->request_service(_service, _unique, _major, _minor);
 }
 
 void
-application_impl::release_service(service_t _service, instance_t _instance) {
+application_impl::release_service(service_t _service, unique_version_t _unique) {
 
-    impl_->release_service(_service, _instance);
+    impl_->release_service(_service, _unique);
 }
 
 void
-application_impl::request_event(service_t _service, instance_t _instance,
+application_impl::request_event(service_t _service, unique_version_t _unique,
         event_t _event, const std::set<eventgroup_t> &_eventgroups,
         bool _is_field) {
 
     const vsomeip_v3::event_type_e its_type = (_is_field) ?
             vsomeip_v3::event_type_e::ET_FIELD :
             vsomeip_v3::event_type_e::ET_EVENT;
-    impl_->request_event(_service, _instance, _event, _eventgroups, its_type);
+    impl_->request_event(_service, _unique, _event, _eventgroups, its_type);
 }
 
 void
-application_impl::release_event(service_t _service, instance_t _instance,
+application_impl::release_event(service_t _service, unique_version_t _unique,
         event_t _event) {
 
-    impl_->release_event(_service, _instance, _event);
+    impl_->release_event(_service, _unique, _event);
 }
 
 void
-application_impl::subscribe(service_t _service, instance_t _instance,
+application_impl::subscribe(service_t _service, unique_version_t _unique,
         eventgroup_t _eventgroup, major_version_t _major,
         subscription_type_e _subscription_type, event_t _event) {
 
     (void)_subscription_type; // unused in v3
-    impl_->subscribe(_service, _instance, _eventgroup, _major, _event);
+    impl_->subscribe(_service, _unique, _eventgroup, _major, _event);
 }
 
 void
-application_impl::unsubscribe(service_t _service, instance_t _instance,
+application_impl::unsubscribe(service_t _service, unique_version_t _unique,
         eventgroup_t _eventgroup) {
 
-    impl_->unsubscribe(_service, _instance, _eventgroup);
+    impl_->unsubscribe(_service, _unique, _eventgroup);
 }
 
 bool
-application_impl::is_available(service_t _service, instance_t _instance,
+application_impl::is_available(service_t _service, unique_version_t _unique,
         major_version_t _major, minor_version_t _minor) const {
 
-    return impl_->is_available(_service, _instance, _major, _minor);
+    return impl_->is_available(_service, _unique, _major, _minor);
 }
 
 void
@@ -179,27 +179,27 @@ application_impl::send(std::shared_ptr<message> _message, bool _flush = true) {
 }
 
 void
-application_impl::notify(service_t _service, instance_t _instance,
+application_impl::notify(service_t _service, unique_version_t _unique,
             event_t _event, std::shared_ptr<payload> _payload) const {
 
     if (_payload) {
         auto its_payload = std::dynamic_pointer_cast<payload_impl>(_payload);
-        impl_->notify(_service, _instance, _event, its_payload->get_impl());
+        impl_->notify(_service, _unique, _event, its_payload->get_impl());
     } else {
-        impl_->notify(_service, _instance, _event, nullptr);
+        impl_->notify(_service, _unique, _event, nullptr);
     }
 }
 
 void
-application_impl::notify_one(service_t _service, instance_t _instance,
+application_impl::notify_one(service_t _service, unique_version_t _unique,
             event_t _event, std::shared_ptr<payload> _payload,
             client_t _client) const {
 
     if (_payload) {
         auto its_payload = std::dynamic_pointer_cast<payload_impl>(_payload);
-        impl_->notify_one(_service, _instance, _event, its_payload->get_impl(), _client);
+        impl_->notify_one(_service, _unique, _event, its_payload->get_impl(), _client);
     } else {
-        impl_->notify_one(_service, _instance, _event, nullptr, _client);
+        impl_->notify_one(_service, _unique, _event, nullptr, _client);
     }
 }
 
@@ -221,10 +221,10 @@ application_impl::unregister_state_handler() {
 
 void
 application_impl::register_message_handler(
-        service_t _service, instance_t _instance, method_t _method,
+        service_t _service, unique_version_t _unique, method_t _method,
         message_handler_t _handler) {
 
-    impl_->register_message_handler(_service, _instance, _method,
+    impl_->register_message_handler(_service, _unique, _method,
             [_handler](const std::shared_ptr<vsomeip_v3::message> &_message) {
                 auto its_message = std::make_shared<message_impl>(_message);
                 _handler(its_message);
@@ -234,9 +234,9 @@ application_impl::register_message_handler(
 
 void
 application_impl::unregister_message_handler(
-        service_t _service, instance_t _instance, method_t _method) {
+        service_t _service, unique_version_t _unique, method_t _method) {
 
-    impl_->unregister_message_handler(_service, _instance, _method);
+    impl_->unregister_message_handler(_service, _unique, _method);
 }
 
 void
@@ -259,14 +259,14 @@ application_impl::unregister_availability_handler(
 
 void
 application_impl::register_subscription_handler(
-        service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+        service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
         subscription_handler_t _handler) {
     {
         std::lock_guard<std::mutex> its_lock(eventgroups_mutex_);
-        eventgroups_[_service][_instance].insert(_eventgroup);
+        eventgroups_[_service][_unique].insert(_eventgroup);
     }
 
-    impl_->register_subscription_handler(_service, _instance, _eventgroup,
+    impl_->register_subscription_handler(_service, _unique, _eventgroup,
             [_handler](client_t _client, vsomeip::uid_t _uid,
                     vsomeip::gid_t _gid, bool _accepted){
                 (void)_uid;
@@ -278,9 +278,9 @@ application_impl::register_subscription_handler(
 
 void
 application_impl::unregister_subscription_handler(
-        service_t _service, instance_t _instance, eventgroup_t _eventgroup) {
+        service_t _service, unique_version_t _unique, eventgroup_t _eventgroup) {
 
-    impl_->unregister_subscription_handler(_service, _instance, _eventgroup);
+    impl_->unregister_subscription_handler(_service, _unique, _eventgroup);
 }
 
 
@@ -291,16 +291,16 @@ application_impl::unregister_subscription_handler(
 
 void
 application_impl::register_subscription_error_handler(
-        service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+        service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
         error_handler_t _handler) {
 
     impl_->register_subscription_status_handler(
-            _service, _instance, _eventgroup, ERROR_HANDLER_DUMMY_EVENT,
-            [_handler](service_t _service, instance_t _instance,
+            _service, _unique, _eventgroup, ERROR_HANDLER_DUMMY_EVENT,
+            [_handler](service_t _service, unique_version_t _unique,
                        eventgroup_t _eventgroup, event_t _event,
                        uint16_t _error) {
                 (void)_service;
-                (void)_instance;
+                (void)_unique;
                 (void)_eventgroup;
                 (void)_event;
 
@@ -312,9 +312,9 @@ application_impl::register_subscription_error_handler(
 
 void
 application_impl::unregister_subscription_error_handler(
-        service_t _service, instance_t _instance, eventgroup_t _eventgroup) {
+        service_t _service, unique_version_t _unique, eventgroup_t _eventgroup) {
 
-    impl_->unregister_subscription_status_handler(_service, _instance,
+    impl_->unregister_subscription_status_handler(_service, _unique,
             _eventgroup, ERROR_HANDLER_DUMMY_EVENT);
 }
 
@@ -332,7 +332,7 @@ application_impl::is_routing() const {
 
 void
 application_impl::offer_event(
-        service_t _service, instance_t _instance, event_t _event,
+        service_t _service, unique_version_t _unique, event_t _event,
         const std::set<eventgroup_t> &_eventgroups,
         bool _is_field,
         std::chrono::milliseconds _cycle,
@@ -349,13 +349,13 @@ application_impl::offer_event(
         // Note: The check can be done on the eventgroup(s) as selective
         // events own an exclusive eventgroup.
         const bool is_selective
-            = is_selective_event(_service, _instance, _eventgroups);
+            = is_selective_event(_service, _unique, _eventgroups);
 
         if (is_selective)
             its_type = vsomeip_v3::event_type_e::ET_SELECTIVE_EVENT;
     }
 
-    impl_->offer_event(_service, _instance, _event, _eventgroups,
+    impl_->offer_event(_service, _unique, _event, _eventgroups,
             its_type, _cycle, _change_resets_cycle, true,
             [_epsilon_change_func](
                     const std::shared_ptr<vsomeip_v3::payload> &_lhs,
@@ -368,44 +368,44 @@ application_impl::offer_event(
 }
 
 void
-application_impl::notify(service_t _service, instance_t _instance,
+application_impl::notify(service_t _service, unique_version_t _unique,
         event_t _event, std::shared_ptr<payload> _payload, bool _force) const {
 
     if (_payload) {
         auto its_payload = std::dynamic_pointer_cast<payload_impl>(_payload);
-        impl_->notify(_service, _instance, _event, its_payload->get_impl(),
+        impl_->notify(_service, _unique, _event, its_payload->get_impl(),
                 _force);
     } else {
-        impl_->notify(_service, _instance, _event, nullptr, _force);
+        impl_->notify(_service, _unique, _event, nullptr, _force);
     }
 }
 
 void
-application_impl::notify_one(service_t _service, instance_t _instance,
+application_impl::notify_one(service_t _service, unique_version_t _unique,
         event_t _event, std::shared_ptr<payload> _payload,
         client_t _client, bool _force) const {
 
     if (_payload) {
         auto its_payload = std::dynamic_pointer_cast<payload_impl>(_payload);
-        impl_->notify_one(_service, _instance, _event, its_payload->get_impl(),
+        impl_->notify_one(_service, _unique, _event, its_payload->get_impl(),
                 _client, _force);
     } else {
-        impl_->notify_one(_service, _instance, _event, nullptr, _client,
+        impl_->notify_one(_service, _unique, _event, nullptr, _client,
                 _force);
     }
 }
 
 bool
 application_impl::are_available(available_t &_available,
-        service_t _service, instance_t _instance,
+        service_t _service, unique_version_t _unique,
         major_version_t _major, minor_version_t _minor) const {
 
-    return impl_->are_available(_available, _service, _instance, _major,
+    return impl_->are_available(_available, _service, _unique, _major,
             _minor);
 }
 
 void
-application_impl::notify(service_t _service, instance_t _instance,
+application_impl::notify(service_t _service, unique_version_t _unique,
         event_t _event, std::shared_ptr<payload> _payload,
         bool _force, bool _flush) const {
 
@@ -413,15 +413,15 @@ application_impl::notify(service_t _service, instance_t _instance,
 
     if (_payload) {
         auto its_payload = std::dynamic_pointer_cast<payload_impl>(_payload);
-        impl_->notify(_service, _instance, _event, its_payload->get_impl(),
+        impl_->notify(_service, _unique, _event, its_payload->get_impl(),
                 _force);
     } else {
-        impl_->notify(_service, _instance, _event, nullptr, _force);
+        impl_->notify(_service, _unique, _event, nullptr, _force);
     }
 }
 
 void
-application_impl::notify_one(service_t _service, instance_t _instance,
+application_impl::notify_one(service_t _service, unique_version_t _unique,
             event_t _event, std::shared_ptr<payload> _payload,
             client_t _client, bool _force, bool _flush) const {
 
@@ -429,10 +429,10 @@ application_impl::notify_one(service_t _service, instance_t _instance,
 
     if (_payload) {
         auto its_payload = std::dynamic_pointer_cast<payload_impl>(_payload);
-        impl_->notify_one(_service, _instance, _event, its_payload->get_impl(),
+        impl_->notify_one(_service, _unique, _event, its_payload->get_impl(),
                 _client, _force);
     } else {
-        impl_->notify_one(_service, _instance, _event, nullptr, _client,
+        impl_->notify_one(_service, _unique, _event, nullptr, _client,
                 _force);
     }
 }
@@ -445,24 +445,24 @@ application_impl::set_routing_state(routing_state_e _routing_state) {
 }
 
 void
-application_impl::unsubscribe(service_t _service, instance_t _instance,
+application_impl::unsubscribe(service_t _service, unique_version_t _unique,
         eventgroup_t _eventgroup, event_t _event) {
 
-    impl_->unsubscribe(_service, _instance, _eventgroup, _event);
+    impl_->unsubscribe(_service, _unique, _eventgroup, _event);
 }
 
 void
 application_impl::register_subscription_status_handler(service_t _service,
-        instance_t _instance, eventgroup_t _eventgroup, event_t _event,
+        unique_version_t _unique, eventgroup_t _eventgroup, event_t _event,
         subscription_status_handler_t _handler) {
 
-    register_subscription_status_handler(_service, _instance,
+    register_subscription_status_handler(_service, _unique,
             _eventgroup, _event, _handler, false);
 }
 
 void
 application_impl::register_subscription_status_handler(service_t _service,
-        instance_t _instance, eventgroup_t _eventgroup, event_t _event,
+        unique_version_t _unique, eventgroup_t _eventgroup, event_t _event,
         subscription_status_handler_t _handler, bool _is_selective) {
     if (_is_selective) {
         std::set<vsomeip::eventgroup_t> its_eventgroups;
@@ -473,20 +473,20 @@ application_impl::register_subscription_status_handler(service_t _service,
         // whether an event is selective, the call to "register_event" does
         // not. Therefore, we re-register the event with correct event type
         // here.
-        impl_->request_event(_service, _instance, _event, its_eventgroups,
+        impl_->request_event(_service, _unique, _event, its_eventgroups,
                 vsomeip_v3::event_type_e::ET_SELECTIVE_EVENT);
     }
 
-    impl_->register_subscription_status_handler(_service, _instance,
+    impl_->register_subscription_status_handler(_service, _unique,
             _eventgroup, _event,
             [_handler](const vsomeip_v3::service_t _service,
-                       const vsomeip_v3::instance_t _instance,
+                       const vsomeip_v3::unique_version_t _unique,
                        const vsomeip_v3::eventgroup_t _eventgroup,
                        const vsomeip_v3::event_t _event,
                        const uint16_t _error) {
 
                 if (_handler)
-                    _handler(_service, _instance, _eventgroup, _event, _error);
+                    _handler(_service, _unique, _eventgroup, _event, _error);
             },
             _is_selective);
 }
@@ -508,14 +508,14 @@ application_impl::set_watchdog_handler(
 
 void
 application_impl::register_async_subscription_handler(
-        service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+        service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
         async_subscription_handler_t _handler) {
 
     {
         std::lock_guard<std::mutex> its_lock(eventgroups_mutex_);
-        eventgroups_[_service][_instance].insert(_eventgroup);
+        eventgroups_[_service][_unique].insert(_eventgroup);
     }
-    impl_->register_async_subscription_handler(_service, _instance,
+    impl_->register_async_subscription_handler(_service, _unique,
             _eventgroup, [_handler](client_t _client,
                     vsomeip::uid_t _uid, vsomeip::gid_t _gid, bool _accepted,
                     std::function<void(const bool)> _handler2) {
@@ -581,12 +581,12 @@ application_impl::register_routing_state_handler(
 
 bool
 application_impl::update_service_configuration(
-        service_t _service, instance_t _instance,
+        service_t _service, unique_version_t _unique,
         std::uint16_t _port, bool _reliable,
         bool _magic_cookies_enabled, bool _offer) {
 
     (void)_service;
-    (void)_instance;
+    (void)_unique;
     (void)_port;
     (void)_reliable;
     (void)_magic_cookies_enabled;
@@ -628,7 +628,7 @@ application_impl::remove_security_policy_configuration(
 
 bool
 application_impl::is_selective_event(
-        vsomeip::service_t _service, vsomeip::instance_t _instance,
+        vsomeip::service_t _service, vsomeip::unique_version_t _unique,
         const std::set<vsomeip::eventgroup_t> &_eventgroups) {
 
     bool is_selective(false);
@@ -636,11 +636,11 @@ application_impl::is_selective_event(
     std::lock_guard<std::mutex> its_events_lock(eventgroups_mutex_);
     const auto its_service = eventgroups_.find(_service);
     if (its_service != eventgroups_.end()) {
-        const auto its_instance = its_service->second.find(_instance);
-        if (its_instance != its_service->second.end()) {
+        const auto its_unique = its_service->second.find(_unique);
+        if (its_unique != its_service->second.end()) {
             for (const auto eg : _eventgroups) {
-                const auto its_egrp = its_instance->second.find(eg);
-                if (its_egrp != its_instance->second.end()) {
+                const auto its_egrp = its_unique->second.find(eg);
+                if (its_egrp != its_unique->second.end()) {
                     is_selective = true;
                     break;
                 }

--- a/implementation/configuration/include/client.hpp
+++ b/implementation/configuration/include/client.hpp
@@ -17,12 +17,12 @@ namespace cfg {
 
 struct client {
     client() : service_(ANY_SERVICE),
-            instance_(ANY_INSTANCE) {
+            unique_(ANY_INSTANCE) {
     }
 
     // ports for specific service / instance
     service_t service_;
-    instance_t instance_;
+    unique_version_t unique_;
     std::map<bool, std::set<uint16_t> > ports_;
     std::map<bool, uint16_t> last_used_specific_client_port_;
 

--- a/implementation/configuration/include/configuration.hpp
+++ b/implementation/configuration/include/configuration.hpp
@@ -58,12 +58,12 @@ public:
     virtual bool lazy_load_security(const std::string &_client_host) = 0;
 #endif // !VSOMEIP_DISABLE_SECURITY
     virtual bool remote_offer_info_add(service_t _service,
-                                       instance_t _instance,
+                                       unique_version_t _unique,
                                        std::uint16_t _port,
                                        bool _reliable,
                                        bool _magic_cookies_enabled) = 0;
     virtual bool remote_offer_info_remove(service_t _service,
-                                          instance_t _instance,
+                                          unique_version_t _unique,
                                           std::uint16_t _port,
                                           bool _reliable,
                                           bool _magic_cookies_enabled,
@@ -99,13 +99,13 @@ public:
     virtual routing_state_e get_initial_routing_state() const = 0;
 
     virtual std::string get_unicast_address(service_t _service,
-            instance_t _instance) const = 0;
+            unique_version_t _unique) const = 0;
     virtual uint16_t get_reliable_port(service_t _service,
-            instance_t _instance) const = 0;
+            unique_version_t _unique) const = 0;
     virtual bool has_enabled_magic_cookies(const std::string &_address,
             uint16_t _port) const = 0;
     virtual uint16_t get_unreliable_port(service_t _service,
-            instance_t _instance) const = 0;
+            unique_version_t _unique) const = 0;
 
     virtual void get_configured_timing_requests(
             service_t _service, const std::string &_ip_target,
@@ -118,22 +118,22 @@ public:
             std::chrono::nanoseconds *_debounce_time,
             std::chrono::nanoseconds *_max_retention_time) const = 0;
 
-    virtual bool is_someip(service_t _service, instance_t _instance) const = 0;
+    virtual bool is_someip(service_t _service, unique_version_t _unique) const = 0;
 
-    virtual bool get_client_port(service_t _service, instance_t _instance,
+    virtual bool get_client_port(service_t _service, unique_version_t _unique,
             uint16_t _remote_port, bool _reliable,
             std::map<bool, std::set<uint16_t> > &_used_client_ports, uint16_t &_client_port) const = 0;
 
-    virtual std::set<std::pair<service_t, instance_t> > get_remote_services() const = 0;
+    virtual std::set<std::pair<service_t, unique_version_t> > get_remote_services() const = 0;
 
-    virtual bool get_multicast(service_t _service, instance_t _instance,
+    virtual bool get_multicast(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, std::string &_address, uint16_t &_port) const = 0;
 
-    virtual uint8_t get_threshold(service_t _service, instance_t _instance,
+    virtual uint8_t get_threshold(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup) const = 0;
 
     virtual void get_event_update_properties(
-            service_t _service, instance_t _instance, event_t _event,
+            service_t _service, unique_version_t _unique, event_t _event,
             std::chrono::milliseconds &_cycle,
             bool &_change_resets_cycle, bool &_update_on_change_) const = 0;
 
@@ -156,14 +156,14 @@ public:
 
     virtual bool supports_selective_broadcasts(const boost::asio::ip::address &_address) const = 0;
 
-    virtual bool is_offered_remote(service_t _service, instance_t _instance) const = 0;
+    virtual bool is_offered_remote(service_t _service, unique_version_t _unique) const = 0;
 
-    virtual bool is_local_service(service_t _service, instance_t _instance) const = 0;
+    virtual bool is_local_service(service_t _service, unique_version_t _unique) const = 0;
 
     virtual reliability_type_e get_event_reliability(
-            service_t _service, instance_t _instance, event_t _event) const = 0;
+            service_t _service, unique_version_t _unique, event_t _event) const = 0;
     virtual reliability_type_e get_service_reliability(
-            service_t _service, instance_t _instance) const = 0;
+            service_t _service, unique_version_t _unique) const = 0;
 
     // Service Discovery configuration
     virtual bool is_sd_enabled() const = 0;
@@ -218,14 +218,14 @@ public:
 
     // TTL factor
     typedef std::uint32_t ttl_factor_t;
-    typedef std::map<service_t, std::map<instance_t, ttl_factor_t>> ttl_map_t;
+    typedef std::map<service_t, std::map<unique_version_t, ttl_factor_t>> ttl_map_t;
     virtual ttl_map_t get_ttl_factor_offers() const = 0;
     virtual ttl_map_t get_ttl_factor_subscribes() const = 0;
 
     // Debouncing
     virtual std::shared_ptr<debounce_filter_impl_t> get_debounce(
             const std::string &_name,
-            service_t _service, instance_t _instance, event_t _event) const = 0;
+            service_t _service, unique_version_t _unique, event_t _event) const = 0;
 
     // Queue size limit endpoints
     typedef std::uint32_t endpoint_queue_limit_t;
@@ -269,7 +269,7 @@ public:
     virtual void set_sd_acceptance_rules_active(
             const boost::asio::ip::address& _address, bool _enable) = 0;
 
-    virtual bool is_secure_service(service_t _service, instance_t _instance) const = 0;
+    virtual bool is_secure_service(service_t _service, unique_version_t _unique) const = 0;
 
     virtual int get_udp_receive_buffer_size() const = 0;
 
@@ -277,17 +277,17 @@ public:
             const vsomeip_sec_client_t *_sec_client) const = 0;
 
     virtual bool check_suppress_events(service_t _service,
-            instance_t _instance, event_t _event) const = 0;
+            unique_version_t _unique, event_t _event) const = 0;
 
     // SOME/IP-TP
     virtual bool is_tp_client(
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             method_t _method) const = 0;
     virtual bool is_tp_service(
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             method_t _method) const = 0;
     virtual void get_tp_configuration(
-            service_t _service, instance_t _instance, method_t _method, bool _is_client,
+            service_t _service, unique_version_t _unique, method_t _method, bool _is_client,
             std::uint16_t &_max_segment_length, std::uint32_t &_separation_time) const = 0;
 
     // routing shutdown timeout
@@ -301,7 +301,7 @@ public:
     virtual uint8_t get_max_remote_subscribers() const = 0;
 
     virtual partition_id_t get_partition_id(
-            service_t _service, instance_t _instance) const = 0;
+            service_t _service, unique_version_t _unique) const = 0;
 
     virtual reliability_type_e get_reliability_type(
             const boost::asio::ip::address &_reliable_address,

--- a/implementation/configuration/include/configuration_impl.hpp
+++ b/implementation/configuration/include/configuration_impl.hpp
@@ -40,15 +40,15 @@ struct watchdog;
 
 struct suppress_t {
     service_t service;
-    instance_t instance;
+    unique_version_t unique;
     event_t event;
 
     inline bool operator<(const suppress_t& entry_) const {
         if(service != entry_.service) {
             return service < entry_.service;
         }
-        if(instance != entry_.instance) {
-            return instance < entry_.instance;
+        if(unique != entry_.unique) {
+            return unique < entry_.unique;
         }
         if(event != entry_.event) {
             return event < entry_.event;
@@ -70,12 +70,12 @@ public:
     VSOMEIP_EXPORT bool lazy_load_security(const std::string &_client_host);
 #endif // !VSOMEIP_DISABLE_SECURITY
     VSOMEIP_EXPORT bool remote_offer_info_add(service_t _service,
-                                              instance_t _instance,
+                                              unique_version_t _unique,
                                               std::uint16_t _port,
                                               bool _reliable,
                                               bool _magic_cookies_enabled);
     VSOMEIP_EXPORT bool remote_offer_info_remove(service_t _service,
-                                                 instance_t _instance,
+                                                 unique_version_t _unique,
                                                  std::uint16_t _port,
                                                  bool _reliable,
                                                  bool _magic_cookies_enabled,
@@ -100,12 +100,12 @@ public:
     VSOMEIP_EXPORT const std::string & get_logfile() const;
     VSOMEIP_EXPORT vsomeip_v3::logger::level_e get_loglevel() const;
 
-    VSOMEIP_EXPORT std::string get_unicast_address(service_t _service, instance_t _instance) const;
+    VSOMEIP_EXPORT std::string get_unicast_address(service_t _service, unique_version_t _unique) const;
 
-    VSOMEIP_EXPORT uint16_t get_reliable_port(service_t _service, instance_t _instance) const;
+    VSOMEIP_EXPORT uint16_t get_reliable_port(service_t _service, unique_version_t _unique) const;
     VSOMEIP_EXPORT bool has_enabled_magic_cookies(const std::string &_address, uint16_t _port) const;
     VSOMEIP_EXPORT uint16_t get_unreliable_port(service_t _service,
-            instance_t _instance) const;
+            unique_version_t _unique) const;
 
     VSOMEIP_EXPORT void get_configured_timing_requests(
             service_t _service, const std::string &_ip_target,
@@ -118,9 +118,9 @@ public:
             std::chrono::nanoseconds *_debounce_time,
             std::chrono::nanoseconds *_max_retention_time) const;
 
-    VSOMEIP_EXPORT bool is_someip(service_t _service, instance_t _instance) const;
+    VSOMEIP_EXPORT bool is_someip(service_t _service, unique_version_t _unique) const;
 
-    VSOMEIP_EXPORT bool get_client_port(service_t _service, instance_t _instance,
+    VSOMEIP_EXPORT bool get_client_port(service_t _service, unique_version_t _unique,
             uint16_t _remote_port, bool _reliable,
             std::map<bool, std::set<uint16_t> > &_used_client_ports, uint16_t &_client_port) const;
 
@@ -147,16 +147,16 @@ public:
     VSOMEIP_EXPORT std::size_t get_request_debouncing(const std::string &_name) const;
     VSOMEIP_EXPORT bool has_session_handling(const std::string &_name) const;
 
-    VSOMEIP_EXPORT std::set<std::pair<service_t, instance_t> > get_remote_services() const;
+    VSOMEIP_EXPORT std::set<std::pair<service_t, unique_version_t> > get_remote_services() const;
 
-    VSOMEIP_EXPORT bool get_multicast(service_t _service, instance_t _instance,
+    VSOMEIP_EXPORT bool get_multicast(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, std::string &_address, uint16_t &_port) const;
 
-    VSOMEIP_EXPORT uint8_t get_threshold(service_t _service, instance_t _instance,
+    VSOMEIP_EXPORT uint8_t get_threshold(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup) const;
 
     VSOMEIP_EXPORT void get_event_update_properties(
-            service_t _service, instance_t _instance, event_t _event,
+            service_t _service, unique_version_t _unique, event_t _event,
             std::chrono::milliseconds &_cycle,
             bool &_change_resets_cycle, bool &_update_on_change_) const;
 
@@ -168,18 +168,18 @@ public:
 
     VSOMEIP_EXPORT bool supports_selective_broadcasts(const boost::asio::ip::address &_address) const;
 
-    VSOMEIP_EXPORT bool is_offered_remote(service_t _service, instance_t _instance) const;
+    VSOMEIP_EXPORT bool is_offered_remote(service_t _service, unique_version_t _unique) const;
 
     VSOMEIP_EXPORT bool log_version() const;
     VSOMEIP_EXPORT uint32_t get_log_version_interval() const;
 
-    VSOMEIP_EXPORT bool is_local_service(service_t _service, instance_t _instance) const;
+    VSOMEIP_EXPORT bool is_local_service(service_t _service, unique_version_t _unique) const;
 
     VSOMEIP_EXPORT reliability_type_e get_event_reliability(
-            service_t _service, instance_t _instance, event_t _event) const;
+            service_t _service, unique_version_t _unique, event_t _event) const;
 
     VSOMEIP_EXPORT reliability_type_e get_service_reliability(
-            service_t _service, instance_t _instance) const;
+            service_t _service, unique_version_t _unique) const;
 
     // Service Discovery configuration
     VSOMEIP_EXPORT bool is_sd_enabled() const;
@@ -211,7 +211,7 @@ public:
             const vsomeip_sec_client_t *_sec_client) const;
 
     VSOMEIP_EXPORT bool check_suppress_events(service_t _service,
-            instance_t _instance, event_t _event) const;
+            unique_version_t _unique, event_t _event) const;
 
     VSOMEIP_EXPORT std::map<plugin_type_e, std::set<std::string>> get_plugins(
             const std::string &_name) const;
@@ -230,7 +230,7 @@ public:
 
     VSOMEIP_EXPORT std::shared_ptr<debounce_filter_impl_t> get_debounce(
             const std::string &_name,
-            service_t _service, instance_t _instance, event_t _event) const;
+            service_t _service, unique_version_t _unique, event_t _event) const;
 
     VSOMEIP_EXPORT endpoint_queue_limit_t get_endpoint_queue_limit(
             const std::string& _address, std::uint16_t _port) const;
@@ -258,18 +258,18 @@ public:
     VSOMEIP_EXPORT void set_sd_acceptance_rules_active(
             const boost::asio::ip::address& _address, bool _enable);
 
-    VSOMEIP_EXPORT bool is_secure_service(service_t _service, instance_t _instance) const;
+    VSOMEIP_EXPORT bool is_secure_service(service_t _service, unique_version_t _unique) const;
 
     VSOMEIP_EXPORT int get_udp_receive_buffer_size() const;
 
     VSOMEIP_EXPORT bool is_tp_client(
             service_t _service,
-            instance_t _instance,
+            unique_version_t _unique,
             method_t _method) const;
     VSOMEIP_EXPORT bool is_tp_service(
-            service_t _service, instance_t _instance, method_t _method) const;
+            service_t _service, unique_version_t _unique, method_t _method) const;
     VSOMEIP_EXPORT void get_tp_configuration(
-            service_t _service, instance_t _instance, method_t _method, bool _is_client,
+            service_t _service, unique_version_t _unique, method_t _method, bool _is_client,
             std::uint16_t &_max_segment_length, std::uint32_t &_separation_time) const;
 
     VSOMEIP_EXPORT std::uint32_t get_shutdown_timeout() const;
@@ -282,7 +282,7 @@ public:
     VSOMEIP_EXPORT uint8_t get_max_remote_subscribers() const;
 
     VSOMEIP_EXPORT partition_id_t get_partition_id(
-            service_t _service, instance_t _instance) const;
+            service_t _service, unique_version_t _unique) const;
 
     VSOMEIP_EXPORT std::map<std::string, std::string> get_additional_data(
             const std::string &_application_name,
@@ -357,7 +357,7 @@ private:
             std::shared_ptr<trace_filter> &_filter);
     void load_trace_filter_match(
             const boost::property_tree::ptree &_data,
-            std::tuple<service_t, instance_t, method_t> &_match);
+            std::tuple<service_t, unique_version_t, method_t> &_match);
 
     void load_suppress_events(const configuration_element &_element);
     void load_suppress_events_data(
@@ -368,7 +368,7 @@ private:
     std::set<event_t> load_range_events(event_t _first_event,
             event_t _last_event) const ;
     void insert_suppress_events(service_t  _service,
-    instance_t _instance, event_t _event);
+    unique_version_t _unique, event_t _event);
     void print_suppress_events(void) const;
 
     void load_network(const configuration_element &_element);
@@ -435,17 +435,17 @@ private:
 
     servicegroup *find_servicegroup(const std::string &_name) const;
     std::shared_ptr<client> find_client(service_t _service,
-            instance_t _instance) const;
-    std::shared_ptr<service> find_service(service_t _service, instance_t _instance) const;
-    std::shared_ptr<service> find_service_unlocked(service_t _service, instance_t _instance) const;
+            unique_version_t _unique) const;
+    std::shared_ptr<service> find_service(service_t _service, unique_version_t _unique) const;
+    std::shared_ptr<service> find_service_unlocked(service_t _service, unique_version_t _unique) const;
     std::shared_ptr<service> find_service(service_t _service,
             const std::string &_address, std::uint16_t _port) const;
     std::shared_ptr<eventgroup> find_eventgroup(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup) const;
+            unique_version_t _unique, eventgroup_t _eventgroup) const;
     bool find_port(uint16_t &_port, uint16_t _remote, bool _reliable,
             std::map<bool, std::set<uint16_t> > &_used_client_ports) const;
     bool find_specific_port(uint16_t &_port, service_t _service,
-            instance_t _instance, bool _reliable,
+            unique_version_t _unique, bool _reliable,
             std::map<bool, std::set<uint16_t> > &_used_client_ports) const;
 
     void set_magic_cookies_unicast_address();
@@ -510,7 +510,7 @@ protected:
 
     mutable std::mutex services_mutex_;
     std::map<service_t,
-        std::map<instance_t,
+        std::map<unique_version_t,
             std::shared_ptr<service> > > services_;
 
     std::map<std::string, // IP
@@ -655,7 +655,7 @@ protected:
     std::uint32_t shutdown_timeout_;
 
     mutable std::mutex secure_services_mutex_;
-    std::map<service_t, std::set<instance_t> > secure_services_;
+    std::map<service_t, std::set<unique_version_t> > secure_services_;
 
     bool log_statistics_;
     uint32_t statistics_interval_;
@@ -666,7 +666,7 @@ protected:
 
     mutable std::mutex partitions_mutex_;
     std::map<service_t,
-        std::map<instance_t,
+        std::map<unique_version_t,
             partition_id_t
         >
     > partitions_;

--- a/implementation/configuration/include/debounce_filter_impl.hpp
+++ b/implementation/configuration/include/debounce_filter_impl.hpp
@@ -27,7 +27,7 @@ struct debounce_filter_impl_t : debounce_filter_t {
 
 using debounce_configuration_t =
     std::map<service_t,
-        std::map<instance_t,
+        std::map<unique_version_t,
             std::map<event_t,
                 std::shared_ptr<debounce_filter_impl_t>>>>;
 

--- a/implementation/configuration/include/service.hpp
+++ b/implementation/configuration/include/service.hpp
@@ -18,7 +18,7 @@ struct eventgroup;
 
 struct service {
     service_t service_;
-    instance_t instance_;
+    unique_version_t unique_;
 
     std::string unicast_address_;
 

--- a/implementation/endpoints/include/client_endpoint_impl.hpp
+++ b/implementation/endpoints/include/client_endpoint_impl.hpp
@@ -151,7 +151,7 @@ private:
     virtual void set_local_port() = 0;
     virtual std::string get_remote_information() const = 0;
     virtual bool tp_segmentation_enabled(service_t _service,
-                                         instance_t _instance,
+                                         unique_version_t _unique,
                                          method_t _method) const;
     virtual std::uint32_t get_max_allowed_reconnects() const = 0;
     virtual void max_allowed_reconnects_reached() = 0;

--- a/implementation/endpoints/include/endpoint_definition.hpp
+++ b/implementation/endpoints/include/endpoint_definition.hpp
@@ -22,7 +22,7 @@ class endpoint_definition {
 public:
     VSOMEIP_EXPORT static std::shared_ptr<endpoint_definition> get(
             const boost::asio::ip::address &_address,
-            uint16_t _port, bool _is_reliable, service_t _service, instance_t _instance);
+            uint16_t _port, bool _is_reliable, service_t _service, unique_version_t _unique);
 
     VSOMEIP_EXPORT const boost::asio::ip::address &get_address() const;
 
@@ -44,7 +44,7 @@ private:
 
     static std::mutex definitions_mutex_;
     static std::map<
-        std::tuple<service_t, instance_t, boost::asio::ip::address, uint16_t, bool>,
+        std::tuple<service_t, unique_version_t, boost::asio::ip::address, uint16_t, bool>,
         std::shared_ptr<endpoint_definition> > definitions_;
 };
 

--- a/implementation/endpoints/include/endpoint_host.hpp
+++ b/implementation/endpoints/include/endpoint_host.hpp
@@ -45,7 +45,7 @@ public:
     virtual void release_port(uint16_t _port, bool _reliable) = 0;
     virtual client_t get_client() const = 0;
     virtual std::string get_client_host() const = 0;
-    virtual instance_t find_instance(service_t _service,
+    virtual unique_version_t find_unique(service_t _service,
             endpoint * const _endpoint) const = 0;
     virtual void add_multicast_option(const multicast_option_t &_option) = 0;
 };

--- a/implementation/endpoints/include/endpoint_impl.hpp
+++ b/implementation/endpoints/include/endpoint_impl.hpp
@@ -57,7 +57,7 @@ public:
 
 protected:
     uint32_t find_magic_cookie(byte_t *_buffer, size_t _size);
-    instance_t get_instance(service_t _service);
+    unique_version_t get_unique(service_t _service);
 
 protected:
     enum class cms_ret_e : uint8_t {

--- a/implementation/endpoints/include/endpoint_manager_base.hpp
+++ b/implementation/endpoints/include/endpoint_manager_base.hpp
@@ -38,7 +38,7 @@ public:
 
     std::shared_ptr<endpoint> find_or_create_local(client_t _client);
     std::shared_ptr<endpoint> find_local(client_t _client);
-    std::shared_ptr<endpoint> find_local(service_t _service, instance_t _instance);
+    std::shared_ptr<endpoint> find_local(service_t _service, unique_version_t _unique);
 
     std::unordered_set<client_t> get_connected_clients() const;
 
@@ -58,7 +58,7 @@ public:
     virtual void release_port(uint16_t _port, bool _reliable);
     client_t get_client() const;
     std::string get_client_host() const;
-    instance_t find_instance(service_t _service,
+    unique_version_t find_unique(service_t _service,
             endpoint* const _endpoint) const;
 
     // Statistics

--- a/implementation/endpoints/include/endpoint_manager_impl.hpp
+++ b/implementation/endpoints/include/endpoint_manager_impl.hpp
@@ -24,25 +24,25 @@ public:
     ~endpoint_manager_impl();
 
     std::shared_ptr<endpoint> find_or_create_remote_client(service_t _service,
-                                                           instance_t _instance,
+                                                           unique_version_t _unique,
                                                            bool _reliable);
 
-    void find_or_create_remote_client(service_t _service, instance_t _instance);
+    void find_or_create_remote_client(service_t _service, unique_version_t _unique);
     void is_remote_service_known(
-            service_t _service, instance_t _instance, major_version_t _major,
+            service_t _service, unique_version_t _unique, major_version_t _major,
             minor_version_t _minor,
             const boost::asio::ip::address &_reliable_address,
             uint16_t _reliable_port, bool* _reliable_known,
             const boost::asio::ip::address &_unreliable_address,
             uint16_t _unreliable_port, bool* _unreliable_known) const;
     void add_remote_service_info(
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             const std::shared_ptr<endpoint_definition>& _ep_definition);
     void add_remote_service_info(
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             const std::shared_ptr<endpoint_definition>& _ep_definition_reliable,
             const std::shared_ptr<endpoint_definition>& _ep_definition_unreliable);
-    void clear_remote_service_info(service_t _service, instance_t _instance,
+    void clear_remote_service_info(service_t _service, unique_version_t _unique,
                                    bool _reliable);
 
     std::shared_ptr<endpoint> create_server_endpoint(uint16_t _port,
@@ -54,19 +54,19 @@ public:
 
     std::shared_ptr<endpoint> find_or_create_server_endpoint(
             uint16_t _port, bool _reliable, bool _start, service_t _service,
-            instance_t _instance, bool &_is_found, bool _is_multicast = false);
+            unique_version_t _unique, bool &_is_found, bool _is_multicast = false);
     bool remove_server_endpoint(uint16_t _port, bool _reliable);
 
 
-    void clear_client_endpoints(service_t _service, instance_t _instance,
+    void clear_client_endpoints(service_t _service, unique_version_t _unique,
                                 bool _reliable);
     void find_or_create_multicast_endpoint(
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             const boost::asio::ip::address &_sender,
             const boost::asio::ip::address &_address, uint16_t _port);
-    void clear_multicast_endpoints(service_t _service, instance_t _instance);
+    void clear_multicast_endpoints(service_t _service, unique_version_t _unique);
 
-    bool supports_selective(service_t _service, instance_t _instance) const;
+    bool supports_selective(service_t _service, unique_version_t _unique) const;
 
     void print_status() const;
 
@@ -75,13 +75,13 @@ public:
             bool &_is_socket_activated,
             const std::shared_ptr<routing_host> &_host);
 
-    instance_t find_instance(service_t _service,
+    unique_version_t find_unique(service_t _service,
                              endpoint* const _endpoint) const;
-    instance_t find_instance_multicast(service_t _service,
+    unique_version_t find_unique_multicast(service_t _service,
             const boost::asio::ip::address &_sender) const;
 
     bool remove_instance(service_t _service, endpoint* const _endpoint);
-    bool remove_instance_multicast(service_t _service, instance_t _instance);
+    bool remove_instance_multicast(service_t _service, unique_version_t _unique);
 
 
     // endpoint_host interface
@@ -117,10 +117,10 @@ public:
 
 private:
     std::shared_ptr<endpoint> find_remote_client(service_t _service,
-                                                 instance_t _instance,
+                                                 unique_version_t _unique,
                                                  bool _reliable);
     std::shared_ptr<endpoint> create_remote_client(service_t _service,
-                                                   instance_t _instance,
+                                                   unique_version_t _unique,
                                                    bool _reliable);
     std::shared_ptr<endpoint> create_client_endpoint(
             const boost::asio::ip::address &_address, uint16_t _local_port,
@@ -134,10 +134,10 @@ private:
 private:
     mutable std::recursive_mutex endpoint_mutex_;
     // Client endpoints for remote services
-    std::map<service_t, std::map<instance_t,
+    std::map<service_t, std::map<unique_version_t,
             std::map<bool, std::shared_ptr<endpoint_definition>>>> remote_service_info_;
 
-    typedef std::map<service_t, std::map<instance_t,
+    typedef std::map<service_t, std::map<unique_version_t,
                 std::map<bool, std::shared_ptr<endpoint>>>> remote_services_t;
     remote_services_t remote_services_;
 
@@ -147,8 +147,8 @@ private:
                               std::map<bool, std::map<partition_id_t, std::shared_ptr<endpoint>>>>>;
     client_endpoints_t client_endpoints_;
 
-    std::map<service_t, std::map<endpoint *, instance_t> > service_instances_;
-    std::map<service_t, std::map<boost::asio::ip::address, instance_t> > service_instances_multicast_;
+    std::map<service_t, std::map<endpoint *, unique_version_t> > service_instances_;
+    std::map<service_t, std::map<boost::asio::ip::address, unique_version_t> > service_instances_multicast_;
 
     std::map<boost::asio::ip::address,
         std::map<port_t,
@@ -162,7 +162,7 @@ private:
     server_endpoints_t server_endpoints_;
 
     // Multicast endpoint info (notifications)
-    std::map<service_t, std::map<instance_t, std::shared_ptr<endpoint_definition>>> multicast_info_;
+    std::map<service_t, std::map<unique_version_t, std::shared_ptr<endpoint_definition>>> multicast_info_;
 
     // Socket option processing (join, leave)
     std::mutex options_mutex_;

--- a/implementation/endpoints/include/server_endpoint_impl.hpp
+++ b/implementation/endpoints/include/server_endpoint_impl.hpp
@@ -142,7 +142,7 @@ private:
     virtual std::string
     get_remote_information(const target_data_iterator_type _queue_iterator) const = 0;
     virtual std::string get_remote_information(const endpoint_type& _remote) const = 0;
-    virtual bool tp_segmentation_enabled(service_t _service, instance_t _instance,
+    virtual bool tp_segmentation_enabled(service_t _service, unique_version_t _unique,
                                          method_t _method) const;
 
     void schedule_train(endpoint_data_type& _target);

--- a/implementation/endpoints/include/tcp_client_endpoint_impl.hpp
+++ b/implementation/endpoints/include/tcp_client_endpoint_impl.hpp
@@ -83,7 +83,7 @@ private:
             const std::chrono::steady_clock::time_point _start);
     std::string get_remote_information() const;
     std::shared_ptr<struct timing> get_timing(
-            const service_t& _service, const instance_t& _instance) const;
+            const service_t& _service, const unique_version_t& _unique) const;
     std::uint32_t get_max_allowed_reconnects() const;
     void max_allowed_reconnects_reached();
 

--- a/implementation/endpoints/include/udp_client_endpoint_impl.hpp
+++ b/implementation/endpoints/include/udp_client_endpoint_impl.hpp
@@ -67,7 +67,7 @@ private:
     std::string get_remote_information() const;
     bool tp_segmentation_enabled(
             service_t _service,
-            instance_t _instance,
+            unique_version_t _unique,
             method_t _method) const;
     std::uint32_t get_max_allowed_reconnects() const;
     void max_allowed_reconnects_reached();

--- a/implementation/endpoints/include/udp_server_endpoint_impl.hpp
+++ b/implementation/endpoints/include/udp_server_endpoint_impl.hpp
@@ -89,7 +89,7 @@ private:
     std::string get_address_port_local() const;
     bool tp_segmentation_enabled(
             service_t _service,
-            instance_t _instance,
+            unique_version_t _unique,
             method_t _method) const;
 
     void on_unicast_received(boost::system::error_code const &_error,

--- a/implementation/endpoints/src/client_endpoint_impl.cpp
+++ b/implementation/endpoints/src/client_endpoint_impl.cpp
@@ -284,7 +284,7 @@ bool client_endpoint_impl<Protocol>::send(const uint8_t *_data, uint32_t _size) 
 
 template<typename Protocol>
 bool client_endpoint_impl<Protocol>::tp_segmentation_enabled(
-        service_t /*_service*/, instance_t /*_instance*/, method_t /*_method*/) const {
+        service_t /*_service*/, unique_version_t /*_instance*/, method_t /*_method*/) const {
 
     return false;
 }
@@ -777,14 +777,14 @@ typename endpoint_impl<Protocol>::cms_ret_e client_endpoint_impl<Protocol>::chec
         if (endpoint_impl<Protocol>::is_supporting_someip_tp_ && _data != nullptr) {
             const service_t its_service = bithelper::read_uint16_be(&_data[VSOMEIP_SERVICE_POS_MIN]);
             const method_t its_method   = bithelper::read_uint16_be(&_data[VSOMEIP_METHOD_POS_MIN]);
-            instance_t its_instance = this->get_instance(its_service);
+            unique_version_t its_unique = this->get_unique(its_service);
           
-            if (its_instance != ANY_INSTANCE) {
-                if (tp_segmentation_enabled(its_service, its_instance, its_method)) {
+            if (get_instance_from_unique(its_unique) != ANY_INSTANCE) {
+                if (tp_segmentation_enabled(its_service, its_unique, its_method)) {
                     std::uint16_t its_max_segment_length;
                     std::uint32_t its_separation_time;
                     this->configuration_->get_tp_configuration(
-                                its_service, its_instance, its_method, true,
+                                its_service, its_unique, its_method, true,
                                 its_max_segment_length, its_separation_time);
                     send_segments(tp::tp::tp_split_message(_data, _size,
                             its_max_segment_length), its_separation_time);

--- a/implementation/endpoints/src/endpoint_definition.cpp
+++ b/implementation/endpoints/src/endpoint_definition.cpp
@@ -9,15 +9,15 @@
 
 namespace vsomeip_v3 {
 
-std::map<std::tuple<service_t, instance_t, boost::asio::ip::address, uint16_t, bool>,
+std::map<std::tuple<service_t, unique_version_t, boost::asio::ip::address, uint16_t, bool>,
          std::shared_ptr<endpoint_definition> > endpoint_definition::definitions_;
 
 std::mutex endpoint_definition::definitions_mutex_;
 
 std::shared_ptr<endpoint_definition>
 endpoint_definition::get(const boost::asio::ip::address &_address,
-                         uint16_t _port, bool _is_reliable, service_t _service, instance_t _instance) {
-    auto key = std::make_tuple(_service, _instance, _address, _port, _is_reliable);
+                         uint16_t _port, bool _is_reliable, service_t _service, unique_version_t _unique) {
+    auto key = std::make_tuple(_service, _unique, _address, _port, _is_reliable);
     std::lock_guard<std::mutex> its_lock(definitions_mutex_);
     std::shared_ptr<endpoint_definition> its_result;
 

--- a/implementation/endpoints/src/endpoint_impl.cpp
+++ b/implementation/endpoints/src/endpoint_impl.cpp
@@ -100,15 +100,15 @@ void endpoint_impl<Protocol>::register_error_handler(const error_handler_t &_err
 }
 
 template<typename Protocol>
-instance_t endpoint_impl<Protocol>::get_instance(service_t _service) {
+unique_version_t endpoint_impl<Protocol>::get_unique(service_t _service) {
 
-    instance_t its_instance(0xFFFF);
+    unique_version_t its_unique(0xFFFF);
 
     auto its_host = endpoint_host_.lock();
     if (its_host)
-        its_instance = its_host->find_instance(_service, this);
+        its_unique = its_host->find_unique(_service, this);
 
-    return its_instance;
+    return its_unique;
 }
 
 // Instantiate template

--- a/implementation/endpoints/src/endpoint_manager_base.cpp
+++ b/implementation/endpoints/src/endpoint_manager_base.cpp
@@ -74,8 +74,8 @@ std::shared_ptr<endpoint> endpoint_manager_base::find_local(client_t _client) {
 }
 
 std::shared_ptr<endpoint> endpoint_manager_base::find_local(service_t _service,
-        instance_t _instance) {
-    return find_local(rm_->find_local_client(_service, _instance));
+        unique_version_t _unique) {
+    return find_local(rm_->find_local_client(_service, _unique));
 }
 
 
@@ -357,7 +357,7 @@ std::shared_ptr<endpoint> endpoint_manager_base::find_local_unlocked(client_t _c
     return its_endpoint;
 }
 
-instance_t endpoint_manager_base::find_instance(
+unique_version_t endpoint_manager_base::find_unique(
         service_t _service, endpoint* const _endpoint) const {
 
     (void)_service;

--- a/implementation/endpoints/src/server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/server_endpoint_impl.cpp
@@ -361,7 +361,7 @@ bool server_endpoint_impl<Protocol>::send_intern(endpoint_type _target, const by
 
 template<typename Protocol>
 bool server_endpoint_impl<Protocol>::tp_segmentation_enabled(service_t /*_service*/,
-                                                             instance_t /*_instance*/,
+                                                             unique_version_t /*_instance*/,
                                                              method_t /*_method*/) const {
 
     return false;
@@ -453,15 +453,15 @@ typename endpoint_impl<Protocol>::cms_ret_e server_endpoint_impl<Protocol>::chec
             const service_t its_service =
                     bithelper::read_uint16_be(&_data[VSOMEIP_SERVICE_POS_MIN]);
             const method_t its_method = bithelper::read_uint16_be(&_data[VSOMEIP_METHOD_POS_MIN]);
-            instance_t its_instance = this->get_instance(its_service);
+            unique_version_t its_unique = this->get_unique(its_service);
 
-            if (its_instance != ANY_INSTANCE) {
-                if (tp_segmentation_enabled(its_service, its_instance, its_method)) {
+            if (get_instance_from_unique(its_unique) != ANY_INSTANCE) {
+                if (tp_segmentation_enabled(its_service, its_unique, its_method)) {
                     std::uint16_t its_max_segment_length;
                     std::uint32_t its_separation_time;
 
                     this->configuration_->get_tp_configuration(
-                            its_service, its_instance, its_method, false, its_max_segment_length,
+                            its_service, its_unique, its_method, false, its_max_segment_length,
                             its_separation_time);
                     send_segments(tp::tp::tp_split_message(_data, _size, its_max_segment_length),
                                   its_separation_time, _target);

--- a/implementation/endpoints/src/udp_client_endpoint_impl.cpp
+++ b/implementation/endpoints/src/udp_client_endpoint_impl.cpp
@@ -651,9 +651,9 @@ void udp_client_endpoint_impl::send_cbk(boost::system::error_code const &_error,
 }
 
 bool udp_client_endpoint_impl::tp_segmentation_enabled(
-        service_t _service, instance_t _instance, method_t _method) const {
+        service_t _service, unique_version_t _unique, method_t _method) const {
 
-    return configuration_->is_tp_client(_service, _instance, _method);
+    return configuration_->is_tp_client(_service, _unique, _method);
 }
 
 bool udp_client_endpoint_impl::is_reliable() const {

--- a/implementation/endpoints/src/udp_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/udp_server_endpoint_impl.cpp
@@ -582,10 +582,10 @@ void udp_server_endpoint_impl::on_message_received(boost::system::error_code con
                     if (tp::tp::tp_flag_is_set(_buffer[i + VSOMEIP_MESSAGE_TYPE_POS])) {
                         const method_t its_method =
                                 bithelper::read_uint16_be(&_buffer[i + VSOMEIP_METHOD_POS_MIN]);
-                        instance_t its_instance = this->get_instance(its_service);
+                        unique_version_t its_unique = this->get_unique(its_service);
 
-                        if (its_instance != ANY_INSTANCE) {
-                            if (!tp_segmentation_enabled(its_service, its_instance, its_method)) {
+                        if (get_instance_from_unique(its_unique) != ANY_INSTANCE) {
+                            if (!tp_segmentation_enabled(its_service, its_unique, its_method)) {
                                 VSOMEIP_WARNING
                                         << "use: Received a SomeIP/TP message for service: 0x"
                                         << std::hex << its_service << " method: 0x" << its_method
@@ -733,10 +733,10 @@ std::string udp_server_endpoint_impl::get_address_port_local() const {
     return its_address_port;
 }
 
-bool udp_server_endpoint_impl::tp_segmentation_enabled(service_t _service, instance_t _instance,
+bool udp_server_endpoint_impl::tp_segmentation_enabled(service_t _service, unique_version_t _unique,
                                                        method_t _method) const {
 
-    return configuration_->is_tp_service(_service, _instance, _method);
+    return configuration_->is_tp_service(_service, _unique, _method);
 }
 
 void udp_server_endpoint_impl::set_multicast_option(const boost::asio::ip::address& _address,

--- a/implementation/protocol/include/command.hpp
+++ b/implementation/protocol/include/command.hpp
@@ -22,6 +22,7 @@ class command {
 public:
     inline id_e get_id() const  { return id_; }
     inline version_t get_version() const { return version_; }
+    inline void set_version(version_t _version) { version_ = _version; }
     inline client_t get_client() const { return client_; }
     inline void set_client(client_t _client) { client_ = _client; }
     inline command_size_t get_size() const { return size_; }

--- a/implementation/routing/include/routing_manager.hpp
+++ b/implementation/routing/include/routing_manager.hpp
@@ -51,34 +51,34 @@ public:
     virtual void stop() = 0;
 
     virtual bool offer_service(client_t _client, service_t _service,
-            instance_t _instance, major_version_t _major,
+            unique_version_t _unique, major_version_t _major,
             minor_version_t _minor) = 0;
 
     virtual void stop_offer_service(client_t _client, service_t _service,
-            instance_t _instance, major_version_t _major,
+            unique_version_t _unique, major_version_t _major,
             minor_version_t _minor) = 0;
 
     virtual void request_service(client_t _client, service_t _service,
-            instance_t _instance, major_version_t _major,
+            unique_version_t _unique, major_version_t _major,
             minor_version_t _minor) = 0;
 
     virtual void release_service(client_t _client, service_t _service,
-            instance_t _instance) = 0;
+            unique_version_t _unique) = 0;
 
     virtual void subscribe(client_t _client, const vsomeip_sec_client_t *_sec_client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, major_version_t _major,
             event_t _event, const std::shared_ptr<debounce_filter_impl_t> &_filter) = 0;
 
     virtual void unsubscribe(client_t _client, const vsomeip_sec_client_t *_sec_client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, event_t _event) = 0;
 
     virtual bool send(client_t _client, std::shared_ptr<message> _message,
             bool _force) = 0;
 
     virtual bool send(client_t _client, const byte_t *_data, uint32_t _size,
-            instance_t _instance, bool _reliable,
+            unique_version_t _unique, bool _reliable,
             client_t _bound_client = VSOMEIP_ROUTING_CLIENT,
             const vsomeip_sec_client_t *_sec_client = nullptr,
             uint8_t _status_check = 0,
@@ -90,10 +90,10 @@ public:
             std::shared_ptr<message> _message) = 0;
 
     virtual bool send_to(const std::shared_ptr<endpoint_definition> &_target,
-            const byte_t *_data, uint32_t _size, instance_t _instance) = 0;
+            const byte_t *_data, uint32_t _size, unique_version_t _unique) = 0;
 
     virtual void register_event(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             event_t _notifier,
             const std::set<eventgroup_t> &_eventgroups,
             const event_type_e _type,
@@ -105,19 +105,19 @@ public:
             bool _is_cache_placeholder = false) = 0;
 
     virtual void unregister_event(client_t _client, service_t _service,
-            instance_t _instance, event_t _event, bool _is_provided) = 0;
+            unique_version_t _unique, event_t _event, bool _is_provided) = 0;
 
     virtual std::shared_ptr<event> find_event(service_t _service,
-            instance_t _instance, event_t _event) const = 0;
+            unique_version_t _unique, event_t _event) const = 0;
 
     virtual std::set<std::shared_ptr<event>> find_events(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup) const = 0;
+            unique_version_t _unique, eventgroup_t _eventgroup) const = 0;
 
-    virtual void notify(service_t _service, instance_t _instance,
+    virtual void notify(service_t _service, unique_version_t _unique,
             event_t _event, std::shared_ptr<payload> _payload,
             bool _force) = 0;
 
-    virtual void notify_one(service_t _service, instance_t _instance,
+    virtual void notify_one(service_t _service, unique_version_t _unique,
             event_t _event, std::shared_ptr<payload> _payload,
             client_t _client, bool _force
 #ifdef VSOMEIP_ENABLE_COMPAT

--- a/implementation/routing/include/routing_manager_base.hpp
+++ b/implementation/routing/include/routing_manager_base.hpp
@@ -74,22 +74,22 @@ public:
     void init(const std::shared_ptr<endpoint_manager_base>& _endpoint_manager);
 
     virtual bool offer_service(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor);
 
     virtual void stop_offer_service(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor);
 
     virtual void request_service(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor);
 
     virtual void release_service(client_t _client,
-            service_t _service, instance_t _instance);
+            service_t _service, unique_version_t _unique);
 
     virtual void register_event(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             event_t _notifier,
             const std::set<eventgroup_t> &_eventgroups,
             const event_type_e _type, reliability_type_e _reliability,
@@ -99,27 +99,27 @@ public:
             bool _is_cache_placeholder = false);
 
     virtual void unregister_event(client_t _client,
-            service_t _service, instance_t _instance, event_t _event,
+            service_t _service, unique_version_t _unique, event_t _event,
             bool _is_provided);
 
     virtual std::set<std::shared_ptr<event>> find_events(service_t _service,
-                instance_t _instance, eventgroup_t _eventgroup) const;
+                unique_version_t _unique, eventgroup_t _eventgroup) const;
 
     virtual void subscribe(client_t _client,
             const vsomeip_sec_client_t *_sec_client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, major_version_t _major,
             event_t _event, const std::shared_ptr<debounce_filter_impl_t> &_filter);
 
     virtual void unsubscribe(client_t _client,
             const vsomeip_sec_client_t *_sec_client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, event_t _event);
 
-    virtual void notify(service_t _service, instance_t _instance,
+    virtual void notify(service_t _service, unique_version_t _unique,
             event_t _event, std::shared_ptr<payload> _payload, bool _force);
 
-    virtual void notify_one(service_t _service, instance_t _instance,
+    virtual void notify_one(service_t _service, unique_version_t _unique,
             event_t _event, std::shared_ptr<payload> _payload,
             client_t _client, bool _force
 #ifdef VSOMEIP_ENABLE_COMPAT
@@ -131,7 +131,7 @@ public:
             bool _force);
 
     virtual bool send(client_t _client, const byte_t *_data, uint32_t _size,
-            instance_t _instance, bool _reliable,
+            unique_version_t _unique, bool _reliable,
             client_t _bound_client, const vsomeip_sec_client_t *_sec_client,
             uint8_t _status_check, bool _sent_from_remote,
             bool _force) = 0;
@@ -152,14 +152,14 @@ public:
 
     virtual void send_get_offered_services_info(client_t _client, offer_type_e _offer_type) = 0;
 
-    std::set<client_t> find_local_clients(service_t _service, instance_t _instance);
+    std::set<client_t> find_local_clients(service_t _service, unique_version_t _unique);
 
-    std::shared_ptr<serviceinfo> find_service(service_t _service, instance_t _instance) const;
+    std::shared_ptr<serviceinfo> find_service(service_t _service, unique_version_t _unique) const;
 
-    client_t find_local_client(service_t _service, instance_t _instance) const;
-    client_t find_local_client_unlocked(service_t _service, instance_t _instance) const;
+    client_t find_local_client(service_t _service, unique_version_t _unique) const;
+    client_t find_local_client_unlocked(service_t _service, unique_version_t _unique) const;
 
-    std::shared_ptr<event> find_event(service_t _service, instance_t _instance,
+    std::shared_ptr<event> find_event(service_t _service, unique_version_t _unique,
             event_t _event) const;
 
     // address data for vsomeip routing via TCP
@@ -177,41 +177,41 @@ public:
     virtual void on_disconnect(const std::shared_ptr<endpoint>& _endpoint) = 0;
 protected:
     std::shared_ptr<serviceinfo> create_service_info(service_t _service,
-            instance_t _instance, major_version_t _major,
+            unique_version_t _unique, major_version_t _major,
             minor_version_t _minor, ttl_t _ttl, bool _is_local_service);
 
-    void clear_service_info(service_t _service, instance_t _instance, bool _reliable);
+    void clear_service_info(service_t _service, unique_version_t _unique, bool _reliable);
     services_t get_services() const;
     services_t get_services_remote() const;
-    virtual bool is_available(service_t _service, instance_t _instance,
+    virtual bool is_available(service_t _service, unique_version_t _unique,
                               major_version_t _major) const;
 
     void remove_local(client_t _client, bool _remove_sec_client);
     void remove_local(client_t _client,
             const std::set<
-                std::tuple<service_t, instance_t, eventgroup_t>
+                std::tuple<service_t, unique_version_t, eventgroup_t>
             > &_subscribed_eventgroups,
             bool _remove_sec_client);
 
     std::set<std::shared_ptr<eventgroupinfo> > find_eventgroups(service_t _service,
-            instance_t _instance) const;
+            unique_version_t _unique) const;
 
     std::shared_ptr<eventgroupinfo> find_eventgroup(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup) const;
+            unique_version_t _unique, eventgroup_t _eventgroup) const;
 
-    void remove_eventgroup_info(service_t _service, instance_t _instance,
+    void remove_eventgroup_info(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup);
 
     bool send_local_notification(client_t _client,
-            const byte_t *_data, uint32_t _size, instance_t _instance,
+            const byte_t *_data, uint32_t _size, unique_version_t _unique,
             bool _reliable, uint8_t _status_check, bool _force);
 
     bool send_local(
             std::shared_ptr<endpoint> &_target, client_t _client,
-            const byte_t *_data, uint32_t _size, instance_t _instance,
+            const byte_t *_data, uint32_t _size, unique_version_t _unique,
             bool _reliable, protocol::id_e _command, uint8_t _status_check) const;
 
-    bool insert_subscription(service_t _service, instance_t _instance,
+    bool insert_subscription(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, event_t _event,
             const std::shared_ptr<debounce_filter_impl_t> &_filter, client_t _client,
             std::set<event_t> *_already_subscribed_events);
@@ -227,53 +227,53 @@ protected:
             instance_t _instance, major_version_t _major);
 
     virtual void send_subscribe(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, major_version_t _major,
             event_t _event, const std::shared_ptr<debounce_filter_impl_t> &_filter) = 0;
 
-    void remove_pending_subscription(service_t _service, instance_t _instance,
+    void remove_pending_subscription(service_t _service, unique_version_t _unique,
                                      eventgroup_t _eventgroup, event_t _event);
 #ifdef VSOMEIP_ENABLE_COMPAT
-    void send_pending_notify_ones(service_t _service, instance_t _instance,
+    void send_pending_notify_ones(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, client_t _client, bool _remote_subscriber = false);
 #endif
 
-    void unset_all_eventpayloads(service_t _service, instance_t _instance);
-    void unset_all_eventpayloads(service_t _service, instance_t _instance,
+    void unset_all_eventpayloads(service_t _service, unique_version_t _unique);
+    void unset_all_eventpayloads(service_t _service, unique_version_t _unique,
                                  eventgroup_t _eventgroup);
 
     void notify_one_current_value(client_t _client, service_t _service,
-                                  instance_t _instance,
+                                  unique_version_t _unique,
                                   eventgroup_t _eventgroup, event_t _event,
                                   const std::set<event_t> &_events_to_exclude);
 
-    std::set<std::tuple<service_t, instance_t, eventgroup_t>>
+    std::set<std::tuple<service_t, unique_version_t, eventgroup_t>>
         get_subscriptions(const client_t _client);
 
-    std::vector<event_t> find_events(service_t _service, instance_t _instance) const;
+    std::vector<event_t> find_events(service_t _service, unique_version_t _unique) const;
 
     bool is_response_allowed(client_t _sender, service_t _service,
-            instance_t _instance, method_t _method);
+            unique_version_t _unique, method_t _method);
     bool is_subscribe_to_any_event_allowed(
             const vsomeip_sec_client_t *_sec_client, client_t _client,
-            service_t _service, instance_t _instance, eventgroup_t _eventgroup);
+            service_t _service, unique_version_t _unique, eventgroup_t _eventgroup);
 
     void add_known_client(client_t _client, const std::string &_client_host);
 
 #ifdef VSOMEIP_ENABLE_COMPAT
-    void set_incoming_subscription_state(client_t _client, service_t _service, instance_t _instance,
+    void set_incoming_subscription_state(client_t _client, service_t _service, unique_version_t _unique _unique,
             eventgroup_t _eventgroup, event_t _event, subscription_state_e _state);
 
-    subscription_state_e get_incoming_subscription_state(client_t _client, service_t _service, instance_t _instance,
+    subscription_state_e get_incoming_subscription_state(client_t _client, service_t _service, unique_version_t _unique _unique,
             eventgroup_t _eventgroup, event_t _event);
 
-    void erase_incoming_subscription_state(client_t _client, service_t _service, instance_t _instance,
+    void erase_incoming_subscription_state(client_t _client, service_t _service, unique_version_t _unique _unique,
             eventgroup_t _eventgroup, event_t _event);
 #endif
 
 private:
     virtual bool create_placeholder_event_and_subscribe(
-            service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+            service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
             event_t _event, const std::shared_ptr<debounce_filter_impl_t> &_filter,
             client_t _client) = 0;
 
@@ -292,20 +292,20 @@ protected:
     std::condition_variable deserializer_condition_;
 
     mutable std::mutex local_services_mutex_;
-    typedef std::map<service_t, std::map<instance_t,
+    typedef std::map<service_t, std::map<unique_version_t,
             std::tuple<major_version_t, minor_version_t, client_t>>> local_services_map_t;
     local_services_map_t local_services_;
-    std::map<service_t, std::map<instance_t, std::set<client_t> > > local_services_history_;
+    std::map<service_t, std::map<unique_version_t, std::set<client_t> > > local_services_history_;
 
     // Eventgroups
     mutable std::mutex eventgroups_mutex_;
     std::map<service_t,
-            std::map<instance_t,
+            std::map<unique_version_t,
                     std::map<eventgroup_t, std::shared_ptr<eventgroupinfo> > > > eventgroups_;
     // Events (part of one or more eventgroups)
     mutable std::mutex events_mutex_;
     std::map<service_t,
-        std::map<instance_t,
+        std::map<unique_version_t,
             std::map<event_t,
                 std::shared_ptr<event> > > > events_;
 
@@ -370,13 +370,13 @@ private:
 
 #ifdef VSOMEIP_ENABLE_COMPAT
     std::map<service_t,
-        std::map<instance_t,
+        std::map<unique_version_t,
             std::map<eventgroup_t,
                 std::shared_ptr<message> > > > pending_notify_ones_;
     std::recursive_mutex pending_notify_ones_mutex_;
     std::map<client_t,
         std::map<service_t,
-            std::map<instance_t,
+            std::map<unique_version_t,
                 std::map<eventgroup_t,
                     std::map<event_t,
                         subscription_state_e> > > > > incoming_subscription_state_;

--- a/implementation/routing/include/routing_manager_client.hpp
+++ b/implementation/routing/include/routing_manager_client.hpp
@@ -50,31 +50,31 @@ public:
     std::string get_env_unlocked(client_t _client) const;
 
     bool offer_service(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor);
 
     void stop_offer_service(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor);
 
     void request_service(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor);
 
     void release_service(client_t _client,
-            service_t _service, instance_t _instance);
+            service_t _service, unique_version_t _unique);
 
     void subscribe(client_t _client, const vsomeip_sec_client_t *_sec_client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, major_version_t _major,
             event_t _event, const std::shared_ptr<debounce_filter_impl_t> &_filter);
 
     void unsubscribe(client_t _client, const vsomeip_sec_client_t *_sec_client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, event_t _event);
 
     bool send(client_t _client, const byte_t *_data, uint32_t _size,
-            instance_t _instance, bool _reliable,
+            unique_version_t _unique, bool _reliable,
             client_t _bound_client, const vsomeip_sec_client_t *_sec_client,
             uint8_t _status_check, bool _sent_from_remote,
             bool _force);
@@ -84,10 +84,10 @@ public:
             std::shared_ptr<message> _message);
 
     bool send_to(const std::shared_ptr<endpoint_definition> &_target,
-            const byte_t *_data, uint32_t _size, instance_t _instance);
+            const byte_t *_data, uint32_t _size, unique_version_t _unique);
 
     void register_event(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             event_t _notifier,
             const std::set<eventgroup_t> &_eventgroups,
             const event_type_e _type,
@@ -98,7 +98,7 @@ public:
             bool _is_provided, bool _is_shadow, bool _is_cache_placeholder);
 
     void unregister_event(client_t _client, service_t _service,
-            instance_t _instance, event_t _notifier, bool _is_provided);
+            unique_version_t _unique, event_t _notifier, bool _is_provided);
 
     void on_connect(const std::shared_ptr<endpoint>& _endpoint);
     void on_disconnect(const std::shared_ptr<endpoint>& _endpoint);
@@ -132,54 +132,54 @@ private:
             minor_version_t _minor);
 
     void send_release_service(client_t _client,
-            service_t _service, instance_t _instance);
+            service_t _service, unique_version_t _unique);
 
     void send_pending_event_registrations(client_t _client);
 
     void send_register_event(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             event_t _notifier,
             const std::set<eventgroup_t> &_eventgroups,
             const event_type_e _type, reliability_type_e _reliability,
             bool _is_provided, bool _is_cyclic);
 
     void send_subscribe(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, major_version_t _major,
             event_t _event, const std::shared_ptr<debounce_filter_impl_t> &_filter);
 
     void send_subscribe_nack(client_t _subscriber, service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup, event_t _event,
+            unique_version_t _unique, eventgroup_t _eventgroup, event_t _event,
             remote_subscription_id_t _id);
 
     void send_subscribe_ack(client_t _subscriber, service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup, event_t _event,
+            unique_version_t _unique, eventgroup_t _eventgroup, event_t _event,
             remote_subscription_id_t _id);
 
-    bool is_field(service_t _service, instance_t _instance,
+    bool is_field(service_t _service, unique_version_t _unique,
             event_t _event) const;
 
     void on_subscribe_nack(client_t _client, service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup, event_t _event);
+            unique_version_t _unique, eventgroup_t _eventgroup, event_t _event);
 
     void on_subscribe_ack(client_t _client, service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup, event_t _event);
+            unique_version_t _unique, eventgroup_t _eventgroup, event_t _event);
 
-    void cache_event_payload(const std::shared_ptr<message> &_message);
+    void cache_event_payload(const std::shared_ptr<message> &_message, major_version_t _major);
 
-    void on_stop_offer_service(service_t _service, instance_t _instance,
+    void on_stop_offer_service(service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor);
 
     void send_pending_commands();
 
     void init_receiver();
 
-    void notify_remote_initially(service_t _service, instance_t _instance,
+    void notify_remote_initially(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, const std::set<event_t> &_events_to_exclude);
 
-    uint32_t get_remote_subscriber_count(service_t _service, instance_t _instance,
+    uint32_t get_remote_subscriber_count(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, bool _increment);
-    void clear_remote_subscriber_count(service_t _service, instance_t _instance);
+    void clear_remote_subscriber_count(service_t _service, unique_version_t _unique);
 
     void assign_client_timeout_cbk(boost::system::error_code const &_error);
 
@@ -194,7 +194,7 @@ private:
     bool is_client_known(client_t _client);
 
     bool create_placeholder_event_and_subscribe(
-            service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+            service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
             event_t _notifier, const std::shared_ptr<debounce_filter_impl_t> &_filter,
             client_t _client);
 
@@ -202,7 +202,7 @@ private:
 
     void send_request_services(const std::set<protocol::service> &_requests);
 
-    void send_unsubscribe_ack(service_t _service, instance_t _instance,
+    void send_unsubscribe_ack(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, remote_subscription_id_t _id);
 
     void resend_provided_event_registrations();
@@ -246,7 +246,7 @@ private:
 
     struct event_data_t {
         service_t service_;
-        instance_t instance_;
+        unique_version_t unique_;
         event_t notifier_;
         event_type_e type_;
         reliability_type_e reliability_;
@@ -255,9 +255,9 @@ private:
         std::set<eventgroup_t> eventgroups_;
 
         bool operator<(const event_data_t &_other) const {
-            return std::tie(service_, instance_, notifier_,
+            return std::tie(service_, unique_, notifier_,
                     type_, reliability_, is_provided_, is_cyclic_, eventgroups_)
-                    < std::tie(_other.service_, _other.instance_,
+                    < std::tie(_other.service_, _other.unique_,
                             _other.notifier_, _other.type_, _other.reliability_,
                             _other.is_provided_, _other.is_cyclic_, _other.eventgroups_);
         }
@@ -272,7 +272,7 @@ private:
     std::condition_variable state_condition_;
 
     std::map<service_t,
-                std::map<instance_t, std::map<eventgroup_t, uint32_t > > > remote_subscriber_count_;
+                std::map<unique_version_t, std::map<eventgroup_t, uint32_t > > > remote_subscriber_count_;
     std::mutex remote_subscriber_count_mutex_;
 
     mutable std::mutex sender_mutex_;

--- a/implementation/routing/include/routing_manager_host.hpp
+++ b/implementation/routing/include/routing_manager_host.hpp
@@ -39,16 +39,16 @@ public:
             minor_version_t _minor = DEFAULT_MINOR) = 0;
     virtual void on_state(state_type_e _state) = 0;
     virtual void on_message(std::shared_ptr<message> &&_message) = 0;
-    virtual void on_subscription(service_t _service, instance_t _instance,
+    virtual void on_subscription(service_t _service, unique_version_t _unique,
         eventgroup_t _eventgroup,
         client_t _client, const vsomeip_sec_client_t *_sec_client,
         const std::string &_env, bool _subscribed,
         const std::function<void(bool)> &_accepted_cb) = 0;
-    virtual void on_subscription_status(service_t _service, instance_t _instance,
+    virtual void on_subscription_status(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, event_t _event, uint16_t _error) = 0;
     virtual void send(std::shared_ptr<message> _message) = 0;
     virtual void on_offered_services_info(
-            std::vector<std::pair<service_t, instance_t>> &_services) = 0;
+            std::vector<std::pair<service_t, unique_version_t>> &_services) = 0;
     virtual bool is_routing() const = 0;
 };
 

--- a/implementation/routing/include/routing_manager_impl.hpp
+++ b/implementation/routing/include/routing_manager_impl.hpp
@@ -66,34 +66,34 @@ public:
     void stop();
 
     bool offer_service(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor);
 
     void stop_offer_service(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor);
 
     void request_service(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor);
 
     void release_service(client_t _client,
-            service_t _service, instance_t _instance);
+            service_t _service, unique_version_t _unique);
 
     void subscribe(client_t _client, const vsomeip_sec_client_t *_sec_client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, major_version_t _major,
             event_t _event, const std::shared_ptr<debounce_filter_impl_t> &_filter);
 
     void unsubscribe(client_t _client, const vsomeip_sec_client_t *_sec_client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, event_t _event);
 
     bool send(client_t _client, std::shared_ptr<message> _message,
             bool _force);
 
     bool send(client_t _client, const byte_t *_data, uint32_t _size,
-            instance_t _instance, bool _reliable,
+            unique_version_t _unique, bool _reliable,
             client_t _bound_client, const vsomeip_sec_client_t *_sec_client,
             uint8_t _status_check, bool _sent_from_remote,
             bool _force);
@@ -104,13 +104,13 @@ public:
 
     bool send_to(const std::shared_ptr<endpoint_definition> &_target,
             const byte_t *_data, uint32_t _size,
-            instance_t _instance);
+            unique_version_t _unique);
 
     bool send_via_sd(const std::shared_ptr<endpoint_definition> &_target,
             const byte_t *_data, uint32_t _size, uint16_t _sd_port);
 
     void register_event(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             event_t _notifier,
             const std::set<eventgroup_t> &_eventgroups,
             const event_type_e _type,
@@ -121,17 +121,17 @@ public:
             bool _is_provided, bool _is_shadow, bool _is_cache_placeholder);
 
     void register_shadow_event(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             event_t _notifier,
             const std::set<eventgroup_t> &_eventgroups,
             event_type_e _type, reliability_type_e _reliability,
             bool _is_provided, bool _is_cyclic);
 
     void unregister_shadow_event(client_t _client, service_t _service,
-            instance_t _instance, event_t _event,
+            unique_version_t _unique, event_t _event,
             bool _is_provided);
 
-    void notify_one(service_t _service, instance_t _instance,
+    void notify_one(service_t _service, unique_version_t _unique,
             event_t _event, std::shared_ptr<payload> _payload,
             client_t _client, bool _force
 #ifdef VSOMEIP_ENABLE_COMPAT
@@ -140,11 +140,11 @@ public:
             );
 
     void on_subscribe_ack(client_t _client, service_t _service,
-                    instance_t _instance, eventgroup_t _eventgroup, event_t _event,
+                    unique_version_t _unique, eventgroup_t _eventgroup, event_t _event,
                     remote_subscription_id_t _id);
 
     void on_subscribe_nack(client_t _client, service_t _service,
-                    instance_t _instance, eventgroup_t _eventgroup,
+                    unique_version_t _unique, eventgroup_t _eventgroup,
                     bool _remove, remote_subscription_id_t _id);
 
 
@@ -158,11 +158,11 @@ public:
     }
 
     std::shared_ptr<endpoint> find_or_create_remote_client(
-            service_t _service, instance_t _instance, bool _reliable);
+            service_t _service, unique_version_t _unique, bool _reliable);
 
     void remove_local(client_t _client, bool _remove_uid);
     void on_stop_offer_service(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor);
 
     void on_availability(service_t _service, instance_t _instance,
@@ -172,11 +172,11 @@ public:
     void on_pong(client_t _client);
 
     void on_subscribe_ack_with_multicast(
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             const boost::asio::ip::address &_sender,
             const boost::asio::ip::address &_address, uint16_t _port);
     void on_unsubscribe_ack(client_t _client, service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup,
+            unique_version_t _unique, eventgroup_t _eventgroup,
             remote_subscription_id_t _id);
 
     void on_connect(const std::shared_ptr<endpoint>& _endpoint);
@@ -187,29 +187,29 @@ public:
             client_t _bound_client, const vsomeip_sec_client_t *_sec_client,
             const boost::asio::ip::address &_remote_address,
             std::uint16_t _remote_port);
-    bool on_message(service_t _service, instance_t _instance,
+    bool on_message(service_t _service, unique_version_t _unique,
             const byte_t *_data, length_t _size, bool _reliable,
             client_t _bound_client, const vsomeip_sec_client_t *_sec_client,
             uint8_t _check_status = 0,
             bool _is_from_remote = false);
     void on_notification(client_t _client, service_t _service,
-            instance_t _instance, const byte_t *_data, length_t _size,
+            unique_version_t _unique, const byte_t *_data, length_t _size,
             bool _notify_one);
 
-    bool offer_service_remotely(service_t _service, instance_t _instance,
+    bool offer_service_remotely(service_t _service, unique_version_t _unique,
                                 std::uint16_t _port, bool _reliable,
                                 bool _magic_cookies_enabled);
-    bool stop_offer_service_remotely(service_t _service, instance_t _instance,
+    bool stop_offer_service_remotely(service_t _service, unique_version_t _unique,
                                      std::uint16_t _port, bool _reliable,
                                      bool _magic_cookies_enabled);
 
     // interface "service_discovery_host"
     std::shared_ptr<eventgroupinfo> find_eventgroup(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup) const;
+            unique_version_t _unique, eventgroup_t _eventgroup) const;
     services_t get_offered_services() const;
     std::shared_ptr<serviceinfo> get_offered_service(
-            service_t _service, instance_t _instance) const;
-    std::map<instance_t, std::shared_ptr<serviceinfo>> get_offered_service_instances(
+            service_t _service, unique_version_t _unique) const;
+    std::map<unique_version_t, std::shared_ptr<serviceinfo>> get_offered_service_instances(
                 service_t _service) const;
 
     std::shared_ptr<endpoint> create_service_discovery_endpoint(const std::string &_address,
@@ -221,7 +221,7 @@ public:
             uint16_t _reliable_port,
             const boost::asio::ip::address &_unreliable_address,
             uint16_t _unreliable_port);
-    void del_routing_info(service_t _service, instance_t _instance,
+    void del_routing_info(service_t _service, unique_version_t _unique,
             bool _has_reliable, bool _has_unreliable);
     void update_routing_info(std::chrono::milliseconds _elapsed);
 
@@ -259,7 +259,7 @@ public:
         (void) _offer_type;
     }
 
-    void send_initial_events(service_t _service, instance_t _instance,
+    void send_initial_events(service_t _service, unique_version_t _unique,
                     eventgroup_t _eventgroup,
                     const std::shared_ptr<endpoint_definition> &_subscriber);
 
@@ -270,11 +270,11 @@ public:
             endpoint* const _receiver,
             const boost::asio::ip::address &_remote_address,
             std::uint16_t _remote_port);
-    void service_endpoint_connected(service_t _service, instance_t _instance,
+    void service_endpoint_connected(service_t _service, unique_version_t _unique,
                                     major_version_t _major, minor_version_t _minor,
                                     const std::shared_ptr<endpoint>& _endpoint,
                                     bool _unreliable_only);
-    void service_endpoint_disconnected(service_t _service, instance_t _instance,
+    void service_endpoint_disconnected(service_t _service, unique_version_t _unique,
                                     major_version_t _major, minor_version_t _minor,
                                     const std::shared_ptr<endpoint>& _endpoint);
 
@@ -287,11 +287,11 @@ public:
                                bool _reliable);
 
     void on_resend_provided_events_response(pending_remote_offer_id_t _id);
-    client_t find_local_client(service_t _service, instance_t _instance);
-    std::set<client_t> find_local_clients(service_t _service, instance_t _instance);
+    client_t find_local_client(service_t _service, unique_version_t _unique);
+    std::set<client_t> find_local_clients(service_t _service, unique_version_t _unique);
     bool is_subscribe_to_any_event_allowed(
             const vsomeip_sec_client_t *_sec_client, client_t _client,
-            service_t _service, instance_t _instance, eventgroup_t _eventgroup);
+            service_t _service, unique_version_t _unique, eventgroup_t _eventgroup);
 
 #ifndef VSOMEIP_DISABLE_SECURITY
     bool update_security_policy_configuration(uid_t _uid, gid_t _gid,
@@ -313,17 +313,17 @@ public:
 
     std::vector<protocol::service> get_requested_services(client_t _client) const;
 
-    virtual bool is_available(service_t _service, instance_t _instance,
+    virtual bool is_available(service_t _service, unique_version_t _unique,
                               major_version_t _major) const;
 
 private:
     bool offer_service(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor,
             bool _must_queue);
 
     void stop_offer_service(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor,
             bool _must_queue);
 
@@ -331,51 +331,51 @@ private:
             instance_t _instance, bool _reliable,
             client_t _bound_client, const vsomeip_sec_client_t *_sec_client,
             uint8_t _status_check = 0, bool _is_from_remote = false);
-    bool deliver_notification(service_t _service, instance_t _instance,
+    bool deliver_notification(service_t _service, unique_version_t _unique,
             const byte_t *_data, length_t _length, bool _reliable,
             client_t _bound_client, const vsomeip_sec_client_t *_sec_client,
             uint8_t _status_check = 0, bool _is_from_remote = false);
 
-    bool is_suppress_event(service_t _service, instance_t _instance,
+    bool is_suppress_event(service_t _service, unique_version_t _unique,
             event_t _event) const;
 
     void init_service_info(service_t _service,
-            instance_t _instance, bool _is_local_service);
+            unique_version_t _unique, bool _is_local_service);
 
-    bool is_field(service_t _service, instance_t _instance,
+    bool is_field(service_t _service, unique_version_t _unique,
             event_t _event) const;
 
     std::shared_ptr<endpoint> find_remote_client(service_t _service,
-            instance_t _instance, bool _reliable, client_t _client);
+            unique_version_t _unique, bool _reliable, client_t _client);
 
     std::shared_ptr<endpoint> create_remote_client(service_t _service,
-                instance_t _instance, bool _reliable, client_t _client);
+                unique_version_t _unique, bool _reliable, client_t _client);
 
-    void clear_client_endpoints(service_t _service, instance_t _instance, bool _reliable);
-    void clear_multicast_endpoints(service_t _service, instance_t _instance);
+    void clear_client_endpoints(service_t _service, unique_version_t _unique, bool _reliable);
+    void clear_multicast_endpoints(service_t _service, unique_version_t _unique);
 
     std::set<eventgroup_t> get_subscribed_eventgroups(service_t _service,
-            instance_t _instance);
+            unique_version_t _unique);
 
-    void clear_targets_and_pending_sub_from_eventgroups(service_t _service, instance_t _instance);
-    void clear_remote_subscriber(service_t _service, instance_t _instance);
+    void clear_targets_and_pending_sub_from_eventgroups(service_t _service, unique_version_t _unique);
+    void clear_remote_subscriber(service_t _service, unique_version_t _unique);
 
     return_code_e check_error(const byte_t *_data, length_t _size,
-            instance_t _instance);
+            unique_version_t _unique);
 
-    bool supports_selective(service_t _service, instance_t _instance);
+    bool supports_selective(service_t _service, unique_version_t _unique);
 
-    void clear_remote_subscriber(service_t _service, instance_t _instance,
+    void clear_remote_subscriber(service_t _service, unique_version_t _unique,
             client_t _client,
             const std::shared_ptr<endpoint_definition> &_target);
 
     void log_version_timer_cbk(boost::system::error_code const & _error);
 
     bool handle_local_offer_service(client_t _client, service_t _service,
-            instance_t _instance, major_version_t _major,minor_version_t _minor);
+            unique_version_t _unique, major_version_t _major,minor_version_t _minor);
 
     void send_subscribe(client_t _client,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, major_version_t _major,
             event_t _event, const std::shared_ptr<debounce_filter_impl_t> &_filter);
 
@@ -402,35 +402,35 @@ private:
             minor_version_t _minor);
 
     void call_sd_endpoint_connected(const boost::system::error_code &_error,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             const std::shared_ptr<endpoint> &_endpoint,
             std::shared_ptr<boost::asio::steady_timer> _timer);
 
     bool create_placeholder_event_and_subscribe(
-            service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+            service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
             event_t _event, const std::shared_ptr<debounce_filter_impl_t> &_filter,
             client_t _client);
 
-    void handle_subscription_state(client_t _client, service_t _service, instance_t _instance,
+    void handle_subscription_state(client_t _client, service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, event_t _event);
 
     void memory_log_timer_cbk(boost::system::error_code const &_error);
     void status_log_timer_cbk(boost::system::error_code const &_error);
 
     void send_subscription(const client_t _offering_client,
-            const service_t _service, const instance_t _instance,
+            const service_t _service, const unique_version_t _unique,
             const eventgroup_t _eventgroup, const major_version_t _major,
             const std::set<client_t> &_clients,
             const remote_subscription_id_t _id);
 
     void send_unsubscription(client_t _offering_client,
-            const service_t _service, const instance_t _instance,
+            const service_t _service, const unique_version_t _unique,
             const eventgroup_t _eventgroup, const major_version_t _major,
             const std::set<client_t> &_removed,
             const remote_subscription_id_t _id);
 
     void send_expired_subscription(client_t _offering_client,
-            const service_t _service, const instance_t _instance,
+            const service_t _service, const unique_version_t _unique,
             const eventgroup_t _eventgroup,
             const std::set<client_t> &_removed,
             const remote_subscription_id_t _id);
@@ -439,18 +439,18 @@ private:
                                  const std::shared_ptr<endpoint>& _endpoint);
 
     pending_remote_offer_id_t pending_remote_offer_add(service_t _service,
-                                                          instance_t _instance);
-    std::pair<service_t, instance_t> pending_remote_offer_remove(
+                                                          unique_version_t _unique);
+    std::pair<service_t, unique_version_t> pending_remote_offer_remove(
             pending_remote_offer_id_t _id);
 
-    bool insert_offer_command(service_t _service, instance_t _instance, uint8_t _command,
+    bool insert_offer_command(service_t _service, unique_version_t _unique, uint8_t _command,
                         client_t _client, major_version_t _major, minor_version_t _minor);
-    bool erase_offer_command(service_t _service, instance_t _instance);
+    bool erase_offer_command(service_t _service, unique_version_t _unique);
 
     std::string get_env(client_t _client) const;
     std::string get_env_unlocked(client_t _client) const;
 
-    bool insert_event_statistics(service_t _service, instance_t _instance,
+    bool insert_event_statistics(service_t _service, unique_version_t _unique,
             method_t _method, length_t _length);
     void statistics_log_timer_cbk(boost::system::error_code const & _error);
 
@@ -465,12 +465,12 @@ private:
     void clear_local_services();
 
     bool is_acl_message_allowed(endpoint *_receiver,
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             const boost::asio::ip::address &_remote_address) const;
 
 #ifdef VSOMEIP_ENABLE_DEFAULT_EVENT_CACHING
     bool has_subscribed_eventgroup(
-            service_t _service, instance_t _instance) const;
+            service_t _service, unique_version_t _unique) const;
 #endif // VSOMEIP_ENABLE_DEFAULT_EVENT_CACHING
 
 private:
@@ -488,7 +488,7 @@ private:
 
     std::mutex remote_subscribers_mutex_;
     std::map<service_t,
-        std::map<instance_t,
+        std::map<unique_version_t,
             std::map<client_t,
                 std::set<std::shared_ptr<endpoint_definition> >
             >
@@ -504,7 +504,7 @@ private:
     bool sd_route_set_;
     bool routing_running_;
     std::mutex pending_sd_offers_mutex_;
-    std::vector<std::pair<service_t, instance_t>> pending_sd_offers_;
+    std::vector<std::pair<service_t, unique_version_t>> pending_sd_offers_;
 #if defined(__linux__) || defined(ANDROID)
     std::shared_ptr<netlink_connector> netlink_connector_;
 #endif
@@ -514,14 +514,14 @@ private:
     // 1st client id in tuple: client id of new offering application
     // 2nd client id in tuple: client id of previously/stored offering application
     std::map<service_t,
-        std::map<instance_t,
+        std::map<unique_version_t,
                 std::tuple<major_version_t, minor_version_t,
                             client_t, client_t>>> pending_offers_;
 
     std::mutex pending_subscription_mutex_;
 
     std::mutex remote_subscription_state_mutex_;
-    std::map<std::tuple<service_t, instance_t, eventgroup_t, client_t>,
+    std::map<std::tuple<service_t, unique_version_t, eventgroup_t, client_t>,
         subscription_state_e> remote_subscription_state_;
 
     std::shared_ptr<e2e::e2e_provider> e2e_provider_;
@@ -541,12 +541,12 @@ private:
 
     std::mutex pending_remote_offers_mutex_;
     pending_remote_offer_id_t pending_remote_offer_id_;
-    std::map<pending_remote_offer_id_t, std::pair<service_t, instance_t>> pending_remote_offers_;
+    std::map<pending_remote_offer_id_t, std::pair<service_t, unique_version_t>> pending_remote_offers_;
 
     std::chrono::steady_clock::time_point last_resume_;
 
     std::mutex offer_serialization_mutex_;
-    std::map<std::pair<service_t, instance_t>, std::deque<std::tuple<uint8_t, client_t, major_version_t, minor_version_t>>> offer_commands_;
+    std::map<std::pair<service_t, unique_version_t>, std::deque<std::tuple<uint8_t, client_t, major_version_t, minor_version_t>>> offer_commands_;
 
     std::mutex callback_counts_mutex_;
     std::map<uint32_t, uint16_t> callback_counts_;
@@ -555,9 +555,9 @@ private:
     boost::asio::steady_timer statistics_log_timer_;
 
     std::mutex message_statistics_mutex_;
-    std::map<std::tuple<service_t, instance_t, method_t>,
+    std::map<std::tuple<service_t, unique_version_t, method_t>,
         msg_statistic_t> message_statistics_;
-    std::tuple<service_t, instance_t, method_t> message_to_discard_;
+    std::tuple<service_t, unique_version_t, method_t> message_to_discard_;
     uint32_t ignored_statistics_counter_;
 
     // synchronize update_remote_subscription() and send_(un)subscription()

--- a/implementation/routing/include/routing_manager_stub.hpp
+++ b/implementation/routing/include/routing_manager_stub.hpp
@@ -58,9 +58,9 @@ public:
             std::uint16_t _remote_port);
 
     void on_offer_service(client_t _client, service_t _service,
-            instance_t _instance, major_version_t _major, minor_version_t _minor);
+            unique_version_t _unique, major_version_t _major, minor_version_t _minor);
     void on_stop_offer_service(client_t _client, service_t _service,
-            instance_t _instance,  major_version_t _major, minor_version_t _minor);
+            unique_version_t _unique,  major_version_t _major, minor_version_t _minor);
 
     bool send_subscribe(
             const std::shared_ptr<endpoint> &_target, client_t _client,
@@ -71,22 +71,22 @@ public:
 
     bool send_unsubscribe(const std::shared_ptr<endpoint>& _target,
             client_t _client, service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup,
+            unique_version_t _unique, eventgroup_t _eventgroup,
             event_t _event, remote_subscription_id_t _id);
 
     bool send_expired_subscription(const std::shared_ptr<endpoint>& _target,
             client_t _client, service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup,
+            unique_version_t _unique, eventgroup_t _eventgroup,
             event_t _event, remote_subscription_id_t _id);
 
     void send_subscribe_nack(client_t _client, service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup, event_t _event);
+            unique_version_t _unique, eventgroup_t _eventgroup, event_t _event);
 
     void send_subscribe_ack(client_t _client, service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup, event_t _event);
+            unique_version_t _unique, eventgroup_t _eventgroup, event_t _event);
 
     bool contained_in_routing_info(client_t _client, service_t _service,
-                                   instance_t _instance, major_version_t _major,
+                                   unique_version_t _unique, major_version_t _major,
                                    minor_version_t _minor) const;
 
     void create_local_receiver();
@@ -150,10 +150,10 @@ private:
 
     void on_offered_service_request(client_t _client, offer_type_e _offer_type);
 
-    void distribute_credentials(client_t _hoster, service_t _service, instance_t _instance);
+    void distribute_credentials(client_t _hoster, service_t _service, unique_version_t _unique);
 
     void inform_requesters(client_t _hoster, service_t _service,
-            instance_t _instance, major_version_t _major,
+            unique_version_t _unique, major_version_t _major,
             minor_version_t _minor, protocol::routing_info_entry_type_e _entry,
             bool _inform_service);
 
@@ -250,7 +250,7 @@ private:
     std::mutex local_receiver_mutex_;
 
     std::map<client_t,
-            std::pair<uint8_t, std::map<service_t, std::map<instance_t, std::pair<major_version_t, minor_version_t>> > > > routing_info_;
+            std::pair<uint8_t, std::map<service_t, std::map<unique_version_t, std::pair<major_version_t, minor_version_t>> > > > routing_info_;
     mutable std::mutex routing_info_mutex_;
     std::shared_ptr<configuration> configuration_;
 
@@ -268,7 +268,7 @@ private:
     std::mutex pinged_clients_mutex_;
     std::map<client_t, boost::asio::steady_timer::time_point> pinged_clients_;
 
-    std::map<client_t, std::map<service_t, std::map<instance_t, std::pair<major_version_t, minor_version_t> > > > service_requests_;
+    std::map<client_t, std::map<service_t, std::map<unique_version_t, std::pair<major_version_t, minor_version_t> > > > service_requests_;
     std::map<client_t, std::set<client_t>> connection_matrix_;
 
     std::mutex pending_security_updates_mutex_;

--- a/implementation/routing/include/routing_manager_stub_host.hpp
+++ b/implementation/routing/include/routing_manager_stub_host.hpp
@@ -22,61 +22,61 @@ public:
     }
 
     virtual bool offer_service(client_t _client, service_t _service,
-            instance_t _instance, major_version_t _major,
+            unique_version_t _unique, major_version_t _major,
             minor_version_t _minor, bool _must_queue = true) = 0;
 
     virtual void stop_offer_service(client_t _client, service_t _service,
-            instance_t _instance, major_version_t _major,
+            unique_version_t _unique, major_version_t _major,
             minor_version_t _minor, bool _must_queue = true) = 0;
 
     virtual void request_service(client_t _client, service_t _service,
-            instance_t _instance, major_version_t _major,
+            unique_version_t _unique, major_version_t _major,
             minor_version_t _minor) = 0;
 
     virtual void release_service(client_t _client, service_t _service,
-            instance_t _instance) = 0;
+            unique_version_t _unique) = 0;
 
     virtual void register_shadow_event(client_t _client, service_t _service,
-            instance_t _instance, event_t _notifier,
+            unique_version_t _unique, event_t _notifier,
             const std::set<eventgroup_t> &_eventgroups, event_type_e _type,
             reliability_type_e _reliability, bool _is_provided,
             bool _is_cyclic) = 0;
 
     virtual void unregister_shadow_event(client_t _client, service_t _service,
-            instance_t _instance, event_t _event, bool _is_provided) = 0;
+            unique_version_t _unique, event_t _event, bool _is_provided) = 0;
 
     virtual void subscribe(client_t _client, const vsomeip_sec_client_t *_sec_client,
-            service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+            service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
             major_version_t _major, event_t _event,
             const std::shared_ptr<debounce_filter_impl_t> &_filter) = 0;
 
     virtual void on_subscribe_ack(client_t _client, service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup, event_t _event,
+            unique_version_t _unique, eventgroup_t _eventgroup, event_t _event,
             remote_subscription_id_t _subscription_id) = 0;
 
     virtual void on_subscribe_nack(client_t _client, service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup,
+            unique_version_t _unique, eventgroup_t _eventgroup,
 			bool _remove, remote_subscription_id_t _subscription_id) = 0;
 
     virtual void unsubscribe(client_t _client, const vsomeip_sec_client_t *_sec_client,
-            service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+            service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
             event_t _event) = 0;
 
     virtual void on_unsubscribe_ack(client_t _client, service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup,
+            unique_version_t _unique, eventgroup_t _eventgroup,
             remote_subscription_id_t _unsubscription_id) = 0;
 
-    virtual bool on_message(service_t _service, instance_t _instance,
+    virtual bool on_message(service_t _service, unique_version_t _unique,
             const byte_t *_data, length_t _size, bool _reliable,
             client_t _bound_client, const vsomeip_sec_client_t *_sec_client,
             uint8_t _status_check = 0, bool _is_from_remote = false) = 0;
 
     virtual void on_notification(client_t _client, service_t _service,
-            instance_t _instance, const byte_t *_data, length_t _size,
+            unique_version_t _unique, const byte_t *_data, length_t _size,
             bool _notify_one = false) = 0;
 
     virtual void on_stop_offer_service(client_t _client, service_t _service,
-            instance_t _instance, major_version_t _major,
+            unique_version_t _unique, major_version_t _major,
             minor_version_t _minor) = 0;
 
     virtual void on_availability(service_t _service, instance_t _instance,
@@ -103,14 +103,14 @@ public:
             pending_remote_offer_id_t _id) = 0;
 
     virtual client_t find_local_client(service_t _service,
-            instance_t _instance) = 0;
+            unique_version_t _unique) = 0;
 
     virtual std::set<client_t> find_local_clients(service_t _service,
-            instance_t _instance) = 0;
+            unique_version_t _unique) = 0;
 
     virtual bool is_subscribe_to_any_event_allowed(
             const vsomeip_sec_client_t *_sec_client,
-            client_t _client, service_t _service, instance_t _instance,
+            client_t _client, service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup) = 0;
 
     virtual void add_known_client(client_t _client,
@@ -130,7 +130,7 @@ public:
 
     virtual std::vector<protocol::service> get_requested_services(client_t _client) const = 0;
 
-    virtual bool is_available(service_t _service, instance_t _instance,
+    virtual bool is_available(service_t _service, unique_version_t _unique,
                               major_version_t _major) const = 0;
 };
 

--- a/implementation/routing/include/types.hpp
+++ b/implementation/routing/include/types.hpp
@@ -20,13 +20,13 @@ class endpoint_definition;
 
 
 typedef std::map<service_t,
-                 std::map<instance_t,
+                 std::map<unique_version_t,
                           std::shared_ptr<serviceinfo> > > services_t;
 
 class eventgroupinfo;
 
 typedef std::map<service_t,
-                 std::map<instance_t,
+                 std::map<unique_version_t,
                           std::map<eventgroup_t,
                                    std::shared_ptr<
                                        eventgroupinfo> > > > eventgroups_t;

--- a/implementation/runtime/include/application_impl.hpp
+++ b/implementation/runtime/include/application_impl.hpp
@@ -58,13 +58,13 @@ public:
     VSOMEIP_EXPORT security_mode_e get_security_mode() const;
 
     // Provide services / events
-    VSOMEIP_EXPORT void offer_service(service_t _service, instance_t _instance,
+    VSOMEIP_EXPORT void offer_service(service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor);
 
-    VSOMEIP_EXPORT void stop_offer_service(service_t _service, instance_t _instance,
+    VSOMEIP_EXPORT void stop_offer_service(service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor);
 
-    VSOMEIP_EXPORT void offer_event(service_t _service, instance_t _instance,
+    VSOMEIP_EXPORT void offer_event(service_t _service, unique_version_t _unique,
             event_t _notifier,
             const std::set<eventgroup_t> &_eventgroups, event_type_e _type,
             std::chrono::milliseconds _cycle, bool _change_resets_cycle,
@@ -73,43 +73,43 @@ public:
             reliability_type_e _reliability);
 
     VSOMEIP_EXPORT void stop_offer_event(service_t _service,
-            instance_t _instance, event_t _event);
+            unique_version_t _unique, event_t _event);
 
     // Consume services / events
     VSOMEIP_EXPORT void request_service(
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor);
     VSOMEIP_EXPORT void release_service(
-            service_t _service, instance_t _instance);
+            service_t _service, unique_version_t _unique);
 
     VSOMEIP_EXPORT void request_event(service_t _service,
-            instance_t _instance, event_t _event,
+            unique_version_t _unique, event_t _event,
             const std::set<eventgroup_t> &_eventgroups,
             event_type_e _type, reliability_type_e _reliability);
     VSOMEIP_EXPORT void release_event(service_t _service,
-            instance_t _instance, event_t _event);
+            unique_version_t _unique, event_t _event);
 
-    VSOMEIP_EXPORT void subscribe(service_t _service, instance_t _instance,
+    VSOMEIP_EXPORT void subscribe(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, major_version_t _major, event_t _event);
-    VSOMEIP_EXPORT void subscribe_with_debounce(service_t _service, instance_t _instance,
+    VSOMEIP_EXPORT void subscribe_with_debounce(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, major_version_t _major,
             event_t _event, const debounce_filter_t &_filter);
 
-    VSOMEIP_EXPORT void unsubscribe(service_t _service, instance_t _instance,
+    VSOMEIP_EXPORT void unsubscribe(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup);
-    VSOMEIP_EXPORT void unsubscribe(service_t _service, instance_t _instance,
+    VSOMEIP_EXPORT void unsubscribe(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, event_t _event);
 
-    VSOMEIP_EXPORT bool is_available(service_t _service, instance_t _instance,
+    VSOMEIP_EXPORT bool is_available(service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor) const;
 
     VSOMEIP_EXPORT void send(std::shared_ptr<message> _message);
 
-    VSOMEIP_EXPORT void notify(service_t _service, instance_t _instance,
+    VSOMEIP_EXPORT void notify(service_t _service, unique_version_t _unique,
             event_t _event, std::shared_ptr<payload> _payload,
             bool _force) const;
 
-    VSOMEIP_EXPORT void notify_one(service_t _service, instance_t _instance,
+    VSOMEIP_EXPORT void notify_one(service_t _service, unique_version_t _unique,
             event_t _event, std::shared_ptr<payload> _payload, client_t _client,
             bool _force) const;
 
@@ -117,26 +117,26 @@ public:
     VSOMEIP_EXPORT void unregister_state_handler();
 
     VSOMEIP_EXPORT void register_message_handler(service_t _service,
-            instance_t _instance, method_t _method, const message_handler_t &_handler);
+            unique_version_t _unique, method_t _method, const message_handler_t &_handler);
     VSOMEIP_EXPORT void unregister_message_handler(service_t _service,
-            instance_t _instance, method_t _method);
+            unique_version_t _unique, method_t _method);
 
     VSOMEIP_EXPORT void register_availability_handler(service_t _service,
-            instance_t _instance, const availability_handler_t &_handler,
+            unique_version_t _unique, const availability_handler_t &_handler,
             major_version_t _major, minor_version_t _minor);
     VSOMEIP_EXPORT void register_availability_handler(service_t _service,
-            instance_t _instance, const availability_state_handler_t &_handler,
+            unique_version_t _unique, const availability_state_handler_t &_handler,
             major_version_t _major, minor_version_t _minor);
     VSOMEIP_EXPORT void unregister_availability_handler(service_t _service,
             instance_t _instance,
             major_version_t _major, minor_version_t _minor);
 
     VSOMEIP_EXPORT void register_subscription_handler(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup, const subscription_handler_t &_handler);
+            unique_version_t _unique, eventgroup_t _eventgroup, const subscription_handler_t &_handler);
     VSOMEIP_EXPORT void register_subscription_handler(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup, const subscription_handler_ext_t &_handler);
+            unique_version_t _unique, eventgroup_t _eventgroup, const subscription_handler_ext_t &_handler);
     VSOMEIP_EXPORT void unregister_subscription_handler(service_t _service,
-                instance_t _instance, eventgroup_t _eventgroup);
+                unique_version_t _unique, eventgroup_t _eventgroup);
 
     VSOMEIP_EXPORT bool is_routing() const;
 
@@ -157,22 +157,22 @@ public:
     VSOMEIP_EXPORT void on_availability(service_t _service, instance_t _instance,
             availability_state_e _state, major_version_t _major, minor_version_t _minor);
     VSOMEIP_EXPORT void on_message(std::shared_ptr<message> &&_message);
-    VSOMEIP_EXPORT void on_subscription(service_t _service, instance_t _instance,
+    VSOMEIP_EXPORT void on_subscription(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, client_t _client, const vsomeip_sec_client_t *_sec_client,
             const std::string &_env, bool _subscribed, const std::function<void(bool)> &_accepted_cb);
-    VSOMEIP_EXPORT void on_subscription_status(service_t _service, instance_t _instance,
+    VSOMEIP_EXPORT void on_subscription_status(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, event_t _event, uint16_t _error);
     VSOMEIP_EXPORT void register_subscription_status_handler(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup, event_t _event,
+            unique_version_t _unique, eventgroup_t _eventgroup, event_t _event,
             subscription_status_handler_t _handler, bool _is_selective);
     VSOMEIP_EXPORT void unregister_subscription_status_handler(service_t _service,
-                instance_t _instance, eventgroup_t _eventgroup, event_t _event);
+                unique_version_t _unique, eventgroup_t _eventgroup, event_t _event);
 
     // service_discovery_host
     VSOMEIP_EXPORT routing_manager * get_routing_manager() const;
 
     VSOMEIP_EXPORT bool are_available(available_t &_available,
-                       service_t _service, instance_t _instance,
+                       service_t _service, unique_version_t _unique,
                        major_version_t _major, minor_version_t _minor) const;
     VSOMEIP_EXPORT void set_routing_state(routing_state_e _routing_state);
 
@@ -181,15 +181,15 @@ public:
 
     VSOMEIP_EXPORT void get_offered_services_async(offer_type_e _offer_type, const offered_services_handler_t &_handler);
 
-    VSOMEIP_EXPORT void on_offered_services_info(std::vector<std::pair<service_t, instance_t>> &_services);
+    VSOMEIP_EXPORT void on_offered_services_info(std::vector<std::pair<service_t, unique_version_t>> &_services);
 
     VSOMEIP_EXPORT void set_watchdog_handler(const watchdog_handler_t &_handler, std::chrono::seconds _interval);
 
     VSOMEIP_EXPORT void register_async_subscription_handler(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup, const async_subscription_handler_t &_handler);
+            unique_version_t _unique, eventgroup_t _eventgroup, const async_subscription_handler_t &_handler);
 
     VSOMEIP_EXPORT void register_async_subscription_handler(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup, const async_subscription_handler_ext_t &_handler);
+            unique_version_t _unique, eventgroup_t _eventgroup, const async_subscription_handler_ext_t &_handler);
 
     VSOMEIP_EXPORT void set_sd_acceptance_required(const remote_info_t& _remote,
                                                    const std::string& _path, bool _enable);
@@ -206,7 +206,7 @@ public:
     VSOMEIP_EXPORT void register_routing_state_handler(const routing_state_handler_t &_handler);
 
     VSOMEIP_EXPORT bool update_service_configuration(service_t _service,
-                                                     instance_t _instance,
+                                                     unique_version_t _unique,
                                                      std::uint16_t _port,
                                                      bool _reliable,
                                                      bool _magic_cookies_enabled,
@@ -227,10 +227,10 @@ public:
             get_additional_data(const std::string &_plugin_name);
 
     VSOMEIP_EXPORT void register_subscription_handler(service_t _service,
-                instance_t _instance, eventgroup_t _eventgroup,
+                unique_version_t _unique, eventgroup_t _eventgroup,
                 const subscription_handler_sec_t &_handler);
     VSOMEIP_EXPORT void register_async_subscription_handler(
-                service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+                service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
                 async_subscription_handler_sec_t _handler);
 
     VSOMEIP_EXPORT void register_message_handler_ext(
@@ -319,21 +319,21 @@ private:
 
     void shutdown();
 
-    void send_back_cached_event(service_t _service, instance_t _instance, event_t _event);
-    void send_back_cached_eventgroup(service_t _service, instance_t _instance, eventgroup_t _eventgroup);
-    void check_send_back_cached_event(service_t _service, instance_t _instance,
+    void send_back_cached_event(service_t _service, unique_version_t _unique, event_t _event);
+    void send_back_cached_eventgroup(service_t _service, unique_version_t _unique, eventgroup_t _eventgroup);
+    void check_send_back_cached_event(service_t _service, unique_version_t _unique,
                                       event_t _event, eventgroup_t _eventgroup,
                                       bool *_send_back_cached_event,
                                       bool *_send_back_cached_eventgroup);
-    void remove_subscription(service_t _service, instance_t _instance,
+    void remove_subscription(service_t _service, unique_version_t _unique,
                              eventgroup_t _eventgroup, event_t _event);
-    bool check_for_active_subscription(service_t _service, instance_t _instance,
+    bool check_for_active_subscription(service_t _service, unique_version_t _unique,
                                        event_t _event);
 
-    void deliver_subscription_state(service_t _service, instance_t _instance,
+    void deliver_subscription_state(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, event_t _event, uint16_t _error);
 
-    bool check_subscription_state(service_t _service, instance_t _instance,
+    bool check_subscription_state(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, event_t _event);
 
     void print_blocking_call(const std::shared_ptr<sync_handler>& _handler);
@@ -421,13 +421,13 @@ private:
 
     // Subscription handlers
     std::map<service_t,
-            std::map<instance_t,
+            std::map<unique_version_t,
                     std::map<eventgroup_t,
                             std::pair<subscription_handler_sec_t,
                                 async_subscription_handler_sec_t> > > > subscription_;
     mutable std::mutex subscription_mutex_;
     std::map<service_t,
-        std::map<instance_t, std::map<eventgroup_t,
+        std::map<unique_version_t, std::map<eventgroup_t,
         std::map<client_t, error_handler_t > > > > eventgroup_error_handlers_;
     mutable std::mutex subscription_error_mutex_;
 
@@ -480,7 +480,7 @@ private:
 
     // Event subscriptions
     std::mutex subscriptions_mutex_;
-    std::map<service_t, std::map<instance_t,
+    std::map<service_t, std::map<unique_version_t,
             std::map<event_t, std::map<eventgroup_t, bool>>>> subscriptions_;
 
     std::thread::id stop_caller_id_;
@@ -488,13 +488,13 @@ private:
 
     bool stopped_called_;
 
-    std::map<service_t, std::map<instance_t, std::map<eventgroup_t,
+    std::map<service_t, std::map<unique_version_t, std::map<eventgroup_t,
             std::map<event_t, std::pair<subscription_status_handler_t, bool> > > > > subscription_status_handlers_;
     std::mutex subscription_status_handlers_mutex_;
 
     std::mutex subscriptions_state_mutex_;
     std::map<service_t,
-        std::map<instance_t,
+        std::map<unique_version_t,
             std::map<eventgroup_t,
                 std::map<event_t, subscription_state_e>
             >

--- a/implementation/service_discovery/include/service_discovery.hpp
+++ b/implementation/service_discovery/include/service_discovery.hpp
@@ -33,17 +33,17 @@ public:
     virtual void start() = 0;
     virtual void stop() = 0;
 
-    virtual void request_service(service_t _service, instance_t _instance,
+    virtual void request_service(service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor, ttl_t _ttl) = 0;
-    virtual void release_service(service_t _service, instance_t _instance) = 0;
+    virtual void release_service(service_t _service, unique_version_t _unique) = 0;
 
-    virtual void subscribe(service_t _service, instance_t _instance,
+    virtual void subscribe(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, major_version_t _major,
             ttl_t _ttl, client_t _client,
             const std::shared_ptr<eventgroupinfo>& _info) = 0;
-    virtual void unsubscribe(service_t _service, instance_t _instance,
+    virtual void unsubscribe(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, client_t _client) = 0;
-    virtual void unsubscribe_all(service_t _service, instance_t _instance) = 0;
+    virtual void unsubscribe_all(service_t _service, unique_version_t _unique) = 0;
     virtual void unsubscribe_all_on_suspend() = 0;
 
     virtual bool send(bool _is_announcing) = 0;
@@ -57,7 +57,7 @@ public:
                   const boost::asio::ip::address& _remote_address = boost::asio::ip::address()) = 0;
 
     virtual void on_endpoint_connected(
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             const std::shared_ptr<endpoint> &_endpoint) = 0;
 
     virtual void offer_service(const std::shared_ptr<serviceinfo> &_info) = 0;

--- a/implementation/service_discovery/include/service_discovery_host.hpp
+++ b/implementation/service_discovery/include/service_discovery_host.hpp
@@ -38,7 +38,7 @@ public:
 
     virtual services_t get_offered_services() const = 0;
     virtual std::shared_ptr<eventgroupinfo> find_eventgroup(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup) const = 0;
+            unique_version_t _unique, eventgroup_t _eventgroup) const = 0;
 
     virtual bool send(client_t _client, std::shared_ptr<message> _message,
             bool _force) = 0;
@@ -53,7 +53,7 @@ public:
             const boost::asio::ip::address &_unreliable_address,
             uint16_t _unreliable_port) = 0;
 
-    virtual void del_routing_info(service_t _service, instance_t _instance,
+    virtual void del_routing_info(service_t _service, unique_version_t _unique,
             bool _has_reliable, bool _has_unreliable) = 0;
 
     virtual void update_routing_info(std::chrono::milliseconds _elapsed) = 0;
@@ -62,16 +62,16 @@ public:
             std::shared_ptr<remote_subscription> &_subscription) = 0;
 
     virtual void on_subscribe_ack(client_t _client,
-            service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+            service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
             event_t _event, remote_subscription_id_t _subscription_id) = 0;
 
     virtual void on_subscribe_ack_with_multicast(
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             const boost::asio::ip::address &_sender,
             const boost::asio::ip::address &_address, uint16_t _port) = 0;
 
     virtual std::shared_ptr<endpoint> find_or_create_remote_client(
-            service_t _service, instance_t _instance, bool _reliable) = 0;
+            service_t _service, unique_version_t _unique, bool _reliable) = 0;
 
     virtual void expire_subscriptions(const boost::asio::ip::address &_address) = 0;
     virtual void expire_subscriptions(const boost::asio::ip::address &_address,
@@ -86,18 +86,18 @@ public:
             const remote_subscription_callback_t& _callback) = 0;
 
     virtual void on_subscribe_nack(client_t _client,
-            service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+            service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
             bool _remove, remote_subscription_id_t _subscription_id) = 0;
 
     virtual std::chrono::steady_clock::time_point expire_subscriptions(bool _force) = 0;
 
     virtual std::shared_ptr<serviceinfo> get_offered_service(
-            service_t _service, instance_t _instance) const = 0;
-    virtual std::map<instance_t, std::shared_ptr<serviceinfo>> get_offered_service_instances(
+            service_t _service, unique_version_t _unique) const = 0;
+    virtual std::map<unique_version_t, std::shared_ptr<serviceinfo>> get_offered_service_instances(
             service_t _service) const = 0;
 
     virtual std::set<eventgroup_t> get_subscribed_eventgroups(service_t _service,
-            instance_t _instance) = 0;
+            unique_version_t _unique) = 0;
 };
 
 }  // namespace sd

--- a/implementation/service_discovery/include/service_discovery_impl.hpp
+++ b/implementation/service_discovery/include/service_discovery_impl.hpp
@@ -45,7 +45,7 @@ class service_discovery_host;
 class subscription;
 
 typedef std::map<service_t,
-            std::map<instance_t,
+            std::map<unique_version_t,
                 std::shared_ptr<request>
             >
         > requests_t;
@@ -70,18 +70,18 @@ public:
     void start();
     void stop();
 
-    void request_service(service_t _service, instance_t _instance,
+    void request_service(service_t _service, unique_version_t _unique,
             major_version_t _major, minor_version_t _minor, ttl_t _ttl);
-    void release_service(service_t _service, instance_t _instance);
+    void release_service(service_t _service, unique_version_t _unique);
 
-    void subscribe(service_t _service, instance_t _instance,
+    void subscribe(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, major_version_t _major, ttl_t _ttl,
             client_t _client, const std::shared_ptr<eventgroupinfo>& _info);
-    void unsubscribe(service_t _service, instance_t _instance,
+    void unsubscribe(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, client_t _client);
-    void unsubscribe_all(service_t _service, instance_t _instance);
+    void unsubscribe_all(service_t _service, unique_version_t _unique);
     void unsubscribe_all_on_suspend();
-    void remove_subscriptions(service_t _service, instance_t _instance);
+    void remove_subscriptions(service_t _service, unique_version_t _unique);
 
     bool send(bool _is_announcing);
 
@@ -93,7 +93,7 @@ public:
                   const boost::asio::ip::address& _remote_address = boost::asio::ip::address());
 
     void on_endpoint_connected(
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             const std::shared_ptr<endpoint> &_endpoint);
 
     void offer_service(const std::shared_ptr<serviceinfo> &_info);
@@ -162,18 +162,18 @@ private:
     void check_sent_offers(const message_impl::entries_t& _entries,
                            const boost::asio::ip::address& _remote_address) const;
     void process_offerservice_serviceentry(
-            service_t _service, instance_t _instance, major_version_t _major,
+            service_t _service, unique_version_t _unique, major_version_t _major,
             minor_version_t _minor, ttl_t _ttl, const boost::asio::ip::address& _reliable_address,
             uint16_t _reliable_port, const boost::asio::ip::address& _unreliable_address,
             uint16_t _unreliable_port, std::vector<std::shared_ptr<message_impl>>& _resubscribes,
             bool _received_via_multicast, const sd_acceptance_state_t& _sd_ac_state);
     void send_offer_service(
             const std::shared_ptr<const serviceinfo> &_info, service_t _service,
-            instance_t _instance, major_version_t _major, minor_version_t _minor,
+            unique_version_t _unique, major_version_t _major, minor_version_t _minor,
             bool _unicast_flag);
 
     void process_findservice_serviceentry(service_t _service,
-            instance_t _instance,
+            unique_version_t _unique,
             major_version_t _major,
             minor_version_t _minor,
             bool _unicast_flag);
@@ -186,7 +186,7 @@ private:
             bool _is_stop_subscribe_subscribe, bool _force_initial_events,
             const sd_acceptance_state_t& _sd_ac_state);
     void handle_eventgroup_subscription(
-            service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+            service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
             major_version_t _major, ttl_t _ttl, uint8_t _counter, uint16_t _reserved,
             const boost::asio::ip::address& _first_address, uint16_t _first_port,
             bool _is_first_reliable, const boost::asio::ip::address& _second_address,
@@ -196,13 +196,13 @@ private:
             const std::set<client_t>& _clients, const sd_acceptance_state_t& _sd_ac_state,
             const std::shared_ptr<eventgroupinfo>& _info, const boost::asio::ip::address& _sender);
     void handle_eventgroup_subscription_ack(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup,
+            unique_version_t _unique, eventgroup_t _eventgroup,
             major_version_t _major, ttl_t _ttl, uint8_t _counter,
             const std::set<client_t> &_clients,
             const boost::asio::ip::address &_sender,
             const boost::asio::ip::address &_address, uint16_t _port);
     void handle_eventgroup_subscription_nack(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup, uint8_t _counter,
+            unique_version_t _unique, eventgroup_t _eventgroup, uint8_t _counter,
             const std::set<client_t> &_clients);
 
     bool send(const std::vector<std::shared_ptr<message_impl>> &_messages);
@@ -214,7 +214,7 @@ private:
             const std::shared_ptr<remote_subscription_ack> &_acknowledgement);
 
     bool is_tcp_connected(service_t _service,
-            instance_t _instance,
+            unique_version_t _unique,
             const std::shared_ptr<endpoint_definition>& its_endpoint);
 
     void start_ttl_timer(int _shift = 0);
@@ -235,14 +235,14 @@ private:
     bool check_layer_four_protocol(
             const std::shared_ptr<const ip_option_impl>& _ip_option) const;
 
-    void get_subscription_endpoints(service_t _service, instance_t _instance,
+    void get_subscription_endpoints(service_t _service, unique_version_t _unique,
             std::shared_ptr<endpoint>& _reliable,
             std::shared_ptr<endpoint>& _unreliable) const;
     void get_subscription_address(const std::shared_ptr<endpoint> &_reliable,
             const std::shared_ptr<endpoint> &_unreliable,
             boost::asio::ip::address &_address) const;
 
-    void update_request(service_t _service, instance_t _instance);
+    void update_request(service_t _service, unique_version_t _unique);
 
     void start_offer_debounce_timer(bool _first_start);
     void on_offer_debounce_timer_expired(const boost::system::error_code &_error);
@@ -285,7 +285,7 @@ private:
             const std::vector<std::shared_ptr<message_impl> > &_messages);
 
     void remote_subscription_acknowledge(
-            service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+            service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
             const std::shared_ptr<remote_subscription> &_subscription);
 
     bool check_stop_subscribe_subscribe(
@@ -308,23 +308,23 @@ private:
             const message_impl::options_t &_options) const;
 
     configuration::ttl_factor_t get_ttl_factor(
-            service_t _service, instance_t _instance,
+            service_t _service, unique_version_t _unique,
             const configuration::ttl_map_t& _ttl_map) const;
     void on_last_msg_received_timer_expired(const boost::system::error_code &_error);
     void stop_last_msg_received_timer();
 
     reliability_type_e get_remote_offer_type(
-            service_t _service, instance_t _instance) const;
+            service_t _service, unique_version_t _unique) const;
     reliability_type_e get_remote_offer_type(
             const std::shared_ptr<subscription> &_subscription) const;
 
-    bool update_remote_offer_type(service_t _service, instance_t _instance,
+    bool update_remote_offer_type(service_t _service, unique_version_t _unique,
                                   reliability_type_e _offer_type,
                                   const boost::asio::ip::address& _reliable_address,
                                   std::uint16_t _reliable_port,
                                   const boost::asio::ip::address& _unreliable_address,
                                   std::uint16_t _unreliable_port, bool _received_via_multicast);
-    void remove_remote_offer_type(service_t _service, instance_t _instance,
+    void remove_remote_offer_type(service_t _service, unique_version_t _unique,
                                   const boost::asio::ip::address &_reliable_address,
                                   std::uint16_t _reliable_port,
                                   const boost::asio::ip::address &_unreliable_address,
@@ -334,7 +334,7 @@ private:
                                         std::uint16_t _port, bool _reliable);
 
     // Returns true if the state changes from unicast -> multicast, false any of the other 3 cases
-    bool set_offer_multicast_state(service_t _service, instance_t _instance,
+    bool set_offer_multicast_state(service_t _service, unique_version_t _unique,
                                    reliability_type_e _offer_type,
                                    const boost::asio::ip::address& _reliable_address,
                                    port_t _reliable_port,
@@ -348,7 +348,7 @@ private:
                         const std::shared_ptr<eventgroupinfo>& _info) const;
 
     std::shared_ptr<remote_subscription> get_remote_subscription(
-            const service_t _service, const instance_t _instance,
+            const service_t _service, const unique_version_t _unique,
             const eventgroup_t _eventgroup);
 
     void send_subscription_ack(
@@ -359,7 +359,7 @@ private:
             bool _is_reliable) const;
 
     void send_subscription(const std::shared_ptr<subscription> &_subscription,
-            const service_t _service, const instance_t _instance,
+            const service_t _service, const unique_version_t _unique,
             const eventgroup_t _eventgroup, const client_t _client);
 
     void add_entry_data(std::vector<std::shared_ptr<message_impl>> &_messages,
@@ -369,7 +369,7 @@ private:
             const std::shared_ptr<remote_subscription_ack>& _acknowledgement,
             const entry_data_t &_data);
     reliability_type_e get_eventgroup_reliability(
-            service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+            service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
             const std::shared_ptr<subscription>& _subscription);
     void deserialize_data(const byte_t* _data, const length_t& _size,
                           std::shared_ptr<message_impl>& _message);
@@ -390,7 +390,7 @@ private:
     requests_t requested_;
     std::mutex requested_mutex_;
     std::map<service_t,
-        std::map<instance_t,
+        std::map<unique_version_t,
             std::map<eventgroup_t,
                 std::shared_ptr<subscription>
             >
@@ -477,10 +477,10 @@ private:
     std::chrono::milliseconds last_msg_received_timer_timeout_;
 
     mutable std::mutex remote_offer_types_mutex_;
-    std::map<std::pair<service_t, instance_t>, reliability_type_e> remote_offer_types_;
+    std::map<std::pair<service_t, unique_version_t>, reliability_type_e> remote_offer_types_;
 
     struct remote_offer_info_t {
-        std::pair<service_t, instance_t> service_info;
+        std::pair<service_t, unique_version_t> service_info;
 
         // The goal of this flag is to handle the SOMEIPSD_00577 requirement
         // To do so we will keep track of the last received offer for a given service+instance pair
@@ -489,9 +489,9 @@ private:
         // It shall be mutable to allow the value to be updated within a std::set
         mutable bool offer_received_via_multicast;
 
-        remote_offer_info_t(service_t _service, instance_t _instance,
+        remote_offer_info_t(service_t _service, unique_version_t _unique,
                             bool _received_via_multicast = true) :
-            service_info(std::make_pair(_service, _instance)),
+            service_info(std::make_pair(_service, _unique)),
             offer_received_via_multicast(_received_via_multicast) { }
 
         // Use the service_info pair as the key for unique values within a std::set

--- a/implementation/service_discovery/src/service_discovery_impl.cpp
+++ b/implementation/service_discovery/src/service_discovery_impl.cpp
@@ -213,41 +213,41 @@ service_discovery_impl::stop() {
 
 void
 service_discovery_impl::request_service(
-        service_t _service, instance_t _instance,
+        service_t _service, unique_version_t _unique,
         major_version_t _major, minor_version_t _minor,
         ttl_t _ttl) {
     std::lock_guard<std::mutex> its_lock(requested_mutex_);
     auto find_service = requested_.find(_service);
     if (find_service != requested_.end()) {
-        auto find_instance = find_service->second.find(_instance);
-        if (find_instance == find_service->second.end()) {
-            find_service->second[_instance]
+        auto find_unique = find_service->second.find(_unique);
+        if (find_unique == find_service->second.end()) {
+            find_service->second[_unique]
                 = std::make_shared<request>(_major, _minor, _ttl);
         }
     } else {
-        requested_[_service][_instance]
+        requested_[_service][_unique]
             = std::make_shared<request>(_major, _minor, _ttl);
     }
 }
 
 void
 service_discovery_impl::release_service(
-        service_t _service, instance_t _instance) {
+        service_t _service, unique_version_t _unique) {
     std::lock_guard<std::mutex> its_lock(requested_mutex_);
     auto find_service = requested_.find(_service);
     if (find_service != requested_.end()) {
-        find_service->second.erase(_instance);
+        find_service->second.erase(_unique);
     }
 }
 
 void
-service_discovery_impl::update_request(service_t _service, instance_t _instance) {
+service_discovery_impl::update_request(service_t _service, unique_version_t _unique) {
     std::lock_guard<std::mutex> its_lock(requested_mutex_);
     auto find_service = requested_.find(_service);
     if (find_service != requested_.end()) {
-        auto find_instance = find_service->second.find(_instance);
-        if (find_instance != find_service->second.end()) {
-            find_instance->second->set_sent_counter(
+        auto find_unique = find_service->second.find(_unique);
+        if (find_unique != find_service->second.end()) {
+            find_unique->second->set_sent_counter(
                     std::uint8_t(repetitions_max_ + 1));
         }
     }
@@ -260,7 +260,7 @@ service_discovery_impl::get_subscribed_mutex() {
 
 void
 service_discovery_impl::subscribe(
-        service_t _service, instance_t _instance,
+        service_t _service, unique_version_t _unique,
         eventgroup_t _eventgroup, major_version_t _major,
         ttl_t _ttl, client_t _client,
         const std::shared_ptr<eventgroupinfo> &_info) {
@@ -278,10 +278,10 @@ service_discovery_impl::subscribe(
     std::lock_guard<std::recursive_mutex> its_lock(subscribed_mutex_);
     auto found_service = subscribed_.find(_service);
     if (found_service != subscribed_.end()) {
-        auto found_instance = found_service->second.find(_instance);
-        if (found_instance != found_service->second.end()) {
-            auto found_eventgroup = found_instance->second.find(_eventgroup);
-            if (found_eventgroup != found_instance->second.end()) {
+        auto found_unique = found_service->second.find(_unique);
+        if (found_unique != found_service->second.end()) {
+            auto found_eventgroup = found_unique->second.find(_eventgroup);
+            if (found_eventgroup != found_unique->second.end()) {
                 auto its_subscription = found_eventgroup->second;
 #ifdef VSOMEIP_ENABLE_COMPAT
                 if (!its_subscription->is_selective() && is_selective) {
@@ -303,7 +303,7 @@ service_discovery_impl::subscribe(
                         its_subscription->set_state(_client,
                                 subscription_state_e::ST_NOT_ACKNOWLEDGED);
                         send_subscription(its_subscription,
-                                _service, _instance, _eventgroup,
+                                _service, _unique, _eventgroup,
                                 _client);
                     }
                 }
@@ -313,7 +313,7 @@ service_discovery_impl::subscribe(
     }
 
     std::shared_ptr<endpoint> its_reliable, its_unreliable;
-        get_subscription_endpoints(_service, _instance,
+        get_subscription_endpoints(_service, _unique,
                 its_reliable, its_unreliable);
 
     // New subscription
@@ -327,21 +327,21 @@ service_discovery_impl::subscribe(
         return;
     }
 
-    subscribed_[_service][_instance][_eventgroup] = its_subscription;
+    subscribed_[_service][_unique][_eventgroup] = its_subscription;
 
     its_subscription->add_client(_client);
     its_subscription->set_state(_client,
             subscription_state_e::ST_NOT_ACKNOWLEDGED);
 
     send_subscription(its_subscription,
-            _service, _instance, _eventgroup,
+            _service, _unique, _eventgroup,
             _client);
 }
 
 void
 service_discovery_impl::send_subscription(
         const std::shared_ptr<subscription> &_subscription,
-        const service_t _service, const instance_t _instance,
+        const service_t _service, const unique_version_t _unique,
         const eventgroup_t _eventgroup,
         const client_t _client) {
     (void)_client;
@@ -349,22 +349,24 @@ service_discovery_impl::send_subscription(
     auto its_reliable = _subscription->get_endpoint(true);
     auto its_unreliable = _subscription->get_endpoint(false);
 
+    instance_t its_instance = get_instance_from_unique(_unique);
+
     boost::asio::ip::address its_address;
     get_subscription_address(its_reliable, its_unreliable, its_address);
     if (!its_address.is_unspecified()) {
         entry_data_t its_data;
         const reliability_type_e its_reliability_type =
-                get_eventgroup_reliability(_service, _instance, _eventgroup, _subscription);
+                get_eventgroup_reliability(_service, _unique, _eventgroup, _subscription);
         if (its_reliability_type == reliability_type_e::RT_UNRELIABLE && its_unreliable) {
             if (its_unreliable->is_established()) {
-                its_data = create_eventgroup_entry(_service, _instance,
+                its_data = create_eventgroup_entry(_service, its_instance,
                         _eventgroup, _subscription, its_reliability_type);
             } else {
                 _subscription->set_udp_connection_established(false);
             }
         } else if (its_reliability_type == reliability_type_e::RT_RELIABLE && its_reliable) {
             if (its_reliable->is_established()) {
-                its_data = create_eventgroup_entry(_service, _instance,
+                its_data = create_eventgroup_entry(_service, its_instance,
                         _eventgroup, _subscription, its_reliability_type);
             } else {
                 _subscription->set_tcp_connection_established(false);
@@ -372,7 +374,7 @@ service_discovery_impl::send_subscription(
         } else if (its_reliability_type == reliability_type_e::RT_BOTH &&
                 its_reliable && its_unreliable) {
             if (its_reliable->is_established() && its_unreliable->is_established()) {
-                its_data = create_eventgroup_entry(_service, _instance,
+                its_data = create_eventgroup_entry(_service, its_instance,
                         _eventgroup, _subscription, its_reliability_type);
             } else {
                 if (!its_reliable->is_established()) {
@@ -386,7 +388,7 @@ service_discovery_impl::send_subscription(
             VSOMEIP_WARNING << "sd::" << __func__ << ": couldn't determine reliability type for subscription to ["
                     << std::hex << std::setfill('0')
                     << std::setw(4) << _service << "."
-                    << std::setw(4) << _instance << "."
+                    << std::setw(4) << its_instance << "."
                     << std::setw(4) << _eventgroup << "] ";
         }
 
@@ -405,13 +407,13 @@ service_discovery_impl::send_subscription(
 
 void
 service_discovery_impl::get_subscription_endpoints(
-        service_t _service, instance_t _instance,
+        service_t _service, unique_version_t _unique,
         std::shared_ptr<endpoint> &_reliable,
         std::shared_ptr<endpoint> &_unreliable) const {
     _unreliable = host_->find_or_create_remote_client(
-            _service, _instance, false);
+            _service, _unique, false);
     _reliable = host_->find_or_create_remote_client(
-            _service, _instance, true);
+            _service, _unique, true);
 }
 
 void
@@ -438,7 +440,7 @@ service_discovery_impl::get_subscription_address(
 
 void
 service_discovery_impl::unsubscribe(service_t _service,
-        instance_t _instance, eventgroup_t _eventgroup, client_t _client) {
+        unique_version_t _unique, eventgroup_t _eventgroup, client_t _client) {
     std::shared_ptr < runtime > its_runtime = runtime_.lock();
     if (!its_runtime) {
         return;
@@ -451,10 +453,10 @@ service_discovery_impl::unsubscribe(service_t _service,
         std::lock_guard<std::recursive_mutex> its_lock(subscribed_mutex_);
         auto found_service = subscribed_.find(_service);
         if (found_service != subscribed_.end()) {
-            auto found_instance = found_service->second.find(_instance);
-            if (found_instance != found_service->second.end()) {
-                auto found_eventgroup = found_instance->second.find(_eventgroup);
-                if (found_eventgroup != found_instance->second.end()) {
+            auto found_unique = found_service->second.find(_unique);
+            if (found_unique != found_service->second.end()) {
+                auto found_eventgroup = found_unique->second.find(_eventgroup);
+                if (found_eventgroup != found_unique->second.end()) {
                     auto its_subscription = found_eventgroup->second;
                     if (its_subscription->remove_client(_client)) {
                         auto its_reliable = its_subscription->get_endpoint(true);
@@ -483,8 +485,8 @@ service_discovery_impl::unsubscribe(service_t _service,
                         its_subscription->add_client(_client);
 
                     const reliability_type_e its_reliability_type =
-                            get_eventgroup_reliability(_service, _instance, _eventgroup, its_subscription);
-                    auto its_data = create_eventgroup_entry(_service, _instance,
+                            get_eventgroup_reliability(_service, _unique, _eventgroup, its_subscription);
+                    auto its_data = create_eventgroup_entry(_service, get_instance_from_unique(_unique),
                         _eventgroup, its_subscription, its_reliability_type);
                     if (its_data.entry_)
                         its_current_message->add_entry_data(its_data.entry_, its_data.options_);
@@ -498,9 +500,9 @@ service_discovery_impl::unsubscribe(service_t _service,
 
                     // Finally update the subscriptions
                     if (!its_subscription->has_client()) {
-                        found_instance->second.erase(found_eventgroup);
-                        if (found_instance->second.size() == 0) {
-                            found_service->second.erase(found_instance);
+                        found_unique->second.erase(found_eventgroup);
+                        if (found_unique->second.size() == 0) {
+                            found_service->second.erase(found_unique);
                         }
                     }
                 }
@@ -516,7 +518,7 @@ service_discovery_impl::unsubscribe(service_t _service,
 
 void
 service_discovery_impl::unsubscribe_all(
-        service_t _service, instance_t _instance) {
+        service_t _service, unique_version_t _unique) {
 
     auto its_current_message = std::make_shared<message_impl>();
     boost::asio::ip::address its_address;
@@ -525,17 +527,17 @@ service_discovery_impl::unsubscribe_all(
         std::lock_guard<std::recursive_mutex> its_lock(subscribed_mutex_);
         auto found_service = subscribed_.find(_service);
         if (found_service != subscribed_.end()) {
-            auto found_instance = found_service->second.find(_instance);
-            if (found_instance != found_service->second.end()) {
-                for (auto &its_eventgroup : found_instance->second) {
+            auto found_unique = found_service->second.find(_unique);
+            if (found_unique != found_service->second.end()) {
+                for (auto &its_eventgroup : found_unique->second) {
                     auto its_subscription = its_eventgroup.second;
                     its_subscription->set_ttl(0);
 
                     const reliability_type_e its_reliability =
-                            get_eventgroup_reliability(_service, _instance,
+                            get_eventgroup_reliability(_service, _unique,
                                 its_eventgroup.first, its_subscription);
 
-                    auto its_data = create_eventgroup_entry(_service, _instance,
+                    auto its_data = create_eventgroup_entry(_service, get_instance_from_unique(_unique),
                             its_eventgroup.first, its_subscription, its_reliability);
                     auto its_reliable = its_subscription->get_endpoint(true);
                     auto its_unreliable = its_subscription->get_endpoint(false);
@@ -545,7 +547,7 @@ service_discovery_impl::unsubscribe_all(
                         its_current_message->add_entry_data(its_data.entry_, its_data.options_);
                     }
                 }
-                found_instance->second.clear();
+                found_unique->second.clear();
             }
         }
     }
@@ -566,16 +568,16 @@ service_discovery_impl::unsubscribe_all_on_suspend() {
     {
         std::lock_guard<std::recursive_mutex> its_lock(subscribed_mutex_);
         for (auto its_service : subscribed_) {
-            for (auto its_instance : its_service.second) {
-                for (auto &its_eventgroup : its_instance.second) {
+            for (auto its_unique : its_service.second) {
+                for (auto &its_eventgroup : its_unique.second) {
                     boost::asio::ip::address its_address;
                     auto its_current_message = std::make_shared<message_impl>();
                     auto its_subscription = its_eventgroup.second;
                     its_subscription->set_ttl(0);
                     const reliability_type_e its_reliability =
-                          get_eventgroup_reliability(its_service.first, its_instance.first,
+                          get_eventgroup_reliability(its_service.first, its_unique.first,
                                   its_eventgroup.first, its_subscription);
-                    auto its_data = create_eventgroup_entry(its_service.first, its_instance.first,
+                    auto its_data = create_eventgroup_entry(its_service.first, get_instance_from_unique(its_unique.first),
                             its_eventgroup.first, its_subscription, its_reliability);
                     auto its_reliable = its_subscription->get_endpoint(true);
                     auto its_unreliable = its_subscription->get_endpoint(false);
@@ -588,12 +590,12 @@ service_discovery_impl::unsubscribe_all_on_suspend() {
                         VSOMEIP_WARNING << __func__ << ": Failed to create StopSubscribe entry for: "
                             << std::hex << std::setfill('0')
                             << std::setw(4) << its_service.first << "."
-                            << std::setw(4) << its_instance.first << "."
+                            << std::setw(4) << get_instance_from_unique(its_unique.first) << "."
                             << std::setw(4) << its_eventgroup.first
                             << " address: " << its_address.to_string();
                     }
                 }
-                its_instance.second.clear();
+                its_unique.second.clear();
             }
             its_service.second.clear();
         }
@@ -610,12 +612,12 @@ service_discovery_impl::unsubscribe_all_on_suspend() {
 
 void
 service_discovery_impl::remove_subscriptions(
-        service_t _service, instance_t _instance) {
+        service_t _service, unique_version_t _unique) {
 
     std::lock_guard<std::recursive_mutex> its_lock(subscribed_mutex_);
     auto found_service = subscribed_.find(_service);
     if (found_service != subscribed_.end()) {
-        found_service->second.erase(_instance);
+        found_service->second.erase(_unique);
         if (found_service->second.empty()) {
             subscribed_.erase(found_service);
         }
@@ -750,22 +752,22 @@ service_discovery_impl::insert_find_entries(
     its_data.entry_ = its_data.other_ = nullptr;
 
     for (const auto& its_service : _requests) {
-        for (const auto& its_instance : its_service.second) {
+        for (const auto& its_unique : its_service.second) {
             std::lock_guard<std::mutex> its_lock(requested_mutex_);
-            auto its_request = its_instance.second;
+            auto its_request = its_unique.second;
 
             // check if release_service was called / offer was received
             auto the_service = requested_.find(its_service.first);
             if ( the_service != requested_.end() ) {
-                auto the_instance = the_service->second.find(its_instance.first);
-                if(the_instance != the_service->second.end() ) {
+                auto the_unique = the_service->second.find(its_unique.first);
+                if(the_unique != the_service->second.end() ) {
                     uint8_t its_sent_counter = its_request->get_sent_counter();
                     if (its_sent_counter != repetitions_max_ + 1) {
                         auto its_entry = std::make_shared<serviceentry_impl>();
                         if (its_entry) {
                             its_entry->set_type(entry_type_e::FIND_SERVICE);
                             its_entry->set_service(its_service.first);
-                            its_entry->set_instance(its_instance.first);
+                            its_entry->set_instance(get_instance_from_unique(its_unique.first));
                             its_entry->set_major_version(its_request->get_major());
                             its_entry->set_minor_version(its_request->get_minor());
                             its_entry->set_ttl(its_request->get_ttl());
@@ -790,17 +792,17 @@ service_discovery_impl::insert_offer_entries(
         std::vector<std::shared_ptr<message_impl> > &_messages,
         const services_t &_services, bool _ignore_phase) {
     for (const auto& its_service : _services) {
-        for (const auto& its_instance : its_service.second) {
+        for (const auto& its_unique : its_service.second) {
             if ((!is_suspended_)
                     && ((!is_diagnosis_)
                     || (is_diagnosis_
                             && !configuration_->is_someip(its_service.first,
-                                    its_instance.first)))) {
+                                    its_unique.first)))) {
                 // Only insert services with configured endpoint(s)
-                if ((_ignore_phase || its_instance.second->is_in_mainphase())
-                        && (its_instance.second->get_endpoint(false)
-                                || its_instance.second->get_endpoint(true))) {
-                    insert_offer_service(_messages, its_instance.second);
+                if ((_ignore_phase || its_unique.second->is_in_mainphase())
+                        && (its_unique.second->get_endpoint(false)
+                                || its_unique.second->get_endpoint(true))) {
+                    insert_offer_service(_messages, its_unique.second);
                 }
             }
         }
@@ -1328,9 +1330,12 @@ void service_discovery_impl::check_sent_offers(const message_impl::entries_t& _e
         if ((*iter)->get_type() == entry_type_e::OFFER_SERVICE && (*iter)->get_ttl() > 0) {
             auto its_service = (*iter)->get_service();
             auto its_instance = (*iter)->get_instance();
+            auto its_major = (*iter)->get_major_version();
+
+            unique_version_t its_unique = get_unique_version(its_instance, its_major);
 
             std::shared_ptr<serviceinfo> its_info =
-                    host_->get_offered_service(its_service, its_instance);
+                    host_->get_offered_service(its_service, its_unique);
             if (its_info) {
                 if (_remote_address.is_unspecified()) {
                     // enable proccess remote subscription for the services
@@ -1360,6 +1365,8 @@ void service_discovery_impl::process_serviceentry(
     major_version_t its_major = _entry->get_major_version();
     minor_version_t its_minor = _entry->get_minor_version();
     ttl_t its_ttl = _entry->get_ttl();
+
+    unique_version_t its_unique = get_unique_version(its_instance, its_major);
 
     // Read address info from options
     boost::asio::ip::address its_reliable_address;
@@ -1429,11 +1436,11 @@ void service_discovery_impl::process_serviceentry(
     if (0 < its_ttl) {
         switch (its_type) {
         case entry_type_e::FIND_SERVICE:
-            process_findservice_serviceentry(its_service, its_instance, its_major, its_minor,
+            process_findservice_serviceentry(its_service, its_unique, its_major, its_minor,
                                              _unicast_flag);
             break;
         case entry_type_e::OFFER_SERVICE:
-            process_offerservice_serviceentry(its_service, its_instance, its_major, its_minor,
+            process_offerservice_serviceentry(its_service, its_unique, its_major, its_minor,
                                               its_ttl, its_reliable_address, its_reliable_port,
                                               its_unreliable_address, its_unreliable_port,
                                               _resubscribes, _received_via_multicast, _sd_ac_state);
@@ -1445,14 +1452,14 @@ void service_discovery_impl::process_serviceentry(
     } else if (its_type != entry_type_e::FIND_SERVICE
                && (_sd_ac_state.sd_acceptance_required_ || _sd_ac_state.accept_entries_)) {
         // stop sending find service in repetition phase
-        update_request(its_service, its_instance);
+        update_request(its_service, its_unique);
 
-        remove_remote_offer_type(its_service, its_instance,
+        remove_remote_offer_type(its_service, its_unique,
                                  its_reliable_address, its_reliable_port,
                                  its_unreliable_address, its_unreliable_port);
-        remove_subscriptions(its_service, its_instance);
+        remove_subscriptions(its_service, its_unique);
         if (!is_diagnosis_ && !is_suspended_) {
-            host_->del_routing_info(its_service, its_instance,
+            host_->del_routing_info(its_service, its_unique,
                                     (its_reliable_port != ILLEGAL_PORT),
                                     (its_unreliable_port != ILLEGAL_PORT));
         }
@@ -1460,7 +1467,7 @@ void service_discovery_impl::process_serviceentry(
 }
 
 void service_discovery_impl::process_offerservice_serviceentry(
-        service_t _service, instance_t _instance, major_version_t _major, minor_version_t _minor,
+        service_t _service, unique_version_t _unique, major_version_t _major, minor_version_t _minor,
         ttl_t _ttl, const boost::asio::ip::address& _reliable_address, uint16_t _reliable_port,
         const boost::asio::ip::address& _unreliable_address, uint16_t _unreliable_port,
         std::vector<std::shared_ptr<message_impl>>& _resubscribes, bool _received_via_multicast,
@@ -1469,7 +1476,7 @@ void service_discovery_impl::process_offerservice_serviceentry(
     if (!its_runtime)
         return;
 
-    bool is_secure = configuration_->is_secure_service(_service, _instance);
+    bool is_secure = configuration_->is_secure_service(_service, _unique);
     if (is_secure &&
             ((_reliable_port != ILLEGAL_PORT &&
                     !configuration_->is_secure_port(_reliable_address, _reliable_port, true))
@@ -1478,13 +1485,13 @@ void service_discovery_impl::process_offerservice_serviceentry(
 
         VSOMEIP_WARNING << __func__ << ": Ignoring offer of ["
                 << std::hex << std::setfill('0')
-                << std::setw(4) << _service << "." << std::setw(4) << _instance
+                << std::setw(4) << _service << "." << std::setw(4) << get_instance_from_unique(_unique)
                 << "]";
         return;
     }
 
     // stop sending find service in repetition phase
-    update_request(_service, _instance);
+    update_request(_service, _unique);
 
     const reliability_type_e offer_type = configuration_->get_reliability_type(
         _reliable_address, _reliable_port, _unreliable_address,_unreliable_port);
@@ -1493,7 +1500,7 @@ void service_discovery_impl::process_offerservice_serviceentry(
         VSOMEIP_WARNING << __func__ << ": Unknown remote offer type ["
                 << std::hex << std::setfill('0')
                 << std::setw(4) << _service << "."
-                << std::setw(4) << _instance << "]";
+                << std::setw(4) << get_instance_from_unique(_unique) << "]";
         return; // Unknown remote offer type --> no way to access it!
     }
 
@@ -1556,17 +1563,17 @@ void service_discovery_impl::process_offerservice_serviceentry(
         }
     }
 
-    if (update_remote_offer_type(_service, _instance, offer_type, _reliable_address, _reliable_port,
+    if (update_remote_offer_type(_service, _unique, offer_type, _reliable_address, _reliable_port,
                                  _unreliable_address, _unreliable_port, _received_via_multicast)) {
         VSOMEIP_WARNING << __func__ << ": Remote offer type changed [" 
                         << std::hex << std::setfill('0')
                         << std::setw(4) << _service << "."
-                        << std::setw(4) << _instance << "]";
+                        << std::setw(4) << get_instance_from_unique(_unique) << "]";
         // Only update eventgroup reliability type if it was initially unknown
-        auto its_eventgroups = host_->get_subscribed_eventgroups(_service, _instance);
+        auto its_eventgroups = host_->get_subscribed_eventgroups(_service, _unique);
         for (auto eg : its_eventgroups) {
             auto its_info = host_->find_eventgroup(
-                    _service, _instance, eg);
+                    _service, _unique, eg);
             if (its_info) {
                 if (its_info->is_reliability_auto_mode()) {
                     if (offer_type != reliability_type_e::RT_UNKNOWN
@@ -1574,7 +1581,7 @@ void service_discovery_impl::process_offerservice_serviceentry(
                         VSOMEIP_WARNING << "sd::" << __func__ << ": eventgroup reliability type changed ["
                                     << std::hex << std::setfill('0')
                                     << std::setw(4) << _service << "."
-                                    << std::setw(4) << _instance << "."
+                                    << std::setw(4) << get_instance_from_unique(_unique) << "."
                                     << std::setw(4) << eg << "]"
                                     << " using reliability type:  "
                                     << std::setw(4) << static_cast<uint16_t>(offer_type);
@@ -1586,20 +1593,20 @@ void service_discovery_impl::process_offerservice_serviceentry(
     }
 
     const bool was_previously_offered_by_unicast = set_offer_multicast_state(
-            _service, _instance, offer_type, _reliable_address, _reliable_port, _unreliable_address,
+            _service, _unique, offer_type, _reliable_address, _reliable_port, _unreliable_address,
             _unreliable_port, _received_via_multicast);
 
     // No need to resubscribe for unicast offers
     if (_received_via_multicast) {
         auto found_service = subscribed_.find(_service);
         if (found_service != subscribed_.end()) {
-            auto found_instance = found_service->second.find(_instance);
-            if (found_instance != found_service->second.end()) {
-                if (0 < found_instance->second.size()) {
-                    for (const auto& its_eventgroup : found_instance->second) {
+            auto found_unique = found_service->second.find(_unique);
+            if (found_unique != found_service->second.end()) {
+                if (0 < found_unique->second.size()) {
+                    for (const auto& its_eventgroup : found_unique->second) {
                         auto its_subscription = its_eventgroup.second;
                         std::shared_ptr<endpoint> its_reliable, its_unreliable;
-                        get_subscription_endpoints(_service, _instance, its_reliable,
+                        get_subscription_endpoints(_service, _unique, its_reliable,
                                                    its_unreliable);
                         its_subscription->set_endpoint(its_reliable, true);
                         its_subscription->set_endpoint(its_unreliable, false);
@@ -1620,10 +1627,10 @@ void service_discovery_impl::process_offerservice_serviceentry(
                             }
                         }
                         const reliability_type_e its_reliability = get_eventgroup_reliability(
-                                _service, _instance, its_eventgroup.first, its_subscription);
+                                _service, _unique, its_eventgroup.first, its_subscription);
 
                         auto its_data =
-                                create_eventgroup_entry(_service, _instance, its_eventgroup.first,
+                                create_eventgroup_entry(_service, get_instance_from_unique(_unique), its_eventgroup.first,
                                                         its_subscription, its_reliability);
                         if (its_data.entry_) {
                             add_entry_data(_resubscribes, its_data);
@@ -1638,21 +1645,21 @@ void service_discovery_impl::process_offerservice_serviceentry(
         }
     }
 
-    host_->add_routing_info(_service, _instance, _major, _minor,
-                            _ttl * get_ttl_factor(_service, _instance, ttl_factor_offers_),
+    host_->add_routing_info(_service, get_instance_from_unique(_unique), _major, _minor,
+                            _ttl * get_ttl_factor(_service, _unique, ttl_factor_offers_),
                             _reliable_address, _reliable_port, _unreliable_address,
                             _unreliable_port);
 }
 
 void
 service_discovery_impl::process_findservice_serviceentry(
-        service_t _service, instance_t _instance,
+        service_t _service, unique_version_t _unique,
         major_version_t _major, minor_version_t _minor,
         bool _unicast_flag) {
 
-    if (_instance != ANY_INSTANCE) {
+    if (get_instance_from_unique(_unique) != ANY_INSTANCE) {
         std::shared_ptr<serviceinfo> its_info = host_->get_offered_service(
-                _service, _instance);
+                _service, _unique);
         if (its_info) {
             if (_major == ANY_MAJOR || _major == its_info->get_major()) {
                 if (_minor == 0xFFFFFFFF || _minor <= its_info->get_minor()) {
@@ -1663,11 +1670,11 @@ service_discovery_impl::process_findservice_serviceentry(
             }
         }
     } else {
-        std::map<instance_t, std::shared_ptr<serviceinfo>> offered_instances =
+        std::map<unique_version_t, std::shared_ptr<serviceinfo>> offered_instances =
                 host_->get_offered_service_instances(_service);
         // send back all available instances
-        for (const auto &found_instance : offered_instances) {
-            auto its_info = found_instance.second;
+        for (const auto &found_unique : offered_instances) {
+            auto its_info = found_unique.second;
             if (_major == ANY_MAJOR || _major == its_info->get_major()) {
                 if (_minor == 0xFFFFFFFF || _minor <= its_info->get_minor()) {
                     if (its_info->get_endpoint(false) || its_info->get_endpoint(true)) {
@@ -1710,7 +1717,7 @@ service_discovery_impl::send_multicast_offer_service(
 
 void
 service_discovery_impl::on_endpoint_connected(
-        service_t _service, instance_t _instance,
+        service_t _service, unique_version_t _unique,
         const std::shared_ptr<endpoint> &_endpoint) {
     std::shared_ptr<runtime> its_runtime = runtime_.lock();
     if (!its_runtime) {
@@ -1735,10 +1742,10 @@ service_discovery_impl::on_endpoint_connected(
         std::lock_guard<std::recursive_mutex> its_lock(subscribed_mutex_);
         auto found_service = subscribed_.find(_service);
         if (found_service != subscribed_.end()) {
-            auto found_instance = found_service->second.find(_instance);
-            if (found_instance != found_service->second.end()) {
-                if (0 < found_instance->second.size()) {
-                    for (const auto &its_eventgroup : found_instance->second) {
+            auto found_unique = found_service->second.find(_unique);
+            if (found_unique != found_service->second.end()) {
+                if (0 < found_unique->second.size()) {
+                    for (const auto &its_eventgroup : found_unique->second) {
                         std::shared_ptr<subscription> its_subscription(its_eventgroup.second);
                         if (its_subscription) {
                             if (!its_subscription->is_tcp_connection_established() ||
@@ -1770,7 +1777,7 @@ service_discovery_impl::on_endpoint_connected(
 
                                     std::shared_ptr<endpoint> its_unreliable;
                                     std::shared_ptr<endpoint> its_reliable;
-                                    get_subscription_endpoints(_service, _instance,
+                                    get_subscription_endpoints(_service, _unique,
                                             its_reliable, its_unreliable);
                                     get_subscription_address(its_reliable, its_unreliable, its_address);
 
@@ -1781,8 +1788,8 @@ service_discovery_impl::on_endpoint_connected(
                                                 subscription_state_e::ST_NOT_ACKNOWLEDGED);
 
                                     const reliability_type_e its_reliability_type =
-                                            get_eventgroup_reliability(_service, _instance, its_eventgroup.first, its_subscription);
-                                    auto its_data = create_eventgroup_entry(_service, _instance,
+                                            get_eventgroup_reliability(_service, _unique, its_eventgroup.first, its_subscription);
+                                    auto its_data = create_eventgroup_entry(_service, get_instance_from_unique(_unique),
                                             its_eventgroup.first, its_subscription, its_reliability_type);
 
                                     if (its_data.entry_) {
@@ -1879,8 +1886,11 @@ service_discovery_impl::process_eventgroupentry(
     major_version_t its_major = _entry->get_major_version();
     ttl_t its_ttl = _entry->get_ttl();
 
+    unique_version_t its_unique = get_unique_version(its_instance, its_major);
+
+
     auto its_info = host_->find_eventgroup(
-            its_service, its_instance, its_eventgroup);
+            its_service, its_unique, its_eventgroup);
     if (!its_info) {
         if (entry_type_e::SUBSCRIBE_EVENTGROUP == its_type) {
             // We received a subscription for a non-existing eventgroup.
@@ -1902,7 +1912,7 @@ service_discovery_impl::process_eventgroupentry(
         } else {
             // We received a subscription [n]ack for an eventgroup that does not exist.
             // --> Remove subscription.
-            unsubscribe(its_service, its_instance, its_eventgroup, VSOMEIP_ROUTING_CLIENT);
+            unsubscribe(its_service, its_unique, its_eventgroup, VSOMEIP_ROUTING_CLIENT);
 
             boost::system::error_code ec;
             VSOMEIP_WARNING << __func__
@@ -2295,19 +2305,19 @@ service_discovery_impl::process_eventgroupentry(
 
     if (entry_type_e::SUBSCRIBE_EVENTGROUP == its_type) {
         handle_eventgroup_subscription(
-                its_service, its_instance, its_eventgroup, its_major, its_ttl, 0, 0,
+                its_service, its_unique, its_eventgroup, its_major, its_ttl, 0, 0,
                 its_first_address, its_first_port, is_first_reliable, its_second_address,
                 its_second_port, is_second_reliable, _acknowledgement, _is_stop_subscribe_subscribe,
                 _force_initial_events, its_clients, _sd_ac_state, its_info, _sender);
     } else {
         if (entry_type_e::SUBSCRIBE_EVENTGROUP_ACK == its_type) { //this type is used for ACK and NACK messages
             if (its_ttl > 0) {
-                handle_eventgroup_subscription_ack(its_service, its_instance,
+                handle_eventgroup_subscription_ack(its_service, its_unique,
                         its_eventgroup, its_major, its_ttl, 0,
                         its_clients, _sender,
                         its_first_address, its_first_port);
             } else {
-                handle_eventgroup_subscription_nack(its_service, its_instance, its_eventgroup,
+                handle_eventgroup_subscription_nack(its_service, its_unique, its_eventgroup,
                         0, its_clients);
             }
         }
@@ -2315,7 +2325,7 @@ service_discovery_impl::process_eventgroupentry(
 }
 
 void service_discovery_impl::handle_eventgroup_subscription(
-        service_t _service, instance_t _instance, eventgroup_t _eventgroup, major_version_t _major,
+        service_t _service, unique_version_t _unique, eventgroup_t _eventgroup, major_version_t _major,
         ttl_t _ttl, uint8_t _counter, uint16_t _reserved,
         const boost::asio::ip::address& _first_address, uint16_t _first_port,
         bool _is_first_reliable, const boost::asio::ip::address& _second_address,
@@ -2367,7 +2377,7 @@ void service_discovery_impl::handle_eventgroup_subscription(
                 << ": Subscription for ["
                 << std::hex << std::setfill('0')
                 << std::setw(4) << _service << "."
-                << std::setw(4) << _instance << "."
+                << std::setw(4) << get_instance_from_unique(_unique) << "."
                 << std::setw(4) << _eventgroup << "]"
                 << " not valid: Event configuration ("
                 << static_cast<std::uint32_t>(_info->get_reliability())
@@ -2381,7 +2391,7 @@ void service_discovery_impl::handle_eventgroup_subscription(
 #endif
 
     if (_ttl > 0) {
-        std::shared_ptr<serviceinfo> its_info = host_->get_offered_service(_service, _instance);
+        std::shared_ptr<serviceinfo> its_info = host_->get_offered_service(_service, _unique);
         bool send_nack = false;
         if (!its_info) {
             send_nack = true;
@@ -2406,7 +2416,7 @@ void service_discovery_impl::handle_eventgroup_subscription(
     // wrong major version
     if (_major != _info->get_major()) {
         // Create a temporary info object with TTL=0 --> send NACK
-        auto its_info = std::make_shared<eventgroupinfo>(_service, _instance,
+        auto its_info = std::make_shared<eventgroupinfo>(_service, get_instance_from_unique(_unique),
                 _eventgroup, _major, 0, VSOMEIP_DEFAULT_MAX_REMOTE_SUBSCRIBERS);
         boost::system::error_code ec;
         // TODO: Add session id
@@ -2415,7 +2425,7 @@ void service_discovery_impl::handle_eventgroup_subscription(
                 << "] in subscription to service: ["
                 << std::hex << std::setfill('0')
                 << std::setw(4) << _service << "."
-                << std::setw(4) << _instance << "."
+                << std::setw(4) << get_instance_from_unique(_unique) << "."
                 << std::setw(4) << _eventgroup << "]"
                 << " does not match with services major version:["
                 << static_cast<uint32_t>(_info->get_major()) << "] subscriber: "
@@ -2429,16 +2439,16 @@ void service_discovery_impl::handle_eventgroup_subscription(
         if (ILLEGAL_PORT != _first_port) {
             uint16_t its_first_port(0);
             its_subscriber = endpoint_definition::get(
-                    _first_address, _first_port, _is_first_reliable, _service, _instance);
+                    _first_address, _first_port, _is_first_reliable, _service, _unique);
             if (!_is_first_reliable &&
                 _info->get_multicast(its_first_address, its_first_port) &&
                 _info->is_sending_multicast()) { // udp multicast
                 its_unreliable = endpoint_definition::get(
-                    its_first_address, its_first_port, false, _service, _instance);
+                    its_first_address, its_first_port, false, _service, _unique);
             } else if (_is_first_reliable) { // tcp unicast
                 its_reliable = its_subscriber;
                 // check if TCP connection is established by client
-                if (_ttl > 0 && !is_tcp_connected(_service, _instance, its_reliable)) {
+                if (_ttl > 0 && !is_tcp_connected(_service, _unique, its_reliable)) {
                     insert_subscription_ack(_acknowledgement, _info, 0, nullptr, _clients);
                     // TODO: Add sender and session id
                     VSOMEIP_ERROR << "TCP connection to target1: ["
@@ -2447,7 +2457,7 @@ void service_discovery_impl::handle_eventgroup_subscription(
                             << "] not established for subscription to: ["
                             << std::hex << std::setfill('0')
                             << std::setw(4) << _service << "."
-                            << std::setw(4) << _instance << "."
+                            << std::setw(4) << get_instance_from_unique(_unique) << "."
                             << std::setw(4) << _eventgroup << "] ";
                     return;
                 }
@@ -2459,16 +2469,16 @@ void service_discovery_impl::handle_eventgroup_subscription(
         if (ILLEGAL_PORT != _second_port) {
             uint16_t its_second_port(0);
             its_subscriber = endpoint_definition::get(
-                    _second_address, _second_port, _is_second_reliable, _service, _instance);
+                    _second_address, _second_port, _is_second_reliable, _service, _unique);
             if (!_is_second_reliable &&
                 _info->get_multicast(its_second_address, its_second_port) &&
                 _info->is_sending_multicast()) { // udp multicast
                 its_unreliable = endpoint_definition::get(
-                    its_second_address, its_second_port, false, _service, _instance);
+                    its_second_address, its_second_port, false, _service, _unique);
             } else if (_is_second_reliable) { // tcp unicast
                 its_reliable = its_subscriber;
                 // check if TCP connection is established by client
-                if (_ttl > 0 && !is_tcp_connected(_service, _instance, its_reliable)) {
+                if (_ttl > 0 && !is_tcp_connected(_service, _unique, its_reliable)) {
                     insert_subscription_ack(_acknowledgement, _info, 0, nullptr, _clients);
                     // TODO: Add sender and session id
                     VSOMEIP_ERROR << "TCP connection to target2 : ["
@@ -2477,7 +2487,7 @@ void service_discovery_impl::handle_eventgroup_subscription(
                             << "] not established for subscription to: ["
                             << std::hex << std::setfill('0')
                             << std::setw(4) << _service << "."
-                            << std::setw(4) << _instance << "."
+                            << std::setw(4) << get_instance_from_unique(_unique) << "."
                             << std::setw(4) << _eventgroup << "] ";
                     return;
                 }
@@ -2533,7 +2543,7 @@ void service_discovery_impl::handle_eventgroup_subscription(
             its_subscription->set_force_initial_events(true);
         }
         its_subscription->set_ttl(_ttl
-                * get_ttl_factor(_service, _instance, ttl_factor_subscriptions_));
+                * get_ttl_factor(_service, _unique, ttl_factor_subscriptions_));
 
         {
             std::lock_guard<std::mutex> its_lock(pending_remote_subscriptions_mutex_);
@@ -2549,21 +2559,21 @@ void service_discovery_impl::handle_eventgroup_subscription(
 
 void
 service_discovery_impl::handle_eventgroup_subscription_nack(
-        service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+        service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
         uint8_t _counter, const std::set<client_t> &_clients) {
     (void)_counter;
 
     std::lock_guard<std::recursive_mutex> its_lock(subscribed_mutex_);
     auto found_service = subscribed_.find(_service);
     if (found_service != subscribed_.end()) {
-        auto found_instance = found_service->second.find(_instance);
-        if (found_instance != found_service->second.end()) {
-            auto found_eventgroup = found_instance->second.find(_eventgroup);
-            if (found_eventgroup != found_instance->second.end()) {
+        auto found_unique = found_service->second.find(_unique);
+        if (found_unique != found_service->second.end()) {
+            auto found_eventgroup = found_unique->second.find(_eventgroup);
+            if (found_eventgroup != found_unique->second.end()) {
                 auto its_subscription = found_eventgroup->second;
                 for (const auto its_client : _clients) {
                     host_->on_subscribe_nack(its_client,
-                            _service, _instance, _eventgroup, ANY_EVENT,
+                            _service, _unique, _eventgroup, ANY_EVENT,
                             PENDING_SUBSCRIPTION_ID); // TODO: This is a dummy call...
                 }
 
@@ -2580,7 +2590,7 @@ service_discovery_impl::handle_eventgroup_subscription_nack(
 
 void
 service_discovery_impl::handle_eventgroup_subscription_ack(
-        service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+        service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
         major_version_t _major, ttl_t _ttl, uint8_t _counter,
         const std::set<client_t> &_clients,
         const boost::asio::ip::address &_sender,
@@ -2592,23 +2602,23 @@ service_discovery_impl::handle_eventgroup_subscription_ack(
     std::lock_guard<std::recursive_mutex> its_lock(subscribed_mutex_);
     auto found_service = subscribed_.find(_service);
     if (found_service != subscribed_.end()) {
-        auto found_instance = found_service->second.find(_instance);
-        if (found_instance != found_service->second.end()) {
-            auto found_eventgroup = found_instance->second.find(_eventgroup);
-            if (found_eventgroup != found_instance->second.end()) {
+        auto found_unique = found_service->second.find(_unique);
+        if (found_unique != found_service->second.end()) {
+            auto found_eventgroup = found_unique->second.find(_eventgroup);
+            if (found_eventgroup != found_unique->second.end()) {
                 for (const auto its_client : _clients) {
                     if (found_eventgroup->second->get_state(its_client)
                             == subscription_state_e::ST_NOT_ACKNOWLEDGED) {
                         found_eventgroup->second->set_state(its_client,
                             subscription_state_e::ST_ACKNOWLEDGED);
                         host_->on_subscribe_ack(its_client,
-                                _service, _instance, _eventgroup,
+                                _service, _unique, _eventgroup,
                                 ANY_EVENT, PENDING_SUBSCRIPTION_ID);
                     }
                 }
                 if (_address.is_multicast()) {
                     host_->on_subscribe_ack_with_multicast(
-                            _service, _instance, _sender, _address, _port);
+                            _service, _unique, _sender, _address, _port);
                 }
             }
         }
@@ -2616,11 +2626,11 @@ service_discovery_impl::handle_eventgroup_subscription_ack(
 }
 
 bool service_discovery_impl::is_tcp_connected(service_t _service,
-         instance_t _instance,
+         unique_version_t _unique,
          const std::shared_ptr<endpoint_definition>& its_endpoint) {
     bool is_connected = false;
     std::shared_ptr<serviceinfo> its_info = host_->get_offered_service(_service,
-            _instance);
+            _unique);
     if (its_info) {
         //get reliable server endpoint
         auto its_reliable_server_endpoint = std::dynamic_pointer_cast<
@@ -2668,11 +2678,12 @@ service_discovery_impl::serialize_and_send(
                 m->set_reboot_flag(its_session.second);
 
                 if (serializer_->serialize(m.get())) {
+
                     if (host_->send_via_sd(endpoint_definition::get(_address, port_,
                             reliable_, m->get_service(), m->get_instance()),
                             serializer_->get_data(), serializer_->get_size(),
                             port_)) {
-                        increment_session(_address);
+                        increment_session(_address); // TODO: Kareem should find a solution for this
                     }
                 } else {
                     VSOMEIP_ERROR << "service_discovery_impl::" << __func__
@@ -2839,19 +2850,22 @@ void
 service_discovery_impl::offer_service(const std::shared_ptr<serviceinfo> &_info) {
     service_t its_service = _info->get_service();
     service_t its_instance = _info->get_instance();
+    major_version_t its_major = _info->get_major();
+
+    unique_version_t its_unique = get_unique_version(its_instance, its_major);
 
     std::lock_guard<std::mutex> its_lock(collected_offers_mutex_);
     // check if offer is in map
     bool found(false);
     const auto its_service_it = collected_offers_.find(its_service);
     if (its_service_it != collected_offers_.end()) {
-        const auto its_instance_it = its_service_it->second.find(its_instance);
-        if (its_instance_it != its_service_it->second.end()) {
+        const auto its_unique_it = its_service_it->second.find(its_unique);
+        if (its_unique_it != its_service_it->second.end()) {
             found = true;
         }
     }
     if (!found) {
-        collected_offers_[its_service][its_instance] = _info;
+        collected_offers_[its_service][its_unique] = _info;
     }
 }
 
@@ -2906,9 +2920,9 @@ service_discovery_impl::on_find_debounce_timer_expired(
     {
         std::lock_guard<std::mutex> its_lock(requested_mutex_);
         for (const auto& its_service : requested_) {
-            for (const auto& its_instance : its_service.second) {
-                if( its_instance.second->get_sent_counter() == 0) {
-                    repetition_phase_finds[its_service.first][its_instance.first] = its_instance.second;
+            for (const auto& its_unique : its_service.second) {
+                if( its_unique.second->get_sent_counter() == 0) {
+                    repetition_phase_finds[its_service.first][its_unique.first] = its_unique.second;
                 }
             }
         }
@@ -2970,9 +2984,9 @@ service_discovery_impl::on_offer_debounce_timer_expired(
             if (is_diagnosis_) {
                 for (services_t::iterator its_service = collected_offers_.begin();
                         its_service != collected_offers_.end(); its_service++) {
-                    for (const auto& its_instance : its_service->second) {
+                    for (const auto& its_unique : its_service->second) {
                         if (!configuration_->is_someip(
-                                its_service->first, its_instance.first)) {
+                                its_service->first, its_unique.first)) {
                             non_someip_services.push_back(its_service);
                         }
                     }
@@ -3157,8 +3171,8 @@ service_discovery_impl::move_offers_into_main_phase(
     const auto its_timer = repetition_phase_timers_.find(_timer);
     if (its_timer != repetition_phase_timers_.end()) {
         for (const auto& its_service : its_timer->second) {
-            for (const auto& its_instance : its_service.second) {
-                its_instance.second->set_is_in_mainphase(true);
+            for (const auto& its_unique : its_service.second) {
+                its_unique.second->set_is_in_mainphase(true);
             }
         }
         repetition_phase_timers_.erase(_timer);
@@ -3174,6 +3188,10 @@ service_discovery_impl::stop_offer_service(
     _info->set_accepting_remote_subscriptions(false);
     const service_t its_service = _info->get_service();
     const instance_t its_instance = _info->get_instance();
+    const major_version_t its_major = _info->get_major();
+
+    unique_version_t its_unique = get_unique_version(its_instance, its_major);
+
     bool stop_offer_required(false);
     // Delete from initial phase offers
     {
@@ -3181,10 +3199,10 @@ service_discovery_impl::stop_offer_service(
         if (collected_offers_.size()) {
             auto its_service_it = collected_offers_.find(its_service);
             if (its_service_it != collected_offers_.end()) {
-                auto its_instance_it = its_service_it->second.find(its_instance);
-                if (its_instance_it != its_service_it->second.end()) {
-                    if (its_instance_it->second == _info) {
-                        its_service_it->second.erase(its_instance_it);
+                auto its_unique_it = its_service_it->second.find(its_unique);
+                if (its_unique_it != its_service_it->second.end()) {
+                    if (its_unique_it->second == _info) {
+                        its_service_it->second.erase(its_unique_it);
 
                         if (!collected_offers_[its_service].size()) {
                             collected_offers_.erase(its_service_it);
@@ -3204,10 +3222,10 @@ service_discovery_impl::stop_offer_service(
                 rpt != repetition_phase_timers_.end();) {
             auto its_service_it = rpt->second.find(its_service);
             if (its_service_it != rpt->second.end()) {
-                auto its_instance_it = its_service_it->second.find(its_instance);
-                if (its_instance_it != its_service_it->second.end()) {
-                    if (its_instance_it->second == _info) {
-                        its_service_it->second.erase(its_instance_it);
+                auto its_unique_it = its_service_it->second.find(its_unique);
+                if (its_unique_it != its_service_it->second.end()) {
+                    if (its_unique_it->second == _info) {
+                        its_service_it->second.erase(its_unique_it);
                         stop_offer_required = true;
                         if (!rpt->second[its_service].size()) {
                             rpt->second.erase(its_service);
@@ -3408,7 +3426,7 @@ service_discovery_impl::update_subscription_expiration_timer(
                 const std::chrono::steady_clock::time_point its_expiration = now
                         + std::chrono::seconds(e->get_ttl()
                                 * get_ttl_factor(
-                                        e->get_service(), e->get_instance(),
+                                        e->get_service(), get_unique_version(e->get_instance(), e->get_major_version()),
                                         ttl_factor_subscriptions_));
                 if (its_expiration < next_subscription_expiration_) {
                     next_subscription_expiration_ = its_expiration;
@@ -3477,8 +3495,12 @@ service_discovery_impl::is_subscribed(
         const message_impl::options_t &_options) const {
     const auto its_service = _entry->get_service();
     const auto its_instance = _entry->get_instance();
+    const auto its_major = _entry->get_major_version();
+
+    unique_version_t its_unique = get_unique_version(its_instance, its_major);
+
     auto its_info = host_->find_eventgroup(
-            its_service, its_instance, _entry->get_eventgroup());
+            its_service, its_unique, _entry->get_eventgroup());
     if (its_info) {
         std::shared_ptr<endpoint_definition> its_reliable, its_unreliable;
         for (const auto& o : _options) {
@@ -3493,7 +3515,7 @@ service_discovery_impl::is_subscribed(
                                         its_endpoint_option->get_address()),
                                 its_endpoint_option->get_port(),
                                 true,
-                                its_service, its_instance);
+                                its_service, its_unique);
                     } else if (its_endpoint_option->get_layer_four_protocol()
                             == layer_four_protocol_e::UDP) {
                         its_unreliable = endpoint_definition::get(
@@ -3501,7 +3523,7 @@ service_discovery_impl::is_subscribed(
                                         its_endpoint_option->get_address()),
                                 its_endpoint_option->get_port(),
                                 false,
-                                its_service, its_instance);
+                                its_service, its_unique);
                     }
                 }
             } else if (o->get_type() == option_type_e::IP6_ENDPOINT) {
@@ -3514,7 +3536,7 @@ service_discovery_impl::is_subscribed(
                                     its_endpoint_option->get_address()),
                             its_endpoint_option->get_port(),
                             true,
-                            its_service, its_instance);
+                            its_service, its_unique);
                 } else if (its_endpoint_option->get_layer_four_protocol()
                         == layer_four_protocol_e::UDP) {
                     its_unreliable = endpoint_definition::get(
@@ -3522,7 +3544,7 @@ service_discovery_impl::is_subscribed(
                                     its_endpoint_option->get_address()),
                             its_endpoint_option->get_port(),
                             false,
-                            its_service, its_instance);
+                            its_service, its_unique);
                 }
             }
         }
@@ -3540,14 +3562,14 @@ service_discovery_impl::is_subscribed(
 
 configuration::ttl_factor_t
 service_discovery_impl::get_ttl_factor(
-        service_t _service, instance_t _instance,
+        service_t _service, unique_version_t _unique,
         const configuration::ttl_map_t& _ttl_map) const {
     configuration::ttl_factor_t its_ttl_factor(1);
     auto found_service = _ttl_map.find(_service);
     if (found_service != _ttl_map.end()) {
-        auto found_instance = found_service->second.find(_instance);
-        if (found_instance != found_service->second.end()) {
-            its_ttl_factor = found_instance->second;
+        auto found_unique = found_service->second.find(_unique);
+        if (found_unique != found_service->second.end()) {
+            its_ttl_factor = found_unique->second;
         }
     }
     return its_ttl_factor;
@@ -3592,9 +3614,9 @@ service_discovery_impl::stop_last_msg_received_timer() {
 
 reliability_type_e
 service_discovery_impl::get_remote_offer_type(
-        service_t _service, instance_t _instance) const {
+        service_t _service, unique_version_t _unique) const {
     std::lock_guard<std::mutex> its_lock(remote_offer_types_mutex_);
-    auto found_si = remote_offer_types_.find(std::make_pair(_service, _instance));
+    auto found_si = remote_offer_types_.find(std::make_pair(_service, _unique));
     if (found_si != remote_offer_types_.end()) {
         return found_si->second;
     }
@@ -3618,13 +3640,13 @@ service_discovery_impl::get_remote_offer_type(
 
 
 bool service_discovery_impl::update_remote_offer_type(
-        service_t _service, instance_t _instance, reliability_type_e _offer_type,
+        service_t _service, unique_version_t _unique, reliability_type_e _offer_type,
         const boost::asio::ip::address& _reliable_address, std::uint16_t _reliable_port,
         const boost::asio::ip::address& _unreliable_address, std::uint16_t _unreliable_port,
         bool _received_via_multicast) {
     bool ret(false);
     std::lock_guard<std::mutex> its_lock(remote_offer_types_mutex_);
-    const remote_offer_info_t its_service_instance(_service, _instance, _received_via_multicast);
+    const remote_offer_info_t its_service_instance(_service, _unique, _received_via_multicast);
     auto found_si = remote_offer_types_.find(its_service_instance.service_info);
     if (found_si != remote_offer_types_.end()) {
         if (found_si->second != _offer_type ) {
@@ -3654,7 +3676,7 @@ bool service_discovery_impl::update_remote_offer_type(
         VSOMEIP_WARNING << __func__ << ": unknown offer type ["
                         << std::hex << std::setfill('0')
                         << std::setw(4) << _service << "."
-                        << std::setw(4) << _instance << "]"
+                        << std::setw(4) << get_instance_from_unique(_unique) << "]"
                         << static_cast<int>(_offer_type);
         break;
     }
@@ -3663,13 +3685,13 @@ bool service_discovery_impl::update_remote_offer_type(
 
 void
 service_discovery_impl::remove_remote_offer_type(
-        service_t _service, instance_t _instance,
+        service_t _service, unique_version_t _unique,
         const boost::asio::ip::address &_reliable_address,
         std::uint16_t _reliable_port,
         const boost::asio::ip::address &_unreliable_address,
         std::uint16_t _unreliable_port) {
     std::lock_guard<std::mutex> its_lock(remote_offer_types_mutex_);
-    const remote_offer_info_t its_service_instance(_service, _instance);
+    const remote_offer_info_t its_service_instance(_service, _unique);
 
     remote_offer_types_.erase(its_service_instance.service_info);
 
@@ -3734,7 +3756,7 @@ void service_discovery_impl::remove_remote_offer_type_by_ip(
 }
 
 bool service_discovery_impl::set_offer_multicast_state(
-        service_t _service, instance_t _instance, reliability_type_e _offer_type,
+        service_t _service, unique_version_t _unique, reliability_type_e _offer_type,
         const boost::asio::ip::address& _reliable_address, port_t _reliable_port,
         const boost::asio::ip::address& _unreliable_address, std::uint16_t _unreliable_port,
         bool _received_via_multicast) {
@@ -3743,12 +3765,12 @@ bool service_discovery_impl::set_offer_multicast_state(
 
     auto check_offer_info = [this, &was_unicast, _received_via_multicast](
                                     const boost::asio::ip::address& address, bool reliable,
-                                    port_t port, service_t service_id, instance_t instance_id) {
+                                    port_t port, service_t service_id, unique_version_t unique_id) {
         auto found_address = remote_offers_by_ip_.find(address);
         if (found_address != remote_offers_by_ip_.end()) {
             auto found_port = found_address->second.find(std::make_pair(reliable, port));
             if (found_port != found_address->second.end()) {
-                auto found_offer_info = found_port->second.find({service_id, instance_id});
+                auto found_offer_info = found_port->second.find({service_id, unique_id});
                 if (found_offer_info != found_port->second.end()) {
                     if (!found_offer_info->offer_received_via_multicast) {
                         was_unicast = true;
@@ -3761,21 +3783,21 @@ bool service_discovery_impl::set_offer_multicast_state(
 
     switch (_offer_type) {
     case reliability_type_e::RT_UNRELIABLE:
-        check_offer_info(_unreliable_address, false, _unreliable_port, _service, _instance);
+        check_offer_info(_unreliable_address, false, _unreliable_port, _service, _unique);
         break;
     case reliability_type_e::RT_RELIABLE:
-        check_offer_info(_reliable_address, true, _reliable_port, _service, _instance);
+        check_offer_info(_reliable_address, true, _reliable_port, _service, _unique);
         break;
     case reliability_type_e::RT_BOTH:
-        check_offer_info(_unreliable_address, false, _unreliable_port, _service, _instance);
-        check_offer_info(_reliable_address, true, _reliable_port, _service, _instance);
+        check_offer_info(_unreliable_address, false, _unreliable_port, _service, _unique);
+        check_offer_info(_reliable_address, true, _reliable_port, _service, _unique);
         break;
     case reliability_type_e::RT_UNKNOWN:
     default:
         VSOMEIP_WARNING << __func__ << ": unknown offer type [" 
                         << std::hex << std::setfill('0')
                         << std::setw(4) << _service << "." 
-                        << std::setw(4) << _instance << "]" 
+                        << std::setw(4) << get_instance_from_unique(_unique) << "]"
                         << static_cast<int>(_offer_type);
         break;
     }
@@ -3950,7 +3972,7 @@ service_discovery_impl::register_reboot_notification_handler(
 }
 
 reliability_type_e service_discovery_impl::get_eventgroup_reliability(
-        service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+        service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
         const std::shared_ptr<subscription>& _subscription) {
     reliability_type_e its_reliability = reliability_type_e::RT_UNKNOWN;
     auto its_info = _subscription->get_eventgroupinfo().lock();
@@ -3960,11 +3982,11 @@ reliability_type_e service_discovery_impl::get_eventgroup_reliability(
                 && its_info->is_reliability_auto_mode()) {
             // fallback: determine how service is offered
             // and update reliability type of eventgroup
-            its_reliability = get_remote_offer_type(_service, _instance);
+            its_reliability = get_remote_offer_type(_service, _unique);
             VSOMEIP_WARNING << "sd::" << __func__ << ": couldn't determine eventgroup reliability type for ["
                         << std::hex << std::setfill('0')
                         << std::setw(4) << _service << "."
-                        << std::setw(4) << _instance << "."
+                        << std::setw(4) << get_instance_from_unique(_unique) << "."
                         << std::setw(4) << _eventgroup << "]"
                         << " using reliability type:  "
                         << std::setw(4) << static_cast<uint16_t>(its_reliability);
@@ -3974,9 +3996,9 @@ reliability_type_e service_discovery_impl::get_eventgroup_reliability(
         VSOMEIP_WARNING << "sd::" << __func__ << ": couldn't lock eventgroupinfo ["
                 << std::hex << std::setfill('0')
                 << std::setw(4) << _service << "."
-                << std::setw(4) << _instance << "."
+                << std::setw(4) << get_instance_from_unique(_unique) << "."
                 << std::setw(4) << _eventgroup << "] ";
-        auto its_eg_info = host_->find_eventgroup(_service, _instance, _eventgroup);
+        auto its_eg_info = host_->find_eventgroup(_service, _unique, _eventgroup);
         if (its_eg_info) {
             _subscription->set_eventgroupinfo(its_eg_info);
             its_reliability = its_eg_info->get_reliability();
@@ -3987,7 +4009,7 @@ reliability_type_e service_discovery_impl::get_eventgroup_reliability(
         VSOMEIP_WARNING << "sd::" << __func__ << ": eventgroup reliability type is unknown ["
                     << std::hex << std::setfill('0')
                     << std::setw(4) << _service << "."
-                    << std::setw(4) << _instance << "."
+                    << std::setw(4) << get_instance_from_unique(_unique) << "."
                     << std::setw(4) << _eventgroup << "]";
     }
     return its_reliability;

--- a/interface/compat/vsomeip/application.hpp
+++ b/interface/compat/vsomeip/application.hpp
@@ -148,7 +148,7 @@ public:
      * \param _minor Minor service version (Default: 0).
      *
      */
-    virtual void offer_service(service_t _service, instance_t _instance,
+    virtual void offer_service(service_t _service, unique_version_t _unique,
             major_version_t _major = DEFAULT_MAJOR, minor_version_t _minor =
                     DEFAULT_MINOR) = 0;
 
@@ -164,7 +164,7 @@ public:
      * \param _minor Minor service version (Default: 0).
      *
      */
-    virtual void stop_offer_service(service_t _service, instance_t _instance,
+    virtual void stop_offer_service(service_t _service, unique_version_t _unique,
             major_version_t _major = DEFAULT_MAJOR, minor_version_t _minor =
                     DEFAULT_MINOR) = 0;
 
@@ -188,7 +188,7 @@ public:
      *
      */
     virtual void offer_event(service_t _service,
-            instance_t _instance, event_t _event,
+            unique_version_t _unique, event_t _event,
             const std::set<eventgroup_t> &_eventgroups,
             bool _is_field) = 0;
 
@@ -207,7 +207,7 @@ public:
      *
      */
     virtual void stop_offer_event(service_t _service,
-            instance_t _instance, event_t _event) = 0;
+            unique_version_t _unique, event_t _event) = 0;
 
     /**
      *
@@ -226,7 +226,7 @@ public:
      * used for the communication of this application to the service instance.
      *
      */
-    virtual void request_service(service_t _service, instance_t _instance,
+    virtual void request_service(service_t _service, unique_version_t _unique,
             major_version_t _major = ANY_MAJOR,
             minor_version_t _minor = ANY_MINOR,
             bool _use_exclusive_proxy = false) = 0;
@@ -247,7 +247,7 @@ public:
      * \param _instance Instance identifier of the offered service instance.
      *
      */
-    virtual void release_service(service_t _service, instance_t _instance) = 0;
+    virtual void release_service(service_t _service, unique_version_t _unique) = 0;
 
     /**
      *
@@ -267,7 +267,7 @@ public:
      * \param _is_field Pure event (false) or field (true).
      *
      */
-    virtual void request_event(service_t _service, instance_t _instance,
+    virtual void request_event(service_t _service, unique_version_t _unique,
             event_t _event, const std::set<eventgroup_t> &_eventgroups,
             bool _is_field) = 0;
     /**
@@ -284,7 +284,7 @@ public:
      * \param _event Event identifier of the event or field.
      * .
      */
-    virtual void release_event(service_t _service, instance_t _instance,
+    virtual void release_event(service_t _service, unique_version_t _unique,
             event_t _event) = 0;
 
     /**
@@ -312,7 +312,7 @@ public:
      * \param _event All (Default) or a specific event.
      *
      */
-    virtual void subscribe(service_t _service, instance_t _instance,
+    virtual void subscribe(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, major_version_t _major = DEFAULT_MAJOR,
             subscription_type_e _subscription_type = subscription_type_e::SU_RELIABLE_AND_UNRELIABLE,
             event_t _event = ANY_EVENT) = 0;
@@ -328,7 +328,7 @@ public:
      * \param _eventgroup Eventgroup identifier of the eventgroup.
      *
      */
-    virtual void unsubscribe(service_t _service, instance_t _instance,
+    virtual void unsubscribe(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup) = 0;
 
     /**
@@ -346,7 +346,7 @@ public:
      * minor version.
      *
      */
-    virtual bool is_available(service_t _service, instance_t _instance,
+    virtual bool is_available(service_t _service, unique_version_t _unique,
             major_version_t _major = DEFAULT_MAJOR, minor_version_t _minor = DEFAULT_MINOR) const = 0;
 
     /**
@@ -385,7 +385,7 @@ public:
      * \param _payload Serialized payload of the event.
      *
      */
-    virtual void notify(service_t _service, instance_t _instance,
+    virtual void notify(service_t _service, unique_version_t _unique,
                 event_t _event, std::shared_ptr<payload> _payload) const = 0;
 
     /**
@@ -409,7 +409,7 @@ public:
      * \param _client Target client.
      *
      */
-    virtual void notify_one(service_t _service, instance_t _instance,
+    virtual void notify_one(service_t _service, unique_version_t _unique,
                 event_t _event, std::shared_ptr<payload> _payload,
                 client_t _client) const = 0;
 
@@ -466,7 +466,7 @@ public:
      *
      */
     virtual void register_message_handler(service_t _service,
-            instance_t _instance, method_t _method,
+            unique_version_t _unique, method_t _method,
             message_handler_t _handler) = 0;
     /**
      *
@@ -484,7 +484,7 @@ public:
      * all methods and events.
      */
     virtual void unregister_message_handler(service_t _service,
-            instance_t _instance, method_t _method) = 0;
+            unique_version_t _unique, method_t _method) = 0;
 
     /**
      *
@@ -509,7 +509,7 @@ public:
      *
      */
     virtual void register_availability_handler(service_t _service,
-            instance_t _instance, availability_handler_t _handler,
+            unique_version_t _unique, availability_handler_t _handler,
             major_version_t _major = DEFAULT_MAJOR, minor_version_t _minor = DEFAULT_MINOR) = 0;
 
     /**
@@ -549,7 +549,7 @@ public:
      *
      */
     virtual void register_subscription_handler(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup,
+            unique_version_t _unique, eventgroup_t _eventgroup,
             subscription_handler_t _handler) = 0;
 
     /**
@@ -565,7 +565,7 @@ public:
      *
      */
     virtual void unregister_subscription_handler(service_t _service,
-                instance_t _instance, eventgroup_t _eventgroup) = 0;
+                unique_version_t _unique, eventgroup_t _eventgroup) = 0;
 
     // [Un]Register handler for subscription errors
     /**
@@ -586,7 +586,7 @@ public:
      *
      */
     virtual void register_subscription_error_handler(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup,
+            unique_version_t _unique, eventgroup_t _eventgroup,
             error_handler_t _handler) = 0;
 
     /**
@@ -602,7 +602,7 @@ public:
      *
      */
     virtual void unregister_subscription_error_handler(service_t _service,
-                instance_t _instance, eventgroup_t _eventgroup) = 0;
+                unique_version_t _unique, eventgroup_t _eventgroup) = 0;
 
     /**
      *
@@ -667,7 +667,7 @@ public:
      * reasons. They will be merged with the next major vsomeip version.
      */
     virtual void offer_event(service_t _service,
-            instance_t _instance, event_t _event,
+            unique_version_t _unique, event_t _event,
             const std::set<eventgroup_t> &_eventgroups,
             bool _is_field,
             std::chrono::milliseconds _cycle,
@@ -698,7 +698,7 @@ public:
      * Note: The different versions of notify do exist for compatibility
      * reasons. They will be merged with the next major vsomeip release.
      */
-    virtual void notify(service_t _service, instance_t _instance,
+    virtual void notify(service_t _service, unique_version_t _unique,
             event_t _event, std::shared_ptr<payload> _payload,
             bool _force) const = 0;
 
@@ -727,7 +727,7 @@ public:
      * Note: The different versions of notify_one do exist for compatibility
      * reasons. They will be merged with the next major vsomeip release.
      */
-    virtual void notify_one(service_t _service, instance_t _instance,
+    virtual void notify_one(service_t _service, unique_version_t _unique,
             event_t _event, std::shared_ptr<payload> _payload,
             client_t _client, bool _force) const = 0;
 
@@ -754,7 +754,7 @@ public:
      * are checked
      */
     virtual bool are_available(available_t &_available,
-            service_t _service = ANY_SERVICE, instance_t _instance = ANY_INSTANCE,
+            service_t _service = ANY_SERVICE, unique_version_t _unique = ANY_INSTANCE,
             major_version_t _major = ANY_MAJOR, minor_version_t _minor = ANY_MINOR) const = 0;
 
     /**
@@ -782,7 +782,7 @@ public:
      * Note: The different versions of notify do exist for compatibility
      * reasons. They will be merged with the next major vsomeip release.
      */
-    virtual void notify(service_t _service, instance_t _instance,
+    virtual void notify(service_t _service, unique_version_t _unique,
             event_t _event, std::shared_ptr<payload> _payload,
             bool _force, bool _flush) const = 0;
 
@@ -812,7 +812,7 @@ public:
      * Note: The different versions of notify_one do exist for compatibility
      * reasons. They will be merged with the next major vsomeip release.
      */
-    virtual void notify_one(service_t _service, instance_t _instance,
+    virtual void notify_one(service_t _service, unique_version_t _unique,
                 event_t _event, std::shared_ptr<payload> _payload,
                 client_t _client, bool _force, bool _flush) const = 0;
 
@@ -839,7 +839,7 @@ public:
      * \param _eventgroup Eventgroup identifier of the eventgroup.
      * \param _event Event to unsubscribe (pass ANY_EVENT for all events of the eventgroup)
      */
-    virtual void unsubscribe(service_t _service, instance_t _instance,
+    virtual void unsubscribe(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, event_t _event) = 0;
 
 
@@ -861,7 +861,7 @@ public:
      * as a follow of application::subscribe.
      */
     virtual void register_subscription_status_handler(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup, event_t _event,
+            unique_version_t _unique, eventgroup_t _eventgroup, event_t _event,
             subscription_status_handler_t _handler) = 0;
 
     /**
@@ -884,7 +884,7 @@ public:
      * subscription is answered with a SUBSCRIBE_NACK.
      */
     virtual void register_subscription_status_handler(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup, event_t _event,
+            unique_version_t _unique, eventgroup_t _eventgroup, event_t _event,
             subscription_status_handler_t _handler, bool _is_selective) = 0;
 
     /**
@@ -946,7 +946,7 @@ public:
      *
      */
     virtual void register_async_subscription_handler(
-            service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+            service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
             async_subscription_handler_t _handler) = 0;
 
     /**
@@ -1044,7 +1044,7 @@ public:
      * \param _offer Offer the service or stop offering it remotely
      */
     virtual bool update_service_configuration(service_t _service,
-                                              instance_t _instance,
+                                              unique_version_t _unique,
                                               std::uint16_t _port,
                                               bool _reliable,
                                               bool _magic_cookies_enabled,

--- a/interface/compat/vsomeip/handler.hpp
+++ b/interface/compat/vsomeip/handler.hpp
@@ -24,7 +24,7 @@ typedef std::function< void (const service_t, const instance_t, const eventgroup
                              const event_t, const uint16_t) > subscription_status_handler_t;
 typedef std::function< void (client_t, bool, std::function< void (const bool) > )> async_subscription_handler_t;
 
-typedef std::function< void (const std::vector<std::pair<service_t, instance_t>> &_services) > offered_services_handler_t;
+typedef std::function< void (const std::vector<std::pair<service_t, unique_version_t>> &_services) > offered_services_handler_t;
 typedef std::function< void () > watchdog_handler_t;
 
 struct ip_address_t {

--- a/interface/compat/vsomeip/primitive_types.hpp
+++ b/interface/compat/vsomeip/primitive_types.hpp
@@ -20,7 +20,8 @@ typedef uint16_t service_t;
 typedef uint16_t method_t;
 typedef uint16_t event_t;
 
-typedef uint16_t instance_t;
+typedef uint32_t instance_t;
+typedef uint64_t unique_version_t;
 typedef uint16_t eventgroup_t;
 
 typedef uint8_t major_version_t;
@@ -52,6 +53,18 @@ typedef std::uint16_t pending_subscription_id_t;
 typedef std::uint32_t pending_remote_offer_id_t;
 
 typedef std::uint32_t pending_security_update_id_t;
+
+inline unique_version_t get_unique_version(instance_t _instance, major_version_t _major) {
+    return static_cast<unique_version_t>((static_cast<unique_version_t>(_major << sizeof(instance_t) * 8)) | _instance);
+}
+
+inline major_version_t get_major_from_unique(unique_version_t _unique) {
+    return static_cast<major_version_t>((_unique >> sizeof(instance_t) * 8));
+}
+
+inline instance_t get_instance_from_unique(unique_version_t _unique) {
+    return static_cast<instance_t>(_unique & ((1U << (sizeof(instance_t) * 8)) - 1));
+}
 
 #ifdef _WIN32
     typedef std::uint32_t uid_t;

--- a/interface/compat/vsomeip/vsomeip.hpp
+++ b/interface/compat/vsomeip/vsomeip.hpp
@@ -18,4 +18,6 @@
 #include "../../compat/vsomeip/runtime.hpp"
 #include "../../compat/vsomeip/trace.hpp"
 
+#define VSOMEIP_MAKE_UNIQUE_SERVICE_VERSION (_instance_, _major) ((_major << 16) | _instance_)
+
 #endif // VSOMEIP_VSOMEIP_HPP

--- a/interface/vsomeip/application.hpp
+++ b/interface/vsomeip/application.hpp
@@ -168,7 +168,7 @@ public:
      * \param _minor Minor service version (Default: 0).
      *
      */
-    virtual void offer_service(service_t _service, instance_t _instance,
+    virtual void offer_service(service_t _service, unique_version_t _unique,
             major_version_t _major = DEFAULT_MAJOR, minor_version_t _minor =
                     DEFAULT_MINOR) = 0;
 
@@ -184,7 +184,7 @@ public:
      * \param _minor Minor service version (Default: 0).
      *
      */
-    virtual void stop_offer_service(service_t _service, instance_t _instance,
+    virtual void stop_offer_service(service_t _service, unique_version_t _unique,
             major_version_t _major = DEFAULT_MAJOR, minor_version_t _minor =
                     DEFAULT_MINOR) = 0;
 
@@ -220,7 +220,7 @@ public:
      * instance's reliability configuration. This parameter has no effect for
      * events of local services.
      */
-    virtual void offer_event(service_t _service, instance_t _instance,
+    virtual void offer_event(service_t _service, unique_version_t _unique,
             event_t _notifier, const std::set<eventgroup_t> &_eventgroups,
             event_type_e _type = event_type_e::ET_EVENT,
             std::chrono::milliseconds _cycle =std::chrono::milliseconds::zero(),
@@ -244,7 +244,7 @@ public:
      *
      */
     virtual void stop_offer_event(service_t _service,
-            instance_t _instance, event_t _event) = 0;
+            unique_version_t _unique, event_t _event) = 0;
 
     /**
      *
@@ -261,7 +261,7 @@ public:
      * \param _minor Minor service version (Default: 0xFFFFFF).
      *
      */
-    virtual void request_service(service_t _service, instance_t _instance,
+    virtual void request_service(service_t _service, unique_version_t _unique,
             major_version_t _major = ANY_MAJOR,
             minor_version_t _minor = ANY_MINOR) = 0;
 
@@ -281,7 +281,7 @@ public:
      * \param _instance Instance identifier of the offered service instance.
      *
      */
-    virtual void release_service(service_t _service, instance_t _instance) = 0;
+    virtual void release_service(service_t _service, unique_version_t _unique) = 0;
 
     /**
      *
@@ -313,7 +313,7 @@ public:
      * belong to the eventgroup. Otherwise, neither event type nor reliability
      * type are known which might result in missing events.
      */
-    virtual void request_event(service_t _service, instance_t _instance,
+    virtual void request_event(service_t _service, unique_version_t _unique,
             event_t _event, const std::set<eventgroup_t> &_eventgroups,
             event_type_e _type = event_type_e::ET_EVENT,
             reliability_type_e _reliability = reliability_type_e::RT_UNKNOWN) = 0;
@@ -331,7 +331,7 @@ public:
      * \param _event Event identifier of the event or field.
      * .
      */
-    virtual void release_event(service_t _service, instance_t _instance,
+    virtual void release_event(service_t _service, unique_version_t _unique,
             event_t _event) = 0;
 
     /**
@@ -358,7 +358,7 @@ public:
      * \param _event All (Default) or a specific event.
      *
      */
-    virtual void subscribe(service_t _service, instance_t _instance,
+    virtual void subscribe(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, major_version_t _major = DEFAULT_MAJOR,
             event_t _event = ANY_EVENT) = 0;
 
@@ -373,7 +373,7 @@ public:
      * \param _eventgroup Eventgroup identifier of the eventgroup.
      *
      */
-    virtual void unsubscribe(service_t _service, instance_t _instance,
+    virtual void unsubscribe(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup) = 0;
 
     /**
@@ -391,7 +391,7 @@ public:
      * minor version.
      *
      */
-    virtual bool is_available(service_t _service, instance_t _instance,
+    virtual bool is_available(service_t _service, unique_version_t _unique,
             major_version_t _major = ANY_MAJOR, minor_version_t _minor = ANY_MINOR) const = 0;
 
     typedef std::map<service_t,
@@ -399,7 +399,7 @@ public:
                     std::map<major_version_t, minor_version_t >>> available_t;
 
     virtual bool are_available(available_t &_available,
-            service_t _service = ANY_SERVICE, instance_t _instance = ANY_INSTANCE,
+            service_t _service = ANY_SERVICE, unique_version_t _unique = ANY_INSTANCE,
             major_version_t _major = ANY_MAJOR, minor_version_t _minor = ANY_MINOR) const = 0;
 
     /**
@@ -436,7 +436,7 @@ public:
      * \param _payload Serialized payload of the event.
      *
      */
-    virtual void notify(service_t _service, instance_t _instance,
+    virtual void notify(service_t _service, unique_version_t _unique,
             event_t _event, std::shared_ptr<payload> _payload,
             bool _force = false) const = 0;
 
@@ -461,7 +461,7 @@ public:
      * \param _client Target client.
      *
      */
-    virtual void notify_one(service_t _service, instance_t _instance,
+    virtual void notify_one(service_t _service, unique_version_t _unique,
                 event_t _event, std::shared_ptr<payload> _payload, client_t _client,
                 bool _force = false) const = 0;
 
@@ -518,7 +518,7 @@ public:
      *
      */
     virtual void register_message_handler(service_t _service,
-            instance_t _instance, method_t _method,
+            unique_version_t _unique, method_t _method,
             const message_handler_t &_handler) = 0;
     /**
      *
@@ -536,7 +536,7 @@ public:
      * all methods and events.
      */
     virtual void unregister_message_handler(service_t _service,
-            instance_t _instance, method_t _method) = 0;
+            unique_version_t _unique, method_t _method) = 0;
 
     /**
      *
@@ -561,7 +561,7 @@ public:
      *
      */
     virtual void register_availability_handler(service_t _service,
-            instance_t _instance, const availability_handler_t &_handler,
+            unique_version_t _unique, const availability_handler_t &_handler,
             major_version_t _major = ANY_MAJOR, minor_version_t _minor = ANY_MINOR) = 0;
 
     /**
@@ -602,7 +602,7 @@ public:
      */
     VSOMEIP_DEPRECATED_UID_GID
     virtual void register_subscription_handler(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup,
+            unique_version_t _unique, eventgroup_t _eventgroup,
             const subscription_handler_t &_handler) = 0;
 
     /**
@@ -629,7 +629,7 @@ public:
      */
     VSOMEIP_DEPRECATED_UID_GID
     virtual void register_async_subscription_handler(
-            service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+            service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
             const async_subscription_handler_t &_handler) = 0;
 
     /**
@@ -645,7 +645,7 @@ public:
      *
      */
     virtual void unregister_subscription_handler(service_t _service,
-                instance_t _instance, eventgroup_t _eventgroup) = 0;
+                unique_version_t _unique, eventgroup_t _eventgroup) = 0;
 
     /**
      *
@@ -691,7 +691,7 @@ public:
      * \param _eventgroup Eventgroup identifier of the eventgroup.
      * \param _event Event to unsubscribe (pass ANY_EVENT for all events of the eventgroup)
      */
-    virtual void unsubscribe(service_t _service, instance_t _instance,
+    virtual void unsubscribe(service_t _service, unique_version_t _unique,
             eventgroup_t _eventgroup, event_t _event) = 0;
 
     /**
@@ -715,7 +715,7 @@ public:
      * subscription is answered with a SUBSCRIBE_NACK.
      */
     virtual void register_subscription_status_handler(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup, event_t _event,
+            unique_version_t _unique, eventgroup_t _eventgroup, event_t _event,
             subscription_status_handler_t _handler, bool _is_selective = false) = 0;
 
     /**
@@ -732,7 +732,7 @@ public:
      * be removed.
      */
     virtual void unregister_subscription_status_handler(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup, event_t _event) = 0;
+            unique_version_t _unique, eventgroup_t _eventgroup, event_t _event) = 0;
 
     /**
      *
@@ -883,7 +883,7 @@ public:
      * \param _offer Offer the service or stop offering it remotely
      */
     virtual bool update_service_configuration(service_t _service,
-                                              instance_t _instance,
+                                              unique_version_t _unique,
                                               std::uint16_t _port,
                                               bool _reliable,
                                               bool _magic_cookies_enabled,
@@ -945,7 +945,7 @@ public:
      */
     VSOMEIP_DEPRECATED_UID_GID
     virtual void register_subscription_handler(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup,
+            unique_version_t _unique, eventgroup_t _eventgroup,
             const subscription_handler_ext_t &_handler) = 0;
 
     /**
@@ -972,7 +972,7 @@ public:
      */
     VSOMEIP_DEPRECATED_UID_GID
     virtual void register_async_subscription_handler(
-            service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+            service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
             const async_subscription_handler_ext_t &_handler) = 0;
 
 
@@ -1001,7 +1001,7 @@ public:
      * \param _filter Filter configuration to decide whether or not an
      * incoming event will be forwarded to the application.
      */
-    virtual void subscribe_with_debounce(service_t _service, instance_t _instance,
+    virtual void subscribe_with_debounce(service_t _service, unique_version_t _unique,
                 eventgroup_t _eventgroup, major_version_t _major,
                 event_t _event, const debounce_filter_t &_filter) = 0;
 
@@ -1049,7 +1049,7 @@ public:
      *
      */
     virtual void register_availability_handler(service_t _service,
-            instance_t _instance, const availability_state_handler_t &_handler,
+            unique_version_t _unique, const availability_state_handler_t &_handler,
             major_version_t _major = ANY_MAJOR, minor_version_t _minor = ANY_MINOR) = 0;
 
     /**
@@ -1073,7 +1073,7 @@ public:
      *
      */
     virtual void register_subscription_handler(service_t _service,
-            instance_t _instance, eventgroup_t _eventgroup,
+            unique_version_t _unique, eventgroup_t _eventgroup,
             const subscription_handler_sec_t &_handler) = 0;
 
     /**
@@ -1100,7 +1100,7 @@ public:
      *
      */
     virtual void register_async_subscription_handler(
-            service_t _service, instance_t _instance, eventgroup_t _eventgroup,
+            service_t _service, unique_version_t _unique, eventgroup_t _eventgroup,
             async_subscription_handler_sec_t _handler) = 0;
 
     /**

--- a/interface/vsomeip/handler.hpp
+++ b/interface/vsomeip/handler.hpp
@@ -32,7 +32,7 @@ VSOMEIP_DEPRECATED_UID_GID typedef std::function< void (client_t, uid_t, gid_t, 
 VSOMEIP_DEPRECATED_UID_GID typedef std::function< void (client_t, uid_t, gid_t, const std::string &, bool,
             std::function< void (const bool) > )> async_subscription_handler_ext_t;
 
-typedef std::function< void (const std::vector<std::pair<service_t, instance_t>> &_services) > offered_services_handler_t;
+typedef std::function< void (const std::vector<std::pair<service_t, unique_version_t>> &_services) > offered_services_handler_t;
 typedef std::function< void () > watchdog_handler_t;
 
 /*

--- a/interface/vsomeip/primitive_types.hpp
+++ b/interface/vsomeip/primitive_types.hpp
@@ -22,6 +22,7 @@ typedef uint16_t method_t;
 typedef uint16_t event_t;
 
 typedef uint16_t instance_t;
+typedef uint32_t unique_version_t;
 typedef uint16_t eventgroup_t;
 
 typedef uint8_t major_version_t;
@@ -55,6 +56,18 @@ typedef std::string trace_filter_type_t;
 typedef std::uint32_t pending_remote_offer_id_t;
 
 typedef std::uint32_t pending_security_update_id_t;
+
+inline unique_version_t get_unique_version(instance_t _instance, major_version_t _major) {
+    return static_cast<unique_version_t>((static_cast<unique_version_t>(_major << sizeof(instance_t) * 8)) | _instance);
+}
+
+inline major_version_t get_major_from_unique(unique_version_t _unique) {
+    return static_cast<major_version_t>((_unique >> sizeof(instance_t) * 8));
+}
+
+inline instance_t get_instance_from_unique(unique_version_t _unique) {
+    return static_cast<instance_t>(_unique & ((1U << (sizeof(instance_t) * 8)) - 1));
+}
 
 #if defined(_WIN32)
     typedef std::uint32_t uid_t;

--- a/interface/vsomeip/trace.hpp
+++ b/interface/vsomeip/trace.hpp
@@ -39,7 +39,7 @@ extern const char *VSOMEIP_TC_DEFAULT_CHANNEL_ID;
  * \brief Filters contain at least one match that specified
  * which messages are filtered.
  */
-typedef std::tuple<service_t, instance_t, method_t> match_t;
+typedef std::tuple<service_t, unique_version_t, method_t> match_t;
 
 /**
  * \brief Representation of a DLT trace channel.


### PR DESCRIPTION


This is an implementation for PRS_SOMEIPSD_00512 and PRS_SOMEIPSD_00806 as I have noticed from [https://github.com/COVESA/vsomeip/issues/797](#797 ) and [https://github.com/COVESA/vsomeip/issues/809](#809 )
That the current version of vsomeip only supports handling services with different instances, whereas according to SOME/IP Specification Document we should handle offering and requesting services with the same instance ID but different major version. It is clear in the 2 Requirements IDs I attached and even in the contradiction sentence that services with only minor versions different shouldn't be offered: "Note: Configuring more than one service instance on one Network Node that differs
only in the Minor Version is not allowed since they can not be distinguished in Eventgroup entries."

I have tried the current implementation and it was true that it doesn't handle these requirements and it is even clear that all data structures in the source code that should distinguish between services has only service ID and instance ID as keys while it should include the major version also.

And to explain what is the change in the PR in brief, I tried first the straight forward solution which is appending the major version as a key in all the maps and data structures of the source code but noticed the impact of that change would be severe. Nearly all of the code structure would be completely changed which might affect the performance and introduce many bugs besides making the code more complex and less readable since in every search loop for example we will have to nest other loops. Also from logical since I noticed it is useless as instance and major should be closely coupled. There is no point of hadling a case where instance ID is the same while major is different. It should be a completely new service if so.

I also tried to split the change into parts and create a PR for every part but unfortunately that too was not possible as changing one part for example 1 map of the offered services would make the rest of the code behaves differently.

So I decided to use what I said before as making the instance and major closely coupled, either by defining a new structure calling it unique_version_t for example and pass it as a key to all maps instead of the instance_t, but this would not keep backward compatibility with the current API and will require complex overloading operators for every data structure and I am not sure it would be possible for the rest of the code.

So I went for the last solution of defining a new primitive type unique_version_t which is simply a uint32_t variable to concatenate bits of major version as the MSBs and instance as the LSBs and pass it as a key instead of the instance_t in every data structure of the code. That would completely keep the backward compatibility as if the user didn't use the inline converting function as: vsomeip_v3::unique_version_t unique = vsomeip_v3::get_unique_version(SAMPLE_INSTANCE_ID, 10);
The change would be 100% impact less as if no change was made and I tested that in fact.

By this change I believe we can keep the structure and architecture of the code as it is and make the least impact of that change and I think the only drawback of that change is that we defined a new type that doesn't exist in the SOME/IP Requirements but I believe we can simply add a comment describing the change.