### PR TITLE
Fix syntax error in routing_manager_stub.cpp

### DIFF
--- a/implementation/routing/src/routing_manager_stub.cpp
+++ b/implementation/routing/src/routing_manager_stub.cpp
@@ -682,7 +682,7 @@ void routing_manager_stub::add_known_client(client_t _client, const std::string&
 
 client_t routing_manager_stub::get_guest_by_address(const boost::asio::ip::address& _address, port_t _port) const {
     return host_->get_guest_by_address(_address, _port);
-};
+}
 
 void routing_manager_stub::add_guest(client_t _client, const boost::asio::ip::address& _address, port_t _port) {
     host_->add_guest(_client, _address, _port);


### PR DESCRIPTION
vsomeip/implementation/routing/src/routing_manager_stub.cpp:685:2: error: extra ‘;’ [-Werror=pedantic]
  685 | };
      |  ^
cc1plus: error: unrecognized command line option ‘-Wno-inconsistent-missing-override’ [-Werror] cc1plus: error: unrecognized command line option ‘-Wno-tsan’ [-Werror] cc1plus: all warnings being treated as errors


fix build error