### PR TITLE
routing: re-notify transferred subscribers on late offer_event() (#1019)

### DIFF
--- a/implementation/routing/src/routing_manager_base.cpp
+++ b/implementation/routing/src/routing_manager_base.cpp
@@ -607,6 +607,9 @@ void routing_manager_base::register_event(client_t _client, service_t _service, 
                     std::set<client_t> its_any_event_subscribers = its_any_event->get_subscribers(eventgroup);
                     for (const client_t subscriber : its_any_event_subscribers) {
                         its_event->add_subscriber(eventgroup, nullptr, subscriber, true);
+                        if (its_event->is_set()) {
+                            its_event->notify_one(subscriber, false);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Problem

When a SOME/IP provider calls `offer_service()` before all `offer_event()` calls complete, consumers that subscribe in their availability handler receive `SUBSCRIBE_ACK` before those events are registered. The `transfer_subscriptions_from_any_event` block in `register_event()` migrates subscribers from the `ANY_EVENT` placeholder via `add_subscriber()` but makes no `notify_one()` call afterward — late-registered events are silently orphaned and their values never delivered.

**Sequence:**
```
offer_service()       ← consumer availability callback fires → subscribe() → SUBSCRIBE_ACK sent
offer_event(0x8001)   ← register_event() → subscriber transferred from ANY_EVENT, no notify_one()
offer_event(0x8002)   ← same — silently orphaned
offer_event(0x800N)   ← same
```

## Fix

After transferring each subscriber to a newly-registered event, call `notify_one()` if the event already has a payload. The `is_set()` guard prevents sending uninitialized payloads for events not yet published.

```diff
--- a/implementation/routing/src/routing_manager_base.cpp
+++ b/implementation/routing/src/routing_manager_base.cpp
@@ -607,6 +607,9 @@
                     for (const client_t subscriber : its_any_event_subscribers) {
                         its_event->add_subscriber(eventgroup, nullptr, subscriber, true);
+                        if (its_event->is_set()) {
+                            its_event->notify_one(subscriber, false);
+                        }
                     }
```

## Behavior

| Path | Before | After |
|------|--------|-------|
| Normal path (`offer_event` before `offer_service`) | No `ANY_EVENT` subscribers → block not reached | Unchanged |
| Late `offer_event` with payload set | Subscriber transferred, no delivery | Transferred + current value delivered |
| Late `offer_event`, no payload yet | No delivery | Deferred to next `notify()` call |
| ET_FIELD events | Missing if late-offered | Delivered immediately if set |

The `is_set()` guard is consistent with the pattern in `notify_one_current_value()` which similarly guards on payload availability before delivery.

Fixes #1019.