### PR TITLE
Add stdint import for GCC 15

### DIFF
--- a/interface/vsomeip/plugin.hpp
+++ b/interface/vsomeip/plugin.hpp
@@ -8,6 +8,7 @@
 
 #include <memory>
 #include <string>
+#include <cstdint>
 
 #if _WIN32
     #if VSOMEIP_DLL_COMPILATION_PLUGIN

--- a/interface/vsomeip/plugins/application_plugin.hpp
+++ b/interface/vsomeip/plugins/application_plugin.hpp
@@ -8,6 +8,7 @@
 
 #include <string>
 #include <memory>
+#include <cstdint>
 
 #include <vsomeip/export.hpp>
 


### PR DESCRIPTION
Hi,
I'm using the newly released Fedora 42, which ships GCC 15 already, and encountered build errors. The errors are caused by GCC 15 requiring `stdint.h` to be explicitly imported ([link](https://gcc.gnu.org/gcc-15/porting_to.html#header-dep-changes)):
```
In particular, the following headers are used less widely within libstdc++ and may need to be included explicitly when compiling with GCC 15:
    <stdint.h> (for int8_t, int32_t etc.) and <cstdint> (for std::int8_t, std::int32_t etc.)
    <ostream> (for std::endl, std::flush etc.)
```

This PR adds the required imports.

<details>
  <summary>Build errors</summary>

```
In file included from /home/arctic-alpaca/git/vsomeip/interface/vsomeip/internal/plugin_manager.hpp:13,
                 from /home/arctic-alpaca/git/vsomeip/implementation/plugin/src/../include/plugin_manager_impl.hpp:9,
                 from /home/arctic-alpaca/git/vsomeip/implementation/plugin/src/plugin_manager.cpp:6:
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugin.hpp:26:6: error: elaborated-type-specifier for a scoped enum must not use the ‘class’ keyword [-Werror]
   26 | enum class plugin_type_e : uint8_t {
      | ~~~~ ^~~~~
      |      -----
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugin.hpp:26:26: error: found ‘:’ in nested-name-specifier, expected ‘::’
   26 | enum class plugin_type_e : uint8_t {
      |                          ^
      |                          ::
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugin.hpp:26:12: error: ‘plugin_type_e’ has not been declared
   26 | enum class plugin_type_e : uint8_t {
      |            ^~~~~~~~~~~~~
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugin.hpp:26:36: error: expected unqualified-id before ‘{’ token
   26 | enum class plugin_type_e : uint8_t {
      |                                    ^
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugin.hpp:44:13: error: ‘uint32_t’ does not name a type
   44 |     virtual uint32_t get_plugin_version() const = 0;
      |             ^~~~~~~~
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugin.hpp:1:1: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
  +++ |+#include <cstdint>
    1 | // Copyright (C) 2016-2021 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugin.hpp:46:13: error: ‘plugin_type_e’ does not name a type
   46 |     virtual plugin_type_e get_plugin_type() const = 0;
      |             ^~~~~~~~~~~~~
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugin.hpp:56:43: error: ‘uint32_t’ has not been declared [-Wtemplate-body]
   56 |     plugin_impl(const std::string &_name, uint32_t _version,
      |                                           ^~~~~~~~
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugin.hpp:56:43: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugin.hpp:57:17: error: ‘plugin_type_e’ has not been declared; did you mean ‘plugin_impl’? [-Wtemplate-body]
   57 |                 plugin_type_e _type) {
      |                 ^~~~~~~~~~~~~
      |                 plugin_impl
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugin.hpp:67:5: error: ‘uint32_t’ does not name a type [-Wtemplate-body]
   67 |     uint32_t get_plugin_version() const {
      |     ^~~~~~~~
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugin.hpp:67:5: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugin.hpp:71:5: error: ‘plugin_type_e’ does not name a type; did you mean ‘plugin_impl’? [-Wtemplate-body]
   71 |     plugin_type_e get_plugin_type() const {
      |     ^~~~~~~~~~~~~
      |     plugin_impl
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugin.hpp:76:5: error: ‘uint32_t’ does not name a type [-Wtemplate-body]
   76 |     uint32_t version_;
      |     ^~~~~~~~
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugin.hpp:76:5: note: ‘uint32_t’ is defined in header ‘<cstdint>’; this is probably fixable by adding ‘#include <cstdint>’
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugin.hpp:78:5: error: ‘plugin_type_e’ does not name a type; did you mean ‘plugin_impl’? [-Wtemplate-body]
   78 |     plugin_type_e type_;
      |     ^~~~~~~~~~~~~
      |     plugin_impl
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugin.hpp: In constructor ‘vsomeip_v3::plugin_impl<Plugin_>::plugin_impl(const std::string&, int, int)’:
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugin.hpp:59:9: error: ‘version_’ was not declared in this scope; did you mean ‘_version’? [-Wtemplate-body]
   59 |         version_ = _version;
      |         ^~~~~~~~
      |         _version
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugin.hpp:60:9: error: ‘type_’ was not declared in this scope [-Wtemplate-body]
   60 |         type_ = _type;
      |         ^~~~~
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/internal/plugin_manager.hpp: At global scope:
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/internal/plugin_manager.hpp:22:63: error: ‘plugin_type_e’ has not been declared; did you mean ‘plugin_impl’?
   22 |     VSOMEIP_EXPORT virtual std::shared_ptr<plugin> get_plugin(plugin_type_e _type, const std::string &_name) = 0;
      |                                                               ^~~~~~~~~~~~~
      |                                                               plugin_impl
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/internal/plugin_manager.hpp:26:47: error: ‘plugin_type_e’ has not been declared; did you mean ‘plugin_impl’?
   26 |     VSOMEIP_EXPORT virtual bool unload_plugin(plugin_type_e _type) = 0;
      |                                               ^~~~~~~~~~~~~
      |                                               plugin_impl
/home/arctic-alpaca/git/vsomeip/implementation/plugin/src/../include/plugin_manager_impl.hpp:32:59: error: ‘plugin_type_e’ has not been declared; did you mean ‘plugin_impl’?
   32 |         VSOMEIP_EXPORT std::shared_ptr<plugin> get_plugin(plugin_type_e _type,
      |                                                           ^~~~~~~~~~~~~
      |                                                           plugin_impl
/home/arctic-alpaca/git/vsomeip/implementation/plugin/src/../include/plugin_manager_impl.hpp:36:46: error: ‘plugin_type_e’ has not been declared; did you mean ‘plugin_impl’?
   36 |                 const std::string& _library, plugin_type_e _type,
      |                                              ^~~~~~~~~~~~~
      |                                              plugin_impl
/home/arctic-alpaca/git/vsomeip/implementation/plugin/src/../include/plugin_manager_impl.hpp:39:43: error: ‘plugin_type_e’ has not been declared; did you mean ‘plugin_impl’?
   39 |         VSOMEIP_EXPORT bool unload_plugin(plugin_type_e _type);
      |                                           ^~~~~~~~~~~~~
      |                                           plugin_impl
/home/arctic-alpaca/git/vsomeip/implementation/plugin/src/../include/plugin_manager_impl.hpp:51:18: error: ‘plugin_type_e’ was not declared in this scope; did you mean ‘plugin_impl’?
   51 |         std::map<plugin_type_e, std::map<std::string, std::shared_ptr<plugin> > > plugins_;
      |                  ^~~~~~~~~~~~~
      |                  plugin_impl
/home/arctic-alpaca/git/vsomeip/implementation/plugin/src/../include/plugin_manager_impl.hpp:51:81: error: template argument 1 is invalid
   51 |         std::map<plugin_type_e, std::map<std::string, std::shared_ptr<plugin> > > plugins_;
      |                                                                                 ^
/home/arctic-alpaca/git/vsomeip/implementation/plugin/src/../include/plugin_manager_impl.hpp:51:81: error: template argument 3 is invalid
/home/arctic-alpaca/git/vsomeip/implementation/plugin/src/../include/plugin_manager_impl.hpp:51:81: error: template argument 4 is invalid
/home/arctic-alpaca/git/vsomeip/implementation/plugin/src/../include/plugin_manager_impl.hpp:52:18: error: ‘plugin_type_e’ was not declared in this scope; did you mean ‘plugin_impl’?
   52 |         std::map<plugin_type_e, std::map<std::string, void*> > handles_;
      |                  ^~~~~~~~~~~~~
      |                  plugin_impl
/home/arctic-alpaca/git/vsomeip/implementation/plugin/src/../include/plugin_manager_impl.hpp:52:62: error: template argument 1 is invalid
   52 |         std::map<plugin_type_e, std::map<std::string, void*> > handles_;
      |                                                              ^
/home/arctic-alpaca/git/vsomeip/implementation/plugin/src/../include/plugin_manager_impl.hpp:52:62: error: template argument 3 is invalid
/home/arctic-alpaca/git/vsomeip/implementation/plugin/src/../include/plugin_manager_impl.hpp:52:62: error: template argument 4 is invalid
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/vsomeip3.dir/build.make:471: CMakeFiles/vsomeip3.dir/implementation/plugin/src/plugin_manager.cpp.o] Error 1
make[2]: *** Waiting for unfinished jobs....
In file included from /home/arctic-alpaca/git/vsomeip/implementation/plugin/src/plugin_manager_impl.cpp:20:
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugins/application_plugin.hpp:19:6: error: elaborated-type-specifier for a scoped enum must not use the ‘class’ keyword [-Werror]
   19 | enum class application_plugin_state_e : uint8_t {
      | ~~~~ ^~~~~
      |      -----
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugins/application_plugin.hpp:19:39: error: found ‘:’ in nested-name-specifier, expected ‘::’
   19 | enum class application_plugin_state_e : uint8_t {
      |                                       ^
      |                                       ::
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugins/application_plugin.hpp:19:12: error: ‘application_plugin_state_e’ has not been declared
   19 | enum class application_plugin_state_e : uint8_t {
      |            ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugins/application_plugin.hpp:19:49: error: expected unqualified-id before ‘{’ token
   19 | enum class application_plugin_state_e : uint8_t {
      |                                                 ^
/home/arctic-alpaca/git/vsomeip/interface/vsomeip/plugins/application_plugin.hpp:37:19: error: ‘application_plugin_state_e’ does not name a type; did you mean ‘application_plugin’?
   37 |             const application_plugin_state_e _app_state) = 0;
      |                   ^~~~~~~~~~~~~~~~~~~~~~~~~~
      |                   application_plugin
cc1plus: all warnings being treated as errors
make[2]: *** [CMakeFiles/vsomeip3.dir/build.make:485: CMakeFiles/vsomeip3.dir/implementation/plugin/src/plugin_manager_impl.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:252: CMakeFiles/vsomeip3.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```
  
</details>

