### PR TITLE
Fix E2E protection checker counter increment

### DIFF
--- a/implementation/e2e_protection/src/e2e/profile/profile04/checker.cpp
+++ b/implementation/e2e_protection/src/e2e/profile/profile04/checker.cpp
@@ -77,6 +77,8 @@ bool profile_04_checker::verify_counter(instance_t _instance, uint16_t _received
             its_delta = uint16_t(_received_counter - its_counter);
         else
             its_delta = uint16_t(uint16_t(0xffff) - its_counter + _received_counter);
+
+        find_counter->second = _received_counter;
     } else {
         counter_[_instance] = _received_counter;
     }

--- a/implementation/e2e_protection/src/e2e/profile/profile05/checker.cpp
+++ b/implementation/e2e_protection/src/e2e/profile/profile05/checker.cpp
@@ -58,6 +58,8 @@ bool profile_05_checker::verify_counter(instance_t _instance, uint8_t _received_
             its_delta = uint8_t(_received_counter - its_counter);
         else
             its_delta = uint8_t(uint8_t(0xff) - its_counter + _received_counter);
+
+        find_counter->second = _received_counter;
     } else {
         counter_[_instance] = _received_counter;
     }

--- a/implementation/e2e_protection/src/e2e/profile/profile07/checker.cpp
+++ b/implementation/e2e_protection/src/e2e/profile/profile07/checker.cpp
@@ -71,6 +71,8 @@ bool profile_07_checker::verify_counter(instance_t _instance, uint32_t _received
             its_delta = uint32_t(_received_counter - its_counter);
         else
             its_delta = uint32_t(uint32_t(0xffffffff) - its_counter + _received_counter);
+
+        find_counter->second = _received_counter;
     } else {
         counter_[_instance] = _received_counter;
     }


### PR DESCRIPTION
Bug introduced by 826ebb8d352245a36ecaec32b6af61e7abf4696e.

E2E checkers should always update the local counters by the received counters after determining the counter deltas in `verify_counter`.