### PR TITLE
fix: clock type mismatch and duration cast unit in test_timer_t

### DIFF
--- a/test/common/include/common/test_timer.hpp
+++ b/test/common/include/common/test_timer.hpp
@@ -17,12 +17,12 @@ public:
 
     bool has_elapsed() {
         const auto current = std::chrono::high_resolution_clock::now();
-        return target <= std::chrono::duration_cast<std::chrono::seconds>(current - start);
+        return target <= std::chrono::duration_cast<std::chrono::milliseconds>(current - start);
     }
 
 private:
     std::chrono::milliseconds target;
-    std::chrono::system_clock::time_point start;
+    std::chrono::high_resolution_clock::time_point start;
 };
 } // namespace common
 


### PR DESCRIPTION
Fixes #821

Two bugs in `test/common/include/common/test_timer.hpp`:

**Bug 1 — Clock type mismatch (compile error on Android/Clang)**

`start` is declared as `std::chrono::system_clock::time_point` but initialized
via `std::chrono::high_resolution_clock::now()` in both constructors.

On platforms where `high_resolution_clock` is not an alias for `system_clock`
(Android x86_64 with Clang, MSVC), this fails with:
> no matching constructor for initialization of 'std::chrono::system_clock::time_point'

Fix: change the member type to `std::chrono::high_resolution_clock::time_point`,
consistent with the initialization expression already present.

**Bug 2 — Duration cast to wrong unit (logic error)**

`has_elapsed()` casts the elapsed duration to `std::chrono::seconds` before
comparing against `target`, which is `std::chrono::milliseconds`. For sub-second
timers the cast always produces `seconds(0)`, causing the timer to fire immediately
regardless of the target interval.

Fix: change `duration_cast<std::chrono::seconds>` to
`duration_cast<std::chrono::milliseconds>`.

Both fixes are single-line changes in the same header. No production code
is affected. No new includes or dependencies.