### PR TITLE
Fix all missing <cstdint> includes

### DIFF
--- a/implementation/plugin/include/plugin_manager_impl.hpp
+++ b/implementation/plugin/include/plugin_manager_impl.hpp
@@ -12,6 +12,7 @@
 #include <chrono>
 #include <mutex>
 #include <set>
+#include <cstdint>
 
 #include <vsomeip/constants.hpp>
 #include <vsomeip/export.hpp>

--- a/interface/vsomeip/plugin.hpp
+++ b/interface/vsomeip/plugin.hpp
@@ -8,6 +8,7 @@
 
 #include <memory>
 #include <string>
+#include <cstdint>
 
 #if _WIN32
     #if VSOMEIP_DLL_COMPILATION_PLUGIN

--- a/interface/vsomeip/plugins/application_plugin.hpp
+++ b/interface/vsomeip/plugins/application_plugin.hpp
@@ -10,6 +10,7 @@
 #include <memory>
 
 #include <vsomeip/export.hpp>
+#include <cstdint>
 
 // Version should be incremented on breaking API change
 #define VSOMEIP_APPLICATION_PLUGIN_VERSION              1


### PR DESCRIPTION
Fails to compile on newer gcc compiler versions because of this missing include