### PR TITLE
Add boost::stacktrace to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,8 +188,14 @@ add_definitions(-DVSOMEIP_INTERNAL_SUPPRESS_DEPRECATED)
 # Threads
 find_package(Threads REQUIRED)
 
-# Boost
-find_package( Boost 1.66 COMPONENTS system thread filesystem REQUIRED )
+# Boost: once this is pushed passed 1.70, it should be found using CONFIG rather
+# than CMake's FindBoost module, see policy CMP0167
+find_package(
+  Boost 1.66 REQUIRED
+  COMPONENTS system thread filesystem
+  OPTIONAL_COMPONENTS stacktrace
+)
+
 if(${CMAKE_SYSTEM_NAME} MATCHES "QNX")
     include_directories(${Boost_INCLUDE_DIR} )
 else()
@@ -351,7 +357,7 @@ target_include_directories(${VSOMEIP_NAME} INTERFACE
 # them (which shouldn't be required). ${Boost_LIBRARIES} includes absolute
 # build host paths as of writing, which also makes this important as it breaks
 # the build.
-target_link_libraries(${VSOMEIP_NAME} PRIVATE ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${DLT_LIBRARIES} ${SystemD_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${VSOMEIP_NAME} PRIVATE ${Boost_LIBRARIES} $<$<TARGET_EXISTS:Boost::stacktrace>:Boost::stacktrace> ${USE_RT} ${DL_LIBRARY} ${DLT_LIBRARIES} ${SystemD_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 if(NOT WIN32)
     target_link_options(${VSOMEIP_NAME} PRIVATE "LINKER:-as-needed")


### PR DESCRIPTION
bd87dea0 added an include to boost/stacktrace into wrappers.  While this include is likely to work because this is brought in by Boost::system, this commit makes this include more specific by adding a proper link to it in the main CMake file.