### PR TITLE
Fix build issue on Ubuntu 24.04

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build_on_ubuntu_boost_183_gcc_x86:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Ubuntu - Install boost 1.83.0 with gcc and x86
         uses: MarkusJx/install-boost@v2.4.4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:jammy
+FROM ubuntu:22.04
 SHELL ["/bin/bash", "-xec"]
 RUN export DEBIAN_FRONTEND=noninteractive;\
     apt-get update;\

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ cmake -DENABLE_SIGNAL_HANDLING=1 ..
 ```
 In the default setting, the application has to take care of shutting down vSomeIP in case these signals are received.
 
+###### Note on Ubuntu 24.04 Build Issues
+
+If you encounter build issues on Ubuntu 24.04, consider using Ubuntu 22.04 as a temporary fix. This is due to the ongoing transition of the GitHub Actions runner to Ubuntu 24.04, which may cause compatibility issues.
 
 ##### Build Instructions for Android
 


### PR DESCRIPTION
Fixes #833

Update workflow and documentation to address build issues on Ubuntu 24.04.

* **README.md**
  - Add a note to use Ubuntu 22.04 as a temporary fix for build issues on Ubuntu 24.04.
  - Mention the issue related to the GitHub Actions runner update.

* **.github/workflows/c-cpp.yml**
  - Change `runs-on` from `ubuntu-latest` to `ubuntu-22.04` for the job `build_on_ubuntu_boost_183_gcc_x86`.

* **Dockerfile**
  - Update base image from `ubuntu:jammy` to `ubuntu:22.04`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/COVESA/vsomeip/pull/834?shareId=7f17f3b1-bb84-485a-8469-97099c985296).