### PR TITLE
Replacing deprecated max_connections with max_listen_connections

### DIFF
--- a/implementation/endpoints/src/local_tcp_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/local_tcp_server_endpoint_impl.cpp
@@ -68,7 +68,7 @@ void local_tcp_server_endpoint_impl::init_unlocked(const endpoint_type& _local,
     if (_error)
         return;
 
-    acceptor_.listen(boost::asio::socket_base::max_connections, _error);
+    acceptor_.listen(boost::asio::socket_base::max_listen_connections, _error);
     if (_error)
         return;
 

--- a/implementation/endpoints/src/local_uds_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/local_uds_server_endpoint_impl.cpp
@@ -74,7 +74,7 @@ void local_uds_server_endpoint_impl::init_helper(const endpoint_type& _local,
     if (_error)
         return;
 
-    acceptor_.listen(boost::asio::socket_base::max_connections, _error);
+    acceptor_.listen(boost::asio::socket_base::max_listen_connections, _error);
     if (_error)
         return;
 

--- a/implementation/endpoints/src/netlink_connector.cpp
+++ b/implementation/endpoints/src/netlink_connector.cpp
@@ -9,7 +9,7 @@
 
 #include <boost/asio/write.hpp>
 #include <boost/asio/read.hpp>
-#include<sstream>
+#include <sstream>
 
 #include <vsomeip/internal/logger.hpp>
 

--- a/implementation/endpoints/src/tcp_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/tcp_server_endpoint_impl.cpp
@@ -63,7 +63,7 @@ void tcp_server_endpoint_impl::init(const endpoint_type& _local,
     if (_error)
         return;
 
-    acceptor_.listen(boost::asio::socket_base::max_connections, _error);
+    acceptor_.listen(boost::asio::socket_base::max_listen_connections, _error);
     if (_error)
         return;
 

--- a/test/network_tests/malicious_data_tests/malicious_data_test_msg_sender.cpp
+++ b/test/network_tests/malicious_data_tests/malicious_data_test_msg_sender.cpp
@@ -140,7 +140,7 @@ TEST_F(malicious_data, send_malicious_events)
             boost::asio::detail::throw_error(ec, "acceptor set_option");
             its_acceptor.bind(local, ec);
             boost::asio::detail::throw_error(ec, "acceptor bind");
-            its_acceptor.listen(boost::asio::socket_base::max_connections, ec);
+            its_acceptor.listen(boost::asio::socket_base::max_listen_connections, ec);
             boost::asio::detail::throw_error(ec, "acceptor listen");
             its_acceptor.async_accept(tcp_socket, [&](boost::system::error_code _error) {
                 if (!_error) {
@@ -377,7 +377,7 @@ TEST_F(malicious_data, send_wrong_protocol_version)
             boost::asio::detail::throw_error(ec, "acceptor set_option");
             its_acceptor.bind(local, ec);
             boost::asio::detail::throw_error(ec, "acceptor bind");
-            its_acceptor.listen(boost::asio::socket_base::max_connections, ec);
+            its_acceptor.listen(boost::asio::socket_base::max_listen_connections, ec);
             boost::asio::detail::throw_error(ec, "acceptor listen");
             its_acceptor.async_accept(tcp_socket, [&](boost::system::error_code _error) {
                 if (!_error) {
@@ -764,7 +764,7 @@ TEST_F(malicious_data, send_wrong_message_type)
             boost::asio::detail::throw_error(ec, "acceptor set_option");
             its_acceptor.bind(local, ec);
             boost::asio::detail::throw_error(ec, "acceptor bind");
-            its_acceptor.listen(boost::asio::socket_base::max_connections, ec);
+            its_acceptor.listen(boost::asio::socket_base::max_listen_connections, ec);
             boost::asio::detail::throw_error(ec, "acceptor listen");
             its_acceptor.async_accept(tcp_socket, [&](boost::system::error_code _error) {
                 if (!_error) {
@@ -1062,7 +1062,7 @@ TEST_F(malicious_data, send_wrong_return_code)
             boost::asio::detail::throw_error(ec, "acceptor set_option");
             its_acceptor.bind(local, ec);
             boost::asio::detail::throw_error(ec, "acceptor bind");
-            its_acceptor.listen(boost::asio::socket_base::max_connections, ec);
+            its_acceptor.listen(boost::asio::socket_base::max_listen_connections, ec);
             boost::asio::detail::throw_error(ec, "acceptor listen");
             its_acceptor.async_accept(tcp_socket, [&](boost::system::error_code _error) {
                 if (!_error) {


### PR DESCRIPTION
This symbol has been deprecated since at least 1.74, and is removed in 1.87.

Replacing it with `max_listen_connections` as recommended here: https://beta.boost.org/doc/libs/1_86_0/doc/html/boost_asio/reference/socket_base.html

Both these symbols are available in [1.66](https://beta.boost.org/doc/libs/1_66_0/doc/html/boost_asio/reference/socket_base.html) so this shouldn't have an impact on backwards compatibility

## Notes
[asio::io_context::post](https://beta.boost.org/doc/libs/1_86_0/doc/html/boost_asio/reference/io_context/post.html) was also removed - it was deprecated even in 1.66.  The recommended alternative is [asio::io_context::post(ctx)](https://beta.boost.org/doc/libs/1_86_0/doc/html/boost_asio/reference/post.html) - I'll deal with this in another PR