### PR TITLE
Fixing unsetting payload log message formatting

### DIFF
--- a/implementation/routing/src/routing_manager_base.cpp
+++ b/implementation/routing/src/routing_manager_base.cpp
@@ -263,7 +263,7 @@ void routing_manager_base::stop_offer_service(client_t _client, service_t _servi
     for (auto& e : events) {
         if (e.second->is_set()) {
             VSOMEIP_INFO << "rmb::" << __func__ << " unsetting payload for [" << std::hex << std::setfill('0') << std::setw(4) << _service
-                         << "." << _instance << "." << e.first;
+                         << "." << _instance << "." << e.first << "]";
         }
         e.second->unset_payload();
         e.second->clear_subscribers();
@@ -360,7 +360,7 @@ void routing_manager_base::register_event(client_t _client, service_t _service, 
                 // don't cache payload for non-fields
                 if (its_event->is_set()) {
                     VSOMEIP_INFO << "rmb::" << __func__ << " unsetting payload for [" << std::hex << std::setfill('0') << std::setw(4)
-                                 << _service << "." << _instance << "." << its_event;
+                                 << _service << "." << _instance << "." << its_event << "]";
                 }
                 its_event->unset_payload(true);
             }
@@ -879,7 +879,7 @@ void routing_manager_base::unset_all_eventpayloads(service_t _service, instance_
     for (const auto& e : its_events) {
         if (e->is_set()) {
             VSOMEIP_INFO << "rmb::" << __func__ << " unsetting payload for [" << std::hex << std::setfill('0') << std::setw(4) << _service
-                         << "." << _instance << "." << e->get_event();
+                         << "." << _instance << "." << e->get_event() << "]";
         }
         e->unset_payload(true);
     }
@@ -904,7 +904,7 @@ void routing_manager_base::unset_all_eventpayloads(service_t _service, instance_
     for (const auto& e : its_events) {
         if (e->is_set()) {
             VSOMEIP_INFO << "rmb::" << __func__ << " unsetting payload for [" << std::hex << std::setfill('0') << std::setw(4) << _service
-                         << "." << _instance << "." << e->get_event();
+                         << "." << _instance << "." << e->get_event() << "]";
         }
         e->unset_payload(true);
     }

--- a/implementation/routing/src/routing_manager_client.cpp
+++ b/implementation/routing/src/routing_manager_client.cpp
@@ -2200,7 +2200,7 @@ void routing_manager_client::on_stop_offer_service(service_t _service, instance_
     for (auto& e : events) {
         if (e.second->is_set()) {
             VSOMEIP_INFO << "rmc::" << __func__ << " unsetting payload for [" << std::hex << std::setfill('0') << std::setw(4) << _service
-                         << "." << _instance << "." << e.first;
+                         << "." << _instance << "." << e.first << "]";
         }
         e.second->unset_payload();
     }

--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -598,7 +598,7 @@ void routing_manager_impl::release_service(client_t _client, service_t _service,
                     for (const auto& e : its_events) {
                         if (e->is_set()) {
                             VSOMEIP_INFO << "rmi::" << __func__ << " unsetting payload for [" << std::hex << std::setfill('0')
-                                         << std::setw(4) << _service << "." << _instance << "." << e->get_event();
+                                         << std::setw(4) << _service << "." << _instance << "." << e->get_event() << "]";
                         }
                         e->unset_payload(true);
                     }
@@ -2281,7 +2281,7 @@ void routing_manager_impl::del_routing_info(service_t _service, instance_t _inst
     for (const auto& e : its_events) {
         if (e->is_set()) {
             VSOMEIP_INFO << "rmi::" << __func__ << " unsetting payload for [" << std::hex << std::setfill('0') << std::setw(4) << _service
-                         << "." << _instance << "." << e->get_event();
+                         << "." << _instance << "." << e->get_event() << "]";
         }
         e->unset_payload(true);
     }
@@ -2901,7 +2901,7 @@ std::chrono::steady_clock::time_point routing_manager_impl::expire_subscriptions
                             if (!has_remote_subscriber && its_event->is_shadow()) {
                                 if (its_event->is_set()) {
                                     VSOMEIP_INFO << "rmi::" << __func__ << " unsetting payload for [" << std::hex << std::setfill('0')
-                                                 << std::setw(4) << its_service << "." << its_instance << "." << its_event->get_event();
+                                                 << std::setw(4) << its_service << "." << its_instance << "." << its_event->get_event() << "]";
                                 }
                                 its_event->unset_payload();
                             }
@@ -3781,7 +3781,7 @@ void routing_manager_impl::clear_targets_and_pending_sub_from_eventgroups(servic
     for (const auto& e : its_events) {
         if (e->is_set()) {
             VSOMEIP_INFO << "rmi::" << __func__ << " unsetting payload for [" << std::hex << std::setfill('0') << std::setw(4) << _service
-                         << "." << _instance << "." << e->get_event();
+                         << "." << _instance << "." << e->get_event() << "]";
         }
         e->unset_payload(true);
     }
@@ -4003,7 +4003,7 @@ void routing_manager_impl::on_unsubscribe_ack(client_t _client, service_t _servi
                     if (!has_remote_subscriber && its_event->is_shadow()) {
                         if (its_event->is_set()) {
                             VSOMEIP_INFO << "rmi::" << __func__ << " unsetting payload for [" << std::hex << std::setfill('0')
-                                         << std::setw(4) << _service << "." << _instance << "." << its_event->get_event();
+                                         << std::setw(4) << _service << "." << _instance << "." << its_event->get_event() << "]";
                         }
                         its_event->unset_payload();
                     }


### PR DESCRIPTION
Fixing the formatting of the message from:
  - "add logs when unsetting payload"
  - tree d5503ca041747bbc059e547d82d18c780f61d37c
  - parent a4aacb5f1cea63ba017a457ee2698ee0e3e728f6

Each message was missing a closing square bracket