### PR TITLE
Fix vsomeip Service Discovery on QNX8 and clang formatting

### DIFF
--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -3464,6 +3464,10 @@ void routing_manager_impl::on_net_interface_or_route_state_changed(bool _is_inte
 void routing_manager_impl::start_ip_routing() {
 #if defined(_WIN32) || defined(__QNX__)
     if_state_running_ = true;
+    sd_route_set_ = true;
+    // QNX: Process any pending service offers now that routing is ready
+    // (On Linux, this is done via on_net_interface_or_route_state_changed)
+    init_pending_services();
 #endif
 
     if (routing_ready_handler_) {
@@ -3899,7 +3903,7 @@ void routing_manager_impl::memory_log_timer_cbk(boost::system::error_code const&
 
     if (EOF
         == std::fscanf(its_file, "%lu %lu %lu %lu %lu %lu %lu", &its_size, &its_rsssize, &its_sharedpages, &its_text, &its_lib, &its_data,
-                    &its_dirtypages)) {
+                       &its_dirtypages)) {
         VSOMEIP_ERROR << "memory_log_timer_cbk: error reading: errno " << errno;
     }
     std::fclose(its_file);


### PR DESCRIPTION
When comparing the docker run in linux with qnx8 run using qemu has been observed that the service discovery was not working between the 2 QEMU instances 
Each QEMU instance is offering and subscribing to the other qemu offered service.
Since i have no knwoledge about this repository file structure and the location where the patch is needed to realise this 
- i have compared linux logs of vsomeip with qnx logs of vsomeip and based on the difference, that the linux version was displaying the network interface used by the vsomeip , i have found the code location

For testing the patch i have used tcp dump on the bridge network between the 2 qemu instances . Then i analysed the pcap file to find that the announcement for offered services is on the bus and that each qemu instance subscribed to each other succesfully