### PR TITLE
Update asio_socket_factory.cpp

### DIFF
--- a/implementation/endpoints/src/asio_socket_factory.cpp
+++ b/implementation/endpoints/src/asio_socket_factory.cpp
@@ -24,4 +24,4 @@ std::unique_ptr<tcp_socket> asio_socket_factory::create_tcp_socket(boost::asio::
 std::unique_ptr<tcp_acceptor> asio_socket_factory::create_tcp_acceptor(boost::asio::io_context& _io) {
     return std::make_unique<asio_tcp_acceptor>(_io);
 }
-};
+}


### PR DESCRIPTION
removing semi-colon at the end
for compiling because there is a flag in the cmakelists that take the warning as an error:

```
/asio_socket_factory.cpp:27:2: error: extra ‘;’ [-Werror=pedantic]
   27 | };
      |  ^
```