### PR TITLE
Remove explicit types on locks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 /Testing
 /logs
 !build_qnx/*
+CMakeUserPresets.json

--- a/implementation/configuration/src/configuration_impl.cpp
+++ b/implementation/configuration/src/configuration_impl.cpp
@@ -2797,7 +2797,7 @@ const std::string& configuration_impl::get_logfile() const {
 }
 
 vsomeip_v3::logger::level_e configuration_impl::get_loglevel() const {
-    std::unique_lock<std::mutex> its_lock(mutex_loglevel_);
+    std::unique_lock its_lock{mutex_loglevel_};
     return loglevel_;
 }
 

--- a/implementation/endpoints/src/local_tcp_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/local_tcp_server_endpoint_impl.cpp
@@ -225,7 +225,7 @@ void local_tcp_server_endpoint_impl::accept_cbk(connection::ptr _connection, boo
     if (!_error) {
         boost::system::error_code its_error;
         {
-            std::unique_lock<std::mutex> its_socket_lock(_connection->get_socket_lock());
+            std::unique_lock its_socket_lock{_connection->get_socket_lock()};
             auto& new_connection_socket = _connection->get_socket();
 
             endpoint_type remote = new_connection_socket.remote_endpoint(its_error);
@@ -932,7 +932,7 @@ void local_tcp_server_endpoint_impl::print_status() {
 
         std::size_t its_recv_size(0);
         {
-            std::unique_lock<std::mutex> c_s_lock(c.second->get_socket_lock());
+            std::unique_lock c_s_lock{c.second->get_socket_lock()};
             its_recv_size = c.second->get_recv_buffer_capacity();
         }
 

--- a/implementation/endpoints/src/local_uds_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/local_uds_server_endpoint_impl.cpp
@@ -873,7 +873,7 @@ void local_uds_server_endpoint_impl::print_status() {
 
         std::size_t its_recv_size(0);
         {
-            std::unique_lock<std::mutex> c_s_lock(c.second->get_socket_lock());
+            std::unique_lock c_s_lock{c.second->get_socket_lock()};
             its_recv_size = c.second->get_recv_buffer_capacity();
         }
 

--- a/implementation/endpoints/src/tcp_client_endpoint_impl.cpp
+++ b/implementation/endpoints/src/tcp_client_endpoint_impl.cpp
@@ -113,7 +113,7 @@ void tcp_client_endpoint_impl::restart(bool _force) {
 
 void tcp_client_endpoint_impl::connect() {
     start_connecting_timer();
-    std::unique_lock<std::mutex> its_lock(socket_mutex_);
+    std::unique_lock its_lock{socket_mutex_};
     boost::system::error_code its_error;
     socket_->open(remote_.protocol(), its_error);
 
@@ -459,7 +459,7 @@ void tcp_client_endpoint_impl::receive_cbk(boost::system::error_code const& _err
             << static_cast<int>( (_recv_buffer)[i] << " ";
     VSOMEIP_INFO << msg.str();
 #endif
-    std::unique_lock<std::mutex> its_lock(socket_mutex_);
+    std::unique_lock its_lock{socket_mutex_};
     std::shared_ptr<routing_host> its_host = routing_host_.lock();
     if (its_host) {
         std::uint32_t its_missing_capacity(0);

--- a/implementation/endpoints/src/udp_client_endpoint_impl.cpp
+++ b/implementation/endpoints/src/udp_client_endpoint_impl.cpp
@@ -47,7 +47,7 @@ bool udp_client_endpoint_impl::is_local() const {
 }
 
 void udp_client_endpoint_impl::connect() {
-    std::unique_lock<std::mutex> its_lock(socket_mutex_);
+    std::unique_lock its_lock{socket_mutex_};
     boost::system::error_code its_error;
     socket_->open(remote_.protocol(), its_error);
     if (!its_error || its_error == boost::asio::error::already_open) {

--- a/implementation/routing/src/routing_manager_base.cpp
+++ b/implementation/routing/src/routing_manager_base.cpp
@@ -1365,7 +1365,7 @@ bool routing_manager_base::insert_subscription(service_t _service, instance_t _i
 
 std::shared_ptr<serializer> routing_manager_base::get_serializer() {
 
-    std::unique_lock<std::mutex> its_lock(serializer_mutex_);
+    std::unique_lock its_lock{serializer_mutex_};
     while (serializers_.empty()) {
         VSOMEIP_INFO << __func__ << ": Client " << std::hex << std::setfill('0') << std::setw(4) << get_client()
                      << " has no available serializer. Waiting...";
@@ -1389,7 +1389,7 @@ void routing_manager_base::put_serializer(const std::shared_ptr<serializer>& _se
 
 std::shared_ptr<deserializer> routing_manager_base::get_deserializer() {
 
-    std::unique_lock<std::mutex> its_lock(deserializer_mutex_);
+    std::unique_lock its_lock{deserializer_mutex_};
     while (deserializers_.empty()) {
         VSOMEIP_INFO << std::hex << "client " << get_client() << "routing_manager_base::get_deserializer ~> all in use!";
         deserializer_condition_.wait(its_lock, [this] { return !deserializers_.empty(); });

--- a/implementation/routing/src/routing_manager_stub.cpp
+++ b/implementation/routing/src/routing_manager_stub.cpp
@@ -818,7 +818,7 @@ void routing_manager_stub::on_offered_service_request(client_t _client, offer_ty
 }
 
 void routing_manager_stub::client_registration_func(void) {
-    std::unique_lock<std::mutex> its_lock(client_registration_mutex_);
+    std::unique_lock its_lock{client_registration_mutex_};
     while (client_registration_running_) {
         client_registration_condition_.wait(
                 its_lock, [this] { return !pending_client_registrations_queue_.empty() || !client_registration_running_; });

--- a/implementation/runtime/src/application_impl.cpp
+++ b/implementation/runtime/src/application_impl.cpp
@@ -2582,7 +2582,7 @@ void application_impl::register_async_subscription_handler(service_t _service, i
     VSOMEIP_INFO << __func__ << ": (" << std::hex << std::setfill('0') << std::setw(4) << get_client() << "): [" << std::setw(4) << _service
                  << "." << std::setw(4) << _instance << "." << std::setw(4) << _eventgroup << "]";
 
-    std::scoped_lock<std::mutex> its_lock(subscription_mutex_);
+    std::scoped_lock its_lock(subscription_mutex_);
     subscription_[_service][_instance][_eventgroup] = std::make_pair(nullptr, _handler);
 }
 

--- a/implementation/service_discovery/src/service_discovery_impl.cpp
+++ b/implementation/service_discovery/src/service_discovery_impl.cpp
@@ -2355,7 +2355,7 @@ void service_discovery_impl::check_ttl(const boost::system::error_code& _error) 
                                // update_routing_info
     if (!_error) {
         {
-            std::unique_lock<std::mutex> its_lock(check_ttl_mutex_, std::try_to_lock);
+            std::unique_lock its_lock{check_ttl_mutex_, std::try_to_lock};
             if (its_lock.owns_lock()) {
                 its_counter = 0;
                 host_->update_routing_info(ttl_timer_runtime_);

--- a/test/network_tests/debounce_callback_tests/debounce_callback_test_service.cpp
+++ b/test/network_tests/debounce_callback_tests/debounce_callback_test_service.cpp
@@ -43,7 +43,7 @@ void debounce_test_service::stop() {
 void debounce_test_service::run() {
 
     {
-        std::unique_lock<std::mutex> its_lock(run_mutex_);
+        std::unique_lock its_lock{run_mutex_};
         auto its_result = run_condition_.wait_for(its_lock, std::chrono::seconds(10));
         if (its_result == std::cv_status::timeout)
             return;

--- a/test/network_tests/debounce_filter_tests/debounce_filter_test_service.cpp
+++ b/test/network_tests/debounce_filter_tests/debounce_filter_test_service.cpp
@@ -37,7 +37,7 @@ void debounce_test_service::stop() {
 
 void debounce_test_service::run() {
     {
-        std::unique_lock<std::mutex> its_lock(run_mutex_);
+        std::unique_lock its_lock{run_mutex_};
         auto its_result = run_condition_.wait_for(its_lock, std::chrono::milliseconds(5000));
         if (its_result == std::cv_status::timeout)
             return;

--- a/test/network_tests/debounce_frequency_tests/debounce_frequency_test_client.cpp
+++ b/test/network_tests/debounce_frequency_tests/debounce_frequency_test_client.cpp
@@ -13,7 +13,7 @@
 // Flag the desired event availability
 void test_client::on_availability(vsomeip::service_t service_, vsomeip::instance_t instance_, bool _is_available) {
     if (_is_available && service_ == DEBOUNCE_SERVICE && instance_ == DEBOUNCE_INSTANCE) {
-        std::unique_lock<std::mutex> lk(mutex);
+        std::unique_lock lk{mutex};
         availability = true;
         condition_availability.notify_one();
     }
@@ -29,12 +29,12 @@ void test_client::on_message(const std::shared_ptr<vsomeip::message>& _message) 
     VSOMEIP_DEBUG << s.str();
 
     if (DEBOUNCE_SERVICE == _message->get_service() && DEBOUNCE_EVENT == _message->get_method()) {
-        std::unique_lock<std::mutex> lk(event_counter_mutex);
+        std::unique_lock lk{event_counter_mutex};
         event_1_recv_messages++;
         return;
     }
     if (DEBOUNCE_SERVICE == _message->get_service() && DEBOUNCE_EVENT_2 == _message->get_method()) {
-        std::unique_lock<std::mutex> lk(event_counter_mutex);
+        std::unique_lock lk{event_counter_mutex};
         event_2_recv_messages++;
         return;
     }
@@ -57,19 +57,19 @@ test_client::test_client(const char* app_name_, const char* app_id_) : vsomeip_u
 }
 
 int test_client::was_event1_recv() {
-    std::unique_lock<std::mutex> lk(event_counter_mutex);
+    std::unique_lock lk{event_counter_mutex};
 
     return event_1_recv_messages;
 }
 
 int test_client::was_event2_recv() {
-    std::unique_lock<std::mutex> lk(event_counter_mutex);
+    std::unique_lock lk{event_counter_mutex};
 
     return event_2_recv_messages;
 }
 
 void test_client::send_request() {
-    std::unique_lock<std::mutex> lk(mutex);
+    std::unique_lock lk{mutex};
     // Only send the requests when the service availability is secured
     if (condition_availability.wait_for(lk, std::chrono::seconds(20), [this] { return availability; })) {
 

--- a/test/network_tests/debounce_tests/debounce_test_service.cpp
+++ b/test/network_tests/debounce_tests/debounce_test_service.cpp
@@ -45,7 +45,7 @@ void debounce_test_service::stop() {
 void debounce_test_service::run() {
 
     {
-        std::unique_lock<std::mutex> its_lock(run_mutex_);
+        std::unique_lock its_lock{run_mutex_};
         auto its_result = run_condition_.wait_for(its_lock, std::chrono::milliseconds(5000));
         if (its_result == std::cv_status::timeout)
             return;

--- a/test/network_tests/someip_tp_tests/someip_tp_test_msg_sender.cpp
+++ b/test/network_tests/someip_tp_tests/someip_tp_test_msg_sender.cpp
@@ -553,7 +553,7 @@ TEST_P(someip_tp, send_in_mode) {
             // send SOMEI-TP message fragmented into 6 parts to service:
             boost::asio::ip::udp::socket::endpoint_type target_service(address_remote_, 30001);
 
-            std::unique_lock<std::mutex> its_lock(all_fragments_received_mutex_);
+            std::unique_lock its_lock{all_fragments_received_mutex_};
             for (const order_e mode : {order_e::ASCENDING, order_e::DESCENDING}) {
                 create_fragments(someip_tp_test::number_of_fragments, someip_tp_test::service.service_id,
                                  someip_tp_test::service.instance_id, someip_tp_test::service.method_id,
@@ -832,7 +832,7 @@ TEST_P(someip_tp, send_in_mode) {
     });
 
     std::mutex all_fragments_received_as_server_mutex_;
-    std::unique_lock<std::mutex> all_fragments_received_as_server_lock(all_fragments_received_as_server_mutex_);
+    std::unique_lock all_fragments_received_as_server_lock{all_fragments_received_as_server_mutex_};
     std::condition_variable all_fragments_received_as_server_cond_;
     std::atomic<bool> wait_for_all_fragments_received_as_server_(true);
     std::atomic<std::uint16_t> remote_client_request_port(0);


### PR DESCRIPTION
Removes the explicit templates on all `std::unique_lock` constructions.

This was a requested change in some of my other WIP PRs, so consolidated the changes here.