### PR TITLE
Implement slog2 logging

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,7 +351,7 @@ target_include_directories(${VSOMEIP_NAME} INTERFACE
 # them (which shouldn't be required). ${Boost_LIBRARIES} includes absolute
 # build host paths as of writing, which also makes this important as it breaks
 # the build.
-target_link_libraries(${VSOMEIP_NAME} PRIVATE ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${DLT_LIBRARIES} ${SystemD_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(${VSOMEIP_NAME} PRIVATE ${Boost_LIBRARIES} ${USE_RT} ${DL_LIBRARY} ${DLT_LIBRARIES} $<$<PLATFORM_ID:QNX>:slog2> ${SystemD_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
 
 if(NOT WIN32)
     target_link_options(${VSOMEIP_NAME} PRIVATE "LINKER:-as-needed")

--- a/implementation/configuration/include/configuration.hpp
+++ b/implementation/configuration/include/configuration.hpp
@@ -73,6 +73,7 @@ public:
     virtual bool is_v6() const = 0;
 
     virtual bool has_console_log() const = 0;
+    virtual bool has_slog2_log() const = 0;
     virtual bool has_file_log() const = 0;
     virtual bool has_dlt_log() const = 0;
     virtual const std::string& get_logfile() const = 0;

--- a/implementation/configuration/include/configuration_impl.hpp
+++ b/implementation/configuration/include/configuration_impl.hpp
@@ -89,6 +89,7 @@ public:
     VSOMEIP_EXPORT bool is_v6() const;
 
     VSOMEIP_EXPORT bool has_console_log() const;
+    VSOMEIP_EXPORT bool has_slog2_log() const;
     VSOMEIP_EXPORT bool has_file_log() const;
     VSOMEIP_EXPORT bool has_dlt_log() const;
     VSOMEIP_EXPORT const std::string& get_logfile() const;
@@ -444,6 +445,7 @@ protected:
     diagnosis_t diagnosis_mask_;
 
     std::atomic_bool has_console_log_;
+    std::atomic_bool has_slog2_log_;
     std::atomic_bool has_file_log_;
     std::atomic_bool has_dlt_log_;
     std::string logfile_;
@@ -517,6 +519,7 @@ protected:
         ET_LOGGING_CONSOLE,
         ET_LOGGING_FILE,
         ET_LOGGING_DLT,
+        ET_LOGGING_SLOG2,
         ET_LOGGING_LEVEL,
         ET_ROUTING,
         ET_SERVICE_DISCOVERY_ENABLE,

--- a/implementation/configuration/src/configuration_impl.cpp
+++ b/implementation/configuration/src/configuration_impl.cpp
@@ -47,7 +47,13 @@ namespace cfg {
 
 configuration_impl::configuration_impl(const std::string& _path) :
     default_unicast_{"local"}, is_loaded_{false}, is_logging_loaded_{false}, prefix_{VSOMEIP_PREFIX}, diagnosis_{VSOMEIP_DIAGNOSIS_ADDRESS},
-    diagnosis_mask_{0xFF00}, has_console_log_{true}, has_file_log_{false}, has_dlt_log_{false}, logfile_{"/tmp/vsomeip.log"},
+    diagnosis_mask_{0xFF00}, has_console_log_{true},
+#ifdef __QNX__
+    has_slog2_log_{true},
+#else
+    has_slog2_log_{false},
+#endif
+    has_file_log_{false}, has_dlt_log_{false}, logfile_{"/tmp/vsomeip.log"},
     loglevel_{vsomeip_v3::logger::level_e::LL_INFO}, is_sd_enabled_{VSOMEIP_SD_DEFAULT_ENABLED}, sd_protocol_{VSOMEIP_SD_DEFAULT_PROTOCOL},
     sd_multicast_{VSOMEIP_SD_DEFAULT_MULTICAST}, sd_port_{VSOMEIP_SD_DEFAULT_PORT},
     sd_initial_delay_min_{VSOMEIP_SD_DEFAULT_INITIAL_DELAY_MIN}, sd_initial_delay_max_{VSOMEIP_SD_DEFAULT_INITIAL_DELAY_MAX},
@@ -98,7 +104,7 @@ configuration_impl::configuration_impl(const std::string& _path) :
 configuration_impl::configuration_impl(const configuration_impl& _other) :
     std::enable_shared_from_this<configuration_impl>(_other), default_unicast_{_other.default_unicast_}, is_loaded_{_other.is_loaded_},
     is_logging_loaded_{_other.is_logging_loaded_}, mandatory_{_other.mandatory_}, has_console_log_{_other.has_console_log_.load()},
-    has_file_log_{_other.has_file_log_.load()}, has_dlt_log_{_other.has_dlt_log_.load()},
+    has_slog2_log_{_other.has_slog2_log_.load()}, has_file_log_{_other.has_file_log_.load()}, has_dlt_log_{_other.has_dlt_log_.load()},
     max_configured_message_size_{_other.max_configured_message_size_}, max_local_message_size_{_other.max_local_message_size_},
     max_reliable_message_size_{_other.max_reliable_message_size_}, max_unreliable_message_size_{_other.max_unreliable_message_size_},
     buffer_shrink_threshold_{_other.buffer_shrink_threshold_}, permissions_uds_{VSOMEIP_DEFAULT_UDS_PERMISSIONS},
@@ -595,6 +601,15 @@ bool configuration_impl::load_logging(const configuration_element& _element, std
                     is_configured_[ET_LOGGING_DLT] = true;
                 }
 #endif
+            } else if (its_key == "slog2") {
+                if (is_configured_[ET_LOGGING_SLOG2]) {
+                    _warnings.insert("Multiple definitions for logging.slog2."
+                            " Ignoring definition from " + _element.name_);
+                } else {
+                    std::string its_value(i->second.data());
+                    has_slog2_log_ = (its_value == "true");
+                    is_configured_[ET_LOGGING_SLOG2] = true;
+                }
             } else if (its_key == "level") {
                 if (is_configured_[ET_LOGGING_LEVEL]) {
                     _warnings.insert("Multiple definitions for logging.level."
@@ -2784,6 +2799,10 @@ bool configuration_impl::has_console_log() const {
     return has_console_log_;
 }
 
+bool configuration_impl::has_slog2_log() const {
+    return has_slog2_log_;
+}
+
 bool configuration_impl::has_file_log() const {
     return has_file_log_;
 }
@@ -2797,7 +2816,7 @@ const std::string& configuration_impl::get_logfile() const {
 }
 
 vsomeip_v3::logger::level_e configuration_impl::get_loglevel() const {
-    std::unique_lock<std::mutex> its_lock(mutex_loglevel_);
+    std::unique_lock its_lock(mutex_loglevel_);
     return loglevel_;
 }
 

--- a/implementation/logger/include/logger_impl.hpp
+++ b/implementation/logger/include/logger_impl.hpp
@@ -36,6 +36,7 @@ public:
     // alignas(4) to work around a bug in ancient MSVC15 which for some reason we still support...
     struct alignas(4) config {
         bool console_enabled;
+        bool slog2_enabled;
         bool dlt_enabled;
         bool file_enabled;
         level_e loglevel;
@@ -45,6 +46,7 @@ public:
     config get_configuration() const;
 
     void log_to_file(std::string_view _msg);
+    void log_to_slog2(level_e _level, std::string_view _msg);
 
 #ifdef USE_DLT
 #ifndef ANDROID
@@ -58,6 +60,17 @@ private:
 
     std::mutex log_file_mutex_;
     std::ofstream log_file_;
+    std::string app_name_;
+
+#ifdef __QNX__
+    // Flag whether slog2 was successfully initialized.
+    bool slog2_is_initialized_ = false;
+
+    static slog2_buffer_set_config_t   buffer_config;
+    static slog2_buffer_t              buffer_handle[1];
+    static std::uint8_t levelAsSlog2(level_e const _level);
+#endif
+    auto init_slog2(const std::shared_ptr<configuration>& _configuration) -> void;
 };
 
 } // namespace logger

--- a/implementation/logger/src/logger_impl.cpp
+++ b/implementation/logger/src/logger_impl.cpp
@@ -5,16 +5,30 @@
 
 #include <vsomeip/runtime.hpp>
 
+#ifdef __QNX__
+#include <sys/slog2.h>
+extern char * __progname;
+#elif __linux__
+extern char * __progname;
+#endif
+
 #include "../include/logger_impl.hpp"
 #include "../../configuration/include/configuration.hpp"
 
 namespace vsomeip_v3 {
 namespace logger {
 
-logger_impl::logger_impl() : config_{{false, false, false, level_e::LL_NONE}} { }
+logger_impl::logger_impl() : config_{{false, false, false, false, level_e::LL_NONE}} { }
+
+#ifdef __QNX__
+slog2_buffer_set_config_t   logger_impl::buffer_config = {0, "main", SLOG2_INFO, {"main", 4}, 1};
+slog2_buffer_t              logger_impl::buffer_handle[1] = {0};
+#endif
 
 void logger_impl::init(const std::shared_ptr<configuration>& _configuration) {
     logger_impl::get()->set_configuration(_configuration);
+
+    logger_impl::get()->init_slog2(_configuration);
 }
 
 logger_impl::config logger_impl::get_configuration() const {
@@ -27,6 +41,7 @@ void logger_impl::set_configuration(const std::shared_ptr<configuration>& _confi
         config cfg; // NOLINT(cppcoreguidelines-pro-type-member-init)
         cfg.loglevel = _configuration->get_loglevel();
         cfg.console_enabled = _configuration->has_console_log();
+        cfg.slog2_enabled = _configuration->has_slog2_log();
         cfg.dlt_enabled = _configuration->has_dlt_log();
         {
             std::scoped_lock its_lock{log_file_mutex_};
@@ -44,6 +59,62 @@ void logger_impl::log_to_file(std::string_view _msg) {
     if (log_file_.is_open()) {
         log_file_ << _msg;
     }
+}
+
+auto logger_impl::init_slog2(const std::shared_ptr<configuration>& _configuration) -> void {
+#ifdef __QNX__
+    if (slog2_is_initialized_ || !_configuration)
+        return;
+
+    logger_impl::buffer_config.buffer_set_name = __progname;
+    logger_impl::buffer_config.num_buffers = 1;
+    logger_impl::buffer_config.verbosity_level = log_level_as_slog2(_configuration->get_loglevel());
+
+    // Use a 16kB log buffer by default
+    // Override with a size specified by environment variable
+    int num_pages = 4;
+    auto s = getenv("VSOMEIP_SLOG2_NUM_PAGES");
+    if (s != nullptr) {
+        char* endptr = nullptr;
+        errno = 0;
+        auto const tmp_num_pages = strtoul(s, &endptr, 0);
+
+        // Safety checks
+        auto const at_least_one_digit_matched = endptr != s;
+        auto const input_is_terminated = *endptr == '\0';
+        auto const no_error = errno == 0;
+        auto const within_range = tmp_num_pages > 0 && tmp_num_pages < 1024; // 1024 pages = 4MB, hard to imagine this not being enough
+
+        if (at_least_one_digit_matched && input_is_terminated && no_error && within_range) {
+            num_pages = static_cast<decltype(num_pages)>(tmp_num_pages);
+        }
+    }
+
+    logger_impl::buffer_config.buffer_config[0].buffer_name = "vsomeip";
+    logger_impl::buffer_config.buffer_config[0].num_pages = num_pages;
+
+    // Register the buffer set.
+    if (-1 == slog2_register(&logger_impl::buffer_config, logger_impl::buffer_handle, 0)) {
+        std::fprintf(stderr, "Error registering slogger2 buffer!\n");
+        return;
+    } else {
+        slog2_is_initialized_ = true;
+    }
+#else
+    static_cast<void>(_configuration);
+#endif
+}
+
+void logger_impl::log_to_slog2(level_e _level, std::string_view _msg) {
+#ifdef __QNX__
+    auto const handle = logger_impl::buffer_handle[0];
+    auto const user_code = 0;
+
+    slog2c(handle, user_code, log_level_as_slog2(_level), _msg.data());
+#else
+    static_cast<void>(_level);
+    static_cast<void>(_msg);
+#endif
 }
 
 #ifdef USE_DLT

--- a/interface/vsomeip/internal/logger.hpp
+++ b/interface/vsomeip/internal/logger.hpp
@@ -13,6 +13,10 @@
 #include <string_view>
 #include <vector>
 
+#ifdef __QNX__
+#include <sys/slog2.h>
+#endif
+
 #include <vsomeip/export.hpp>
 
 namespace vsomeip_v3 {
@@ -27,6 +31,35 @@ enum class VSOMEIP_IMPORT_EXPORT level_e : std::uint8_t {
     LL_DEBUG = 5,
     LL_VERBOSE = 6
 };
+
+#ifdef __QNX__
+inline constexpr auto log_level_as_slog2(level_e const _level) -> std::uint8_t
+{
+    uint8_t severity = 0;
+    switch (_level) {
+    case level_e::LL_FATAL:
+        severity = SLOG2_CRITICAL;
+        break;
+    case level_e::LL_ERROR:
+        severity = SLOG2_ERROR;
+        break;
+    case level_e::LL_WARNING:
+        severity = SLOG2_WARNING;
+        break;
+    case level_e::LL_INFO:
+        severity = SLOG2_INFO;
+        break;
+    case level_e::LL_DEBUG:
+        severity = SLOG2_DEBUG1;
+        break;
+    case level_e::LL_VERBOSE:
+    default:
+        severity = SLOG2_DEBUG2;
+        break;
+    }
+    return severity;
+}
+#endif
 
 class message : public std::ostream {
 public:
@@ -55,7 +88,9 @@ private:
 
     buffer buffer_;
     const level_e level_;
+    level_e threshold_level_;
     bool console_enabled_{false};
+    bool slog2_enabled_{false};
     bool dlt_enabled_{false};
     bool file_enabled_{false};
     std::chrono::system_clock::time_point when_;


### PR DESCRIPTION
slog2 is enabled by default, but guarded with `#ifdef __QNX__`. It can be controlled with /etc/vsomeip/logging.json, _i.e._:

```json
"logging": {
  "slog2": true
}
```

This code allocates 4 pages (16kB) by default, but the caller can provide an environment variable `VSOMEIP_SLOG2_NUM_PAGES` to control the allocation