### PR TITLE
Fix SD Route Initialization for Windows

### DIFF
--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -4030,6 +4030,7 @@ void routing_manager_impl::on_net_interface_or_route_state_changed(
 void routing_manager_impl::start_ip_routing() {
 #if defined(_WIN32) || defined(__QNX__)
     if_state_running_ = true;
+    sd_route_set_ = true;
 #endif
 
     if (routing_ready_handler_) {


### PR DESCRIPTION
The sd_route_set_ flag is never set to true in the Windows build. As result, Service Discovery calls such as offer_service() will fail checks performed by routing_manager_impl::is_external_routing_ready().

One solution is to initialize the sd_route_set flag to true in Windows and QNX builds within routing_manager_impl::start_ip_routing().