### PR TITLE
Fix syntax error in routing_manager_stub.cpp (#980)

### DIFF
--- a/implementation/routing/src/routing_manager_stub.cpp
+++ b/implementation/routing/src/routing_manager_stub.cpp
@@ -682,7 +682,7 @@ void routing_manager_stub::add_known_client(client_t _client, const std::string&
 
 client_t routing_manager_stub::get_guest_by_address(const boost::asio::ip::address& _address, port_t _port) const {
     return host_->get_guest_by_address(_address, _port);
-};
+}
 
 void routing_manager_stub::add_guest(client_t _client, const boost::asio::ip::address& _address, port_t _port) {
     host_->add_guest(_client, _address, _port);


### PR DESCRIPTION
Summary
Fix syntax error in routing_manager_stub.cpp
Details
Remove unnecessary colons after curly braces in routing_manager_stub.cpp