### PR TITLE
fix: cap TCP recv buffer size to prevent unbounded allocation (#1009)

### DIFF
--- a/implementation/configuration/src/configuration_impl.cpp
+++ b/implementation/configuration/src/configuration_impl.cpp
@@ -3453,7 +3453,7 @@ std::uint32_t configuration_impl::get_max_message_size_reliable(const std::strin
             return its_port->second;
         }
     }
-    return (max_reliable_message_size_ == 0) ? ((VSOMEIP_MAX_TCP_MESSAGE_SIZE == 0) ? MESSAGE_SIZE_UNLIMITED : VSOMEIP_MAX_TCP_MESSAGE_SIZE)
+    return (max_reliable_message_size_ == 0) ? ((VSOMEIP_MAX_TCP_MESSAGE_SIZE == 0) ? VSOMEIP_MAX_TCP_MESSAGE_SIZE_DEFAULT : VSOMEIP_MAX_TCP_MESSAGE_SIZE)
                                              : max_reliable_message_size_;
 }
 

--- a/implementation/endpoints/src/tcp_server_endpoint_impl.cpp
+++ b/implementation/endpoints/src/tcp_server_endpoint_impl.cpp
@@ -677,7 +677,7 @@ void tcp_server_endpoint_impl::connection::receive_cbk(boost::system::error_code
                         its_lock.unlock();
                         wait_until_sent(boost::asio::error::operation_aborted);
                         return;
-                    } else if (max_message_size_ != MESSAGE_SIZE_UNLIMITED && current_message_size > max_message_size_) {
+                    } else if (current_message_size > max_message_size_) {
                         recv_buffer_size_ = 0;
                         recv_buffer_.resize(recv_buffer_size_initial_, 0x0);
                         recv_buffer_.shrink_to_fit();

--- a/interface/vsomeip/defines.hpp
+++ b/interface/vsomeip/defines.hpp
@@ -14,6 +14,12 @@ constexpr std::uint8_t VSOMEIP_PROTOCOL_VERSION = 0x1;
 constexpr std::size_t VSOMEIP_MAX_LOCAL_MESSAGE_SIZE = 0;
 // 0 = unlimited, if not specified otherwise via configuration file
 constexpr std::size_t VSOMEIP_MAX_TCP_MESSAGE_SIZE = 0;
+// Safe default cap for TCP receive buffer when neither VSOMEIP_MAX_TCP_MESSAGE_SIZE
+// nor the runtime "max-message-size-reliable" JSON option is set.  Prevents unbounded
+// heap growth from an attacker-supplied SOME/IP Length field (CWE-789, issue #1009).
+// Operators who genuinely need larger messages should set max-message-size-reliable
+// in their vsomeip configuration file.
+constexpr std::uint32_t VSOMEIP_MAX_TCP_MESSAGE_SIZE_DEFAULT = 1048576U; // 1 MiB
 constexpr std::size_t VSOMEIP_MAX_UDP_MESSAGE_SIZE = 1416;
 
 constexpr std::size_t VSOMEIP_PACKET_SIZE = VSOMEIP_MAX_UDP_MESSAGE_SIZE;


### PR DESCRIPTION
## Problem

When neither `VSOMEIP_MAX_TCP_MESSAGE_SIZE` (compile-time) nor `max-message-size-reliable` (JSON config) is set — the default for most deployments — the TCP receive buffer can grow without bound in response to an attacker-supplied SOME/IP `Length` field.

**Root cause** (two cooperating bugs):

1. `get_max_message_size_reliable()` in `configuration_impl.cpp` returns `MESSAGE_SIZE_UNLIMITED` (`UINT32_MAX`) when both `VSOMEIP_MAX_TCP_MESSAGE_SIZE == 0` and no JSON size limit is configured.

2. The size guard in `receive_cbk()` (`tcp_server_endpoint_impl.cpp`) is gated on `max_message_size_ != MESSAGE_SIZE_UNLIMITED`, making it dead code under the default configuration. When the guard is skipped, `missing_capacity_` is set to the full attacker-controlled `current_message_size`, and `receive()` allocates `recv_buffer_size_ + missing_capacity_` unconditionally.

**Attack**: A 16-byte SOME/IP header with `Length = 0x04000000` causes a ~64 MiB allocation per connection (4 194 304 : 1 amplification ratio). On an embedded automotive ECU with 512 MiB–2 GiB RAM, a handful of connections exhausts available memory → OOM kill → all SOME/IP services on that ECU go offline. CWE-789, CVSS 4.6 (Physical) rising to 7.5 if the endpoint is reachable through a T-Box or gateway.

See issue #1009 for full CVSS breakdown and data-flow trace.

## Fix

**3 files, 8 lines (+6 net)**:

| File | Change |
|------|--------|
| `interface/vsomeip/defines.hpp` | Add `VSOMEIP_MAX_TCP_MESSAGE_SIZE_DEFAULT = 1048576U` (1 MiB) — safe fallback when neither compile-time nor runtime size is configured |
| `implementation/configuration/src/configuration_impl.cpp` | Use `VSOMEIP_MAX_TCP_MESSAGE_SIZE_DEFAULT` instead of `MESSAGE_SIZE_UNLIMITED` in `get_max_message_size_reliable()` when both sources are unset |
| `implementation/endpoints/src/tcp_server_endpoint_impl.cpp` | Remove the now-unnecessary `max_message_size_ != MESSAGE_SIZE_UNLIMITED` pre-condition from the size guard in `receive_cbk()` |

After this fix, the size guard at line 680 becomes effective unconditionally. The 1 MiB default cap can be raised at any time via the `max-message-size-reliable` JSON configuration option — no recompilation required.

## Behaviour change

| Scenario | Before | After |
|----------|--------|-------|
| No JSON config, no compile-time size | `max_message_size_ = UINT32_MAX`; guard dead; recv buffer unbounded | `max_message_size_ = 1 MiB`; guard active; oversized frames close connection |
| JSON `max-message-size-reliable` set | Unchanged | Unchanged |
| Compile-time `VSOMEIP_MAX_TCP_MESSAGE_SIZE` set (non-zero) | Unchanged | Unchanged |

Deployments that already configure `max-message-size-reliable` are unaffected. Only the unconfigured default changes.

Fixes #1009.