### PR TITLE
adapt finding Boost for CMake 3.30+

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,6 +188,7 @@ add_definitions(-DVSOMEIP_INTERNAL_SUPPRESS_DEPRECATED)
 find_package(Threads REQUIRED)
 
 # Boost
+cmake_policy(SET CMP0167 NEW) #to adapt for CMake 3.30+ as built-in FindBoost module has been deprecated and removed
 find_package( Boost 1.66 COMPONENTS system thread filesystem REQUIRED )
 if(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
     include_directories(${Boost_INCLUDE_DIR} )


### PR DESCRIPTION
In CMake 3.30+, the built-in "FindBoost" module has been deprecated and removed. Previously, calling: find_package(Boost REQUIRED) would use CMake’s built-in logic to locate Boost. But now, CMake expects you to use a package manager (like Conan, vcpkg, or FetchContent) to provide Boost. Because vsomeip still uses the old approach, CMake 3.30+ triggers a warning and fails to find Boost.