### PR TITLE
cached_event_tests/CMakeLists.txt: update cmake_minimum_required

### DIFF
--- a/test/network_tests/cached_event_tests/CMakeLists.txt
+++ b/test/network_tests/cached_event_tests/CMakeLists.txt
@@ -3,7 +3,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.4...3.22)
 
 # Configure necessary files into the build folder.
 set(configuration_files


### PR DESCRIPTION
Update cmake_minimum_required to make it consistent with the others.

Fix configuration error in higher versions of CMake: CMake Error at test/network_tests/cached_event_tests/CMakeLists.txt:6 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake.

  Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
  to tell CMake that the project requires at least <min> but has been updated
  to work with policies introduced by <max> or earlier.