### PR TITLE
fix: set check_routing_credentials_ in set_routing_credentials() (#1016)

### DIFF
--- a/implementation/security/src/policy_manager_impl.cpp
+++ b/implementation/security/src/policy_manager_impl.cpp
@@ -175,6 +175,7 @@ void policy_manager_impl::set_routing_credentials(uid_t _uid, gid_t _gid, const 
                         << " Ignoring definition from " << _name;
     } else {
         routing_credentials_ = std::make_pair(_uid, _gid);
+        check_routing_credentials_ = true;
         is_configured_ = true;
     }
 }


### PR DESCRIPTION
## Summary

Fixes the security bypass reported in issue #1016.

### Root Cause

When routing credentials are configured using the current (non-deprecated) format:

```json
{
  "routing": {
    "host": {
      "uid": "1000",
      "gid": "1000"
    }
  }
}
```

the configuration loader calls `policy_manager_impl::set_routing_credentials()` to store the UID/GID pair. However, `set_routing_credentials()` did not set `check_routing_credentials_` to `true`.

Because `check_routing_credentials_` remains `false`, `check_routing_credentials()` evaluates:

```cpp
if (!check_routing_credentials_) {
    // audit mode text ...
}
return !check_routing_credentials_; // returns true — connection allowed
```

Any connecting application is allowed regardless of its actual UID/GID. The configuration is silently treated as audit mode.

### Comparison with deprecated format

The deprecated format (`/routing-credentials/uid+gid`) is handled by `load_routing_credentials()` in `policy_manager_impl.cpp`, which correctly sets `check_routing_credentials_ = true` after storing the credential pair (line 858). The new-format path (`set_routing_credentials()`) did not, creating a silent behavioural asymmetry between the two config paths.

### Fix

One line added to `set_routing_credentials()`:

```diff
     routing_credentials_ = std::make_pair(_uid, _gid);
+    check_routing_credentials_ = true;
     is_configured_ = true;
```

This makes both configuration paths enforce credentials identically.

## Files changed

`implementation/security/src/policy_manager_impl.cpp` — 1 file, +1 line

## Security framing

- CWE-284 (Improper Access Control)
- Affected: all releases where `/routing/host/uid+gid` format is supported
- Impact: any application can connect to the routing manager regardless of configured credentials when using the current config format

Closes #1016

Signed-off-by: Akihiko Komada <aki1770@gmail.com>