### PR TITLE
Fix incorrect microsecond extraction in logging timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /build*/*
 /examples/hello_world/build
 /.idea/
+/.vs/
 /.vscode/
 /.settings
 /.project

--- a/implementation/logger/src/message.cpp
+++ b/implementation/logger/src/message.cpp
@@ -119,7 +119,7 @@ message::~message() try {
 #else
         localtime_r(&its_time_t, &its_time);
 #endif
-        auto its_ms = (when_.time_since_epoch().count() / 100) % 1000000;
+        auto its_ms = std::chrono::duration_cast<std::chrono::microseconds>(when_.time_since_epoch()).count() % 1000000;
 
         if (its_logger->has_console_log()) {
 #ifndef ANDROID


### PR DESCRIPTION
This PR fixes an issue in the logging module where the microsecond part of the timestamp was calculated incorrectly. Previously, the code used:

```cpp
auto its_ms = (when_.time_since_epoch().count() / 100) % 1000000;
```
However, this approach incorrectly scaled the raw duration count. The correct division factor should have been `1000` (not `100`), or better yet, the calculation can be performed in a type-safe manner using `std::chrono::duration_cast`.

The updated code now correctly extracts the microsecond portion by converting the duration to microseconds.

You can see the difference of the two approaches [here!](https://tio.run/##pVTbattAEH33VwwpBRkaO31VbEMvr2mhpG8Fsd4dW4v3IvYSNZR8uzsraSWZJJDSfRBiNefMmTPH5k1zfeT8fH4nDVdRIGx47ayxu8V0I60PDpme33EfhDRht1jQEzSTpljCnwXQYTFYMLaFLVBRWfaEZekffUBdcWX5qSypoFjeTgDH2orbSGTbBF4FqbHy1A8rbCyvi@Wq@5xAHWq9hut/Ohn1XQn41DTOMl6XcMdMZAqYk6HWGCQHbs0DOi@tWWXIfS093dPgzPuo0UOoWaAHAiFO4NBbFQNBgAo/3tyAYcZ6JCrhR5av8kGSaUfYP3Y1rY0kpW83I@tdIEu05C6TfMgkVGYgsFPi0VZEFbuG6YCSWgbfMTlmjria7LVKVNqTt8Vk9DoBl/A@48nY/3P2G7YzZ3/6pFFEx5IxFWc@wMG6V/2Vg3IaWGs0AgWwgQz2yFn0CDKkMvzdKMnpne1t7J2LhiafzWuw7ee9iOCFmM3Fp7nZu@LlBI4RvPAsxyqGZhBDcYgqy@m7JJ2bDVz9YO18y8XljyLr6wCp0bKEq4SblpZIfpmr2xe472YjQDGPeaYZUvBmjvlCM8fg7Mgxzt8k5UyV8MXqhjnsE93acYs4OCIPUOQ8bge@/OfxXNFnG@oZBdCLiJzCkeg909nu1TjRE6CirLxGeP9M1sQp5OGADsnnvMOJtZ/UYYjOAC3@aXE@/wU "C++ (gcc) – Try It Online")

Also updated .gitignore to ignore the `.vs` folder for Visual Studio.