### PR TITLE
fix github actions

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -55,10 +55,9 @@ jobs:
           boost_version: 1.83.0
           platform: windows
           boost_install_dir: C:\runner
-          link: static  
           toolset: msvc
           arch: x86
-          cache: false
+          cache: true
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
CI windows builds were failing. 

https://github.com/MarkusJx/install-boost/pull/88 
this PR solves it.
Changing for the commit with the change, and eventually
 it will be updated to a new version when it is released.