### PR TITLE
sd: defer SUBSCRIBE_NACK when TCP connection not yet committed (#971)

### DIFF
--- a/implementation/service_discovery/include/service_discovery_impl.hpp
+++ b/implementation/service_discovery/include/service_discovery_impl.hpp
@@ -294,6 +294,52 @@ private:
     void check_offer_services(const boost::system::error_code& error, uint32_t _faulty_value);
 
 private:
+    // ------------------------------------------------------------------
+    // TOCTOU fix: deferred-NACK for TCP subscriptions (issue #971)
+    //
+    // When is_tcp_connected() returns false we may be in the race window
+    // between UDP SUBSCRIBE arrival and accept_cbk() committing the TCP
+    // connection into connections_.  Instead of NACKing immediately we
+    // park the subscription for 100 ms and retry once.
+    // ------------------------------------------------------------------
+    struct pending_tcp_sub_t {
+        service_t                service;
+        instance_t               instance;
+        eventgroup_t             eventgroup;
+        major_version_t          major;
+        ttl_t                    ttl;
+        uint8_t                  counter;
+        uint16_t                 reserved;
+        boost::asio::ip::address first_address;
+        uint16_t                 first_port;
+        bool                     is_first_reliable;
+        boost::asio::ip::address second_address;
+        uint16_t                 second_port;
+        bool                     is_second_reliable;
+        bool                     is_stop_subscribe_subscribe;
+        bool                     force_initial_events;
+        std::set<client_t>       clients;
+        // sd_acceptance_state_t holds a reference; store the three fields
+        // by value so the retry lambda can reconstruct the struct safely.
+        expired_ports_t          expired_ports_copy;
+        bool                     sd_ac_required;
+        bool                     sd_ac_accept;
+        std::shared_ptr<eventgroupinfo>          info;
+        boost::asio::ip::address sender;
+        std::shared_ptr<remote_subscription_ack> ack;
+    };
+
+    void retry_pending_tcp_subscription(
+        pending_tcp_sub_t                           _entry,
+        std::shared_ptr<boost::asio::steady_timer>  _timer);
+
+    std::mutex pending_tcp_subscriptions_mutex_;
+    using pending_tcp_key_t = std::tuple<service_t, instance_t, eventgroup_t,
+                                         boost::asio::ip::address, uint16_t>;
+    std::map<pending_tcp_key_t,
+             std::shared_ptr<boost::asio::steady_timer>> pending_tcp_subscriptions_;
+
+private:
     // Runtime
     std::weak_ptr<runtime> runtime_;
 

--- a/implementation/service_discovery/src/service_discovery_impl.cpp
+++ b/implementation/service_discovery/src/service_discovery_impl.cpp
@@ -2117,12 +2117,55 @@ void service_discovery_impl::handle_eventgroup_subscription(
                 its_reliable = its_subscriber;
                 // check if TCP connection is established by client
                 if (_ttl > 0 && !is_tcp_connected(_service, _instance, its_reliable)) {
-                    insert_subscription_ack(_acknowledgement, _info, 0, nullptr, _clients);
-                    // TODO: Add sender and session id
-                    VSOMEIP_ERROR << "TCP connection to target1: [" << its_reliable->get_address().to_string() << ":"
-                                  << its_reliable->get_port() << "] not established for subscription to: [" << std::hex << std::setfill('0')
-                                  << std::setw(4) << _service << "." << std::setw(4) << _instance << "." << std::setw(4) << _eventgroup
-                                  << "] ";
+                    VSOMEIP_WARNING << "TCP connection to target1: ["
+                        << its_reliable->get_address().to_string() << ":"
+                        << its_reliable->get_port()
+                        << "] not yet established for subscription to: ["
+                        << std::hex << std::setfill('0')
+                        << std::setw(4) << _service << "."
+                        << std::setw(4) << _instance << "."
+                        << std::setw(4) << _eventgroup
+                        << "] — deferring 100 ms (issue #971)";
+                    pending_tcp_sub_t entry;
+                    entry.service    = _service;    entry.instance  = _instance;
+                    entry.eventgroup = _eventgroup; entry.major     = _major;
+                    entry.ttl        = _ttl;        entry.counter   = _counter;
+                    entry.reserved   = _reserved;
+                    entry.first_address     = _first_address;
+                    entry.first_port        = _first_port;
+                    entry.is_first_reliable = _is_first_reliable;
+                    entry.second_address     = _second_address;
+                    entry.second_port        = _second_port;
+                    entry.is_second_reliable = _is_second_reliable;
+                    entry.is_stop_subscribe_subscribe = _is_stop_subscribe_subscribe;
+                    entry.force_initial_events        = _force_initial_events;
+                    entry.clients            = _clients;
+                    entry.expired_ports_copy = _sd_ac_state.expired_ports_;
+                    entry.sd_ac_required     = _sd_ac_state.sd_acceptance_required_;
+                    entry.sd_ac_accept       = _sd_ac_state.accept_entries_;
+                    entry.info   = _info;
+                    entry.sender = _sender;
+                    entry.ack    = std::make_shared<remote_subscription_ack>(_sender);
+                    auto its_timer = std::make_shared<boost::asio::steady_timer>(io_);
+                    pending_tcp_key_t key{_service, _instance, _eventgroup,
+                                          its_reliable->get_address(),
+                                          its_reliable->get_port()};
+                    {
+                        std::scoped_lock lk(pending_tcp_subscriptions_mutex_);
+                        if (auto it = pending_tcp_subscriptions_.find(key);
+                                it != pending_tcp_subscriptions_.end()) {
+                            it->second->cancel();
+                        }
+                        pending_tcp_subscriptions_[key] = its_timer;
+                    }
+                    its_timer->expires_after(std::chrono::milliseconds(100));
+                    its_timer->async_wait(
+                        [self = shared_from_this(), e = std::move(entry),
+                         t = its_timer](const boost::system::error_code& ec) mutable {
+                            if (!ec) {
+                                self->retry_pending_tcp_subscription(std::move(e), t);
+                            }
+                        });
                     return;
                 }
             } else { // udp unicast
@@ -2136,12 +2179,55 @@ void service_discovery_impl::handle_eventgroup_subscription(
                 its_reliable = its_subscriber;
                 // check if TCP connection is established by client
                 if (_ttl > 0 && !is_tcp_connected(_service, _instance, its_reliable)) {
-                    insert_subscription_ack(_acknowledgement, _info, 0, nullptr, _clients);
-                    // TODO: Add sender and session id
-                    VSOMEIP_ERROR << "TCP connection to target2 : [" << its_reliable->get_address().to_string() << ":"
-                                  << its_reliable->get_port() << "] not established for subscription to: [" << std::hex << std::setfill('0')
-                                  << std::setw(4) << _service << "." << std::setw(4) << _instance << "." << std::setw(4) << _eventgroup
-                                  << "] ";
+                    VSOMEIP_WARNING << "TCP connection to target2: ["
+                        << its_reliable->get_address().to_string() << ":"
+                        << its_reliable->get_port()
+                        << "] not yet established for subscription to: ["
+                        << std::hex << std::setfill('0')
+                        << std::setw(4) << _service << "."
+                        << std::setw(4) << _instance << "."
+                        << std::setw(4) << _eventgroup
+                        << "] — deferring 100 ms (issue #971)";
+                    pending_tcp_sub_t entry;
+                    entry.service    = _service;    entry.instance  = _instance;
+                    entry.eventgroup = _eventgroup; entry.major     = _major;
+                    entry.ttl        = _ttl;        entry.counter   = _counter;
+                    entry.reserved   = _reserved;
+                    entry.first_address     = _first_address;
+                    entry.first_port        = _first_port;
+                    entry.is_first_reliable = _is_first_reliable;
+                    entry.second_address     = _second_address;
+                    entry.second_port        = _second_port;
+                    entry.is_second_reliable = _is_second_reliable;
+                    entry.is_stop_subscribe_subscribe = _is_stop_subscribe_subscribe;
+                    entry.force_initial_events        = _force_initial_events;
+                    entry.clients            = _clients;
+                    entry.expired_ports_copy = _sd_ac_state.expired_ports_;
+                    entry.sd_ac_required     = _sd_ac_state.sd_acceptance_required_;
+                    entry.sd_ac_accept       = _sd_ac_state.accept_entries_;
+                    entry.info   = _info;
+                    entry.sender = _sender;
+                    entry.ack    = std::make_shared<remote_subscription_ack>(_sender);
+                    auto its_timer = std::make_shared<boost::asio::steady_timer>(io_);
+                    pending_tcp_key_t key{_service, _instance, _eventgroup,
+                                          its_reliable->get_address(),
+                                          its_reliable->get_port()};
+                    {
+                        std::scoped_lock lk(pending_tcp_subscriptions_mutex_);
+                        if (auto it = pending_tcp_subscriptions_.find(key);
+                                it != pending_tcp_subscriptions_.end()) {
+                            it->second->cancel();
+                        }
+                        pending_tcp_subscriptions_[key] = its_timer;
+                    }
+                    its_timer->expires_after(std::chrono::milliseconds(100));
+                    its_timer->async_wait(
+                        [self = shared_from_this(), e = std::move(entry),
+                         t = its_timer](const boost::system::error_code& ec) mutable {
+                            if (!ec) {
+                                self->retry_pending_tcp_subscription(std::move(e), t);
+                            }
+                        });
                     return;
                 }
             } else { // udp unicast
@@ -2273,6 +2359,66 @@ bool service_discovery_impl::is_tcp_connected(service_t _service, instance_t _in
         }
     }
     return is_connected;
+}
+
+void service_discovery_impl::retry_pending_tcp_subscription(
+        pending_tcp_sub_t _entry,
+        std::shared_ptr<boost::asio::steady_timer> _timer) {
+
+    const bool first_was_reliable = _entry.is_first_reliable
+                                    && _entry.first_port != ILLEGAL_PORT;
+    const boost::asio::ip::address& rel_addr =
+        first_was_reliable ? _entry.first_address : _entry.second_address;
+    const uint16_t rel_port =
+        first_was_reliable ? _entry.first_port : _entry.second_port;
+
+    pending_tcp_key_t key{_entry.service, _entry.instance, _entry.eventgroup,
+                          rel_addr, rel_port};
+    {
+        std::scoped_lock lk(pending_tcp_subscriptions_mutex_);
+        pending_tcp_subscriptions_.erase(key);
+    }
+
+    auto its_reliable_ep = endpoint_definition::get(
+        rel_addr, rel_port,
+        first_was_reliable ? _entry.is_first_reliable : _entry.is_second_reliable,
+        _entry.service, _entry.instance);
+
+    if (is_tcp_connected(_entry.service, _entry.instance, its_reliable_ep)) {
+        expired_ports_t its_expired_ports = _entry.expired_ports_copy;
+        sd_acceptance_state_t its_sd_ac_state(its_expired_ports);
+        its_sd_ac_state.sd_acceptance_required_ = _entry.sd_ac_required;
+        its_sd_ac_state.accept_entries_         = _entry.sd_ac_accept;
+
+        handle_eventgroup_subscription(
+            _entry.service, _entry.instance, _entry.eventgroup,
+            _entry.major, _entry.ttl, _entry.counter, _entry.reserved,
+            _entry.first_address,  _entry.first_port,  _entry.is_first_reliable,
+            _entry.second_address, _entry.second_port, _entry.is_second_reliable,
+            _entry.ack,
+            _entry.is_stop_subscribe_subscribe, _entry.force_initial_events,
+            _entry.clients, its_sd_ac_state, _entry.info, _entry.sender);
+
+        _entry.ack->complete();
+        if (_entry.ack->has_subscription()) {
+            update_acknowledgement(_entry.ack);
+        } else if (!_entry.ack->is_pending() && !_entry.ack->is_done()) {
+            send_subscription_ack(_entry.ack);
+        }
+    } else {
+        VSOMEIP_ERROR << "TCP connection to ["
+            << rel_addr.to_string() << ":" << rel_port
+            << "] still not established after 100 ms for subscription to: ["
+            << std::hex << std::setfill('0')
+            << std::setw(4) << _entry.service << "."
+            << std::setw(4) << _entry.instance << "."
+            << std::setw(4) << _entry.eventgroup << "] — sending NACK";
+        insert_subscription_ack(_entry.ack, _entry.info, 0, nullptr, _entry.clients);
+        _entry.ack->complete();
+        if (!_entry.ack->is_pending() && !_entry.ack->is_done()) {
+            send_subscription_ack(_entry.ack);
+        }
+    }
 }
 
 bool service_discovery_impl::send(const std::vector<std::shared_ptr<message_impl>>& _messages) {


### PR DESCRIPTION
## Problem

With ≥2 `io_context` threads, `accept_cbk` (which writes the new TCP connection into `connections_`) and `handle_eventgroup_subscription` (which reads `connections_` via `is_tcp_connected`) run on different threads with no ordering guarantee. If the UDP SUBSCRIBE arrives before `accept_cbk` finishes committing the connection, `is_tcp_connected` returns false and a spurious SUBSCRIBE_NACK is sent — even though the TCP three-way handshake already completed.

Maintainer confirmed: *"It rarely happened."*

**Race window:**
```
Thread A: accept_cbk — blocked at socket-option setup (connections_ not yet written)
Thread B: handle_eventgroup_subscription — is_tcp_connected reads connections_ → empty → NACK
Thread A: accept_cbk completes, writes connections_[remote] — too late
```

`connections_mutex_` prevents map corruption but enforces no happens-before between the two async paths.

## Fix

When `is_tcp_connected` returns false for a `TTL > 0` subscription, park the subscription in `pending_tcp_subscriptions_` with a 100 ms `steady_timer` instead of immediately NACKing.

When the timer fires, `retry_pending_tcp_subscription` re-checks `is_tcp_connected`:
- **Connection now present** → call `handle_eventgroup_subscription` normally → ACK sent
- **Still absent after 100 ms** → genuine failure → definitive NACK sent

The 100 ms window covers TCP handshake + kernel accept + `accept_cbk` dispatch latency by a large margin. A duplicate SUBSCRIBE for the same (service, instance, eventgroup, address, port) tuple cancels the previous timer before arming a new one.

## Scope

2 files, SD layer only — no cross-layer dependency introduced:
- `implementation/service_discovery/include/service_discovery_impl.hpp` — `pending_tcp_sub_t` struct + `retry_pending_tcp_subscription` declaration + `pending_tcp_subscriptions_` map + mutex
- `implementation/service_discovery/src/service_discovery_impl.cpp` — deferred-NACK path at both `is_tcp_connected` call sites + `retry_pending_tcp_subscription` implementation

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Single io thread (no race possible) | NACK if not connected | Same — `accept_cbk` always runs before SUBSCRIBE on one thread |
| Race window (≥2 threads) | Spurious NACK | 100 ms defer → retry → ACK on connection present |
| Genuine connection failure | NACK | NACK after 100 ms (within SD retry interval of ~3 s) |
| Duplicate SUBSCRIBE during defer | Second NACK | Previous timer cancelled, new timer armed |

Fixes #971.