### PR TITLE
bump github checkout-action v5

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -21,7 +21,7 @@ jobs:
           arch: x86
           cache: true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: install dependencies
         run: |
@@ -59,7 +59,7 @@ jobs:
           arch: x86
           cache: true
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Run CMake
         run: cmake -Bbuild -D BOOST_ROOT=C:\runner\boost/boost\ .


### PR DESCRIPTION
This update is recommended due to upgrade of node.js.