### PR TITLE
Change data assignment to copy instead of move

### DIFF
--- a/implementation/message/src/deserializer.cpp
+++ b/implementation/message/src/deserializer.cpp
@@ -176,7 +176,7 @@ void deserializer::set_data(const byte_t* _data, std::size_t _length) {
 
 void deserializer::set_data(const std::vector<byte_t>& _data) {
 
-    data_ = std::move(_data);
+    data_ = _data;
     position_ = data_.begin();
     remaining_ = data_.size();
 }


### PR DESCRIPTION
A move operation has no effect on const variables.