### PR TITLE
Small modernizations to internal.hpp

### DIFF
--- a/implementation/configuration/include/internal.hpp.in
+++ b/implementation/configuration/include/internal.hpp.in
@@ -178,7 +178,7 @@ enum class port_type_e {
 };
 
 using partition_id_t = std::uint8_t;
-const partition_id_t VSOMEIP_DEFAULT_PARTITION_ID = 0;
+inline constexpr partition_id_t VSOMEIP_DEFAULT_PARTITION_ID = 0;
 
 } // namespace vsomeip_v3
 

--- a/test/unit_tests/security_tests/ut_is_client_allowed.cpp
+++ b/test/unit_tests/security_tests/ut_is_client_allowed.cpp
@@ -22,8 +22,8 @@ namespace {
 
     vsomeip_v3::gid_t invalid_uid = 1;
     vsomeip_v3::gid_t invalid_gid = 1;
-    vsomeip_v3::uid_t ANY_UID = 0xFFFFFFFF;
-    vsomeip_v3::gid_t ANY_GID = 0xFFFFFFFF;
+    vsomeip_v3::uid_t ANY_UID = std::numeric_limits<uid_t>::max();
+    vsomeip_v3::gid_t ANY_GID = std::numeric_limits<uid_t>::max();
 
     vsomeip_v3::gid_t deny_uid  = 9999;
     vsomeip_v3::gid_t deny_gid  = 9999;


### PR DESCRIPTION
- Use `std::numeric_limits<uid_t>::max()` to ensure consistency with uid/gid
- Specify `partition_id_t` as a `constexpr`