### PR TITLE
fix(endpoint_manager): scope client_endpoints_ by service to prevent socket sharing (#899)

### DIFF
--- a/implementation/endpoints/include/endpoint_manager_impl.hpp
+++ b/implementation/endpoints/include/endpoint_manager_impl.hpp
@@ -109,8 +109,9 @@ private:
     typedef std::map<service_t, std::map<instance_t, std::map<bool, std::shared_ptr<boardnet_endpoint>>>> remote_services_t;
     remote_services_t remote_services_;
 
-    using client_endpoints_t = std::map<boost::asio::ip::address,
-                                        std::map<uint16_t, std::map<bool, std::map<partition_id_t, std::shared_ptr<boardnet_endpoint>>>>>;
+    using client_endpoints_t = std::map<service_t,
+                                        std::map<boost::asio::ip::address,
+                                                 std::map<uint16_t, std::map<bool, std::map<partition_id_t, std::shared_ptr<boardnet_endpoint>>>>>>;
     client_endpoints_t client_endpoints_;
 
     std::map<service_t, std::map<boardnet_endpoint*, instance_t>> service_instances_;

--- a/implementation/endpoints/src/endpoint_manager_impl.cpp
+++ b/implementation/endpoints/src/endpoint_manager_impl.cpp
@@ -425,23 +425,29 @@ void endpoint_manager_impl::clear_client_endpoints(service_t _service, instance_
                         its_udp_client_endpoint->get_remote_address(its_remote_address);
                     }
                 }
-                const auto found_ip = client_endpoints_.find(its_remote_address);
-                if (found_ip != client_endpoints_.end()) {
-                    const auto found_port = found_ip->second.find(its_remote_port);
-                    if (found_port != found_ip->second.end()) {
-                        auto found_reliable = found_port->second.find(_reliable);
-                        if (found_reliable != found_port->second.end()) {
-                            const auto found_partition = found_reliable->second.find(its_partition);
-                            if (found_partition != found_reliable->second.end()) {
-                                if (found_partition->second == its_endpoint) {
-                                    found_reliable->second.erase(its_partition);
-                                    // delete if necessary
-                                    if (0 == found_reliable->second.size()) {
-                                        found_port->second.erase(_reliable);
-                                        if (0 == found_port->second.size()) {
-                                            found_ip->second.erase(found_port);
-                                            if (0 == found_ip->second.size()) {
-                                                client_endpoints_.erase(found_ip);
+                const auto found_service_ep = client_endpoints_.find(_service);
+                if (found_service_ep != client_endpoints_.end()) {
+                    const auto found_ip = found_service_ep->second.find(its_remote_address);
+                    if (found_ip != found_service_ep->second.end()) {
+                        const auto found_port = found_ip->second.find(its_remote_port);
+                        if (found_port != found_ip->second.end()) {
+                            auto found_reliable = found_port->second.find(_reliable);
+                            if (found_reliable != found_port->second.end()) {
+                                const auto found_partition = found_reliable->second.find(its_partition);
+                                if (found_partition != found_reliable->second.end()) {
+                                    if (found_partition->second == its_endpoint) {
+                                        found_reliable->second.erase(its_partition);
+                                        // delete if necessary
+                                        if (0 == found_reliable->second.size()) {
+                                            found_port->second.erase(_reliable);
+                                            if (0 == found_port->second.size()) {
+                                                found_ip->second.erase(found_port);
+                                                if (0 == found_ip->second.size()) {
+                                                    found_service_ep->second.erase(found_ip);
+                                                    if (0 == found_service_ep->second.size()) {
+                                                        client_endpoints_.erase(found_service_ep);
+                                                    }
+                                                }
                                             }
                                         }
                                     }
@@ -577,12 +583,14 @@ void endpoint_manager_impl::print_status() const {
         VSOMEIP_INFO << "status start remote client endpoints:";
         std::uint32_t num_remote_client_endpoints(0);
         // normal endpoints
-        for (const auto& its_address : its_client_endpoints) {
-            for (const auto& its_port : its_address.second) {
-                for (const auto& its_reliability : its_port.second) {
-                    for (const auto& its_partition : its_reliability.second) {
-                        its_partition.second->print_status();
-                        num_remote_client_endpoints++;
+        for (const auto& its_service : its_client_endpoints) {
+            for (const auto& its_address : its_service.second) {
+                for (const auto& its_port : its_address.second) {
+                    for (const auto& its_reliability : its_port.second) {
+                        for (const auto& its_partition : its_reliability.second) {
+                            its_partition.second->print_status();
+                            num_remote_client_endpoints++;
+                        }
                     }
                 }
             }
@@ -990,15 +998,17 @@ std::shared_ptr<boardnet_endpoint> endpoint_manager_impl::find_remote_client(ser
             auto found_reliable = found_instance->second.find(_reliable);
             if (found_reliable != found_instance->second.end()) {
                 std::shared_ptr<endpoint_definition> its_ep_def = found_reliable->second;
-                auto found_address = client_endpoints_.find(its_ep_def->get_address());
-                if (found_address != client_endpoints_.end()) {
-                    auto found_port = found_address->second.find(its_ep_def->get_remote_port());
-                    if (found_port != found_address->second.end()) {
-                        auto found_reliable2 = found_port->second.find(_reliable);
-                        if (found_reliable2 != found_port->second.end()) {
-                            auto found_partition = found_reliable2->second.find(its_partition_id);
-                            if (found_partition != found_reliable2->second.end()) {
-                                its_endpoint = found_partition->second;
+                auto found_service_ce = client_endpoints_.find(_service);
+                if (found_service_ce != client_endpoints_.end()) {
+                    auto found_address = found_service_ce->second.find(its_ep_def->get_address());
+                    if (found_address != found_service_ce->second.end()) {
+                        auto found_port = found_address->second.find(its_ep_def->get_remote_port());
+                        if (found_port != found_address->second.end()) {
+                            auto found_reliable2 = found_port->second.find(_reliable);
+                            if (found_reliable2 != found_port->second.end()) {
+                                auto found_partition = found_reliable2->second.find(its_partition_id);
+                                if (found_partition != found_reliable2->second.end()) {
+                                    its_endpoint = found_partition->second;
 
                                 // store the endpoint under this service/instance id
                                 // as well - needed for later cleanup
@@ -1062,7 +1072,7 @@ std::shared_ptr<boardnet_endpoint> endpoint_manager_impl::create_remote_client(s
                 remote_services_[_service][_instance][_reliable] = its_endpoint;
 
                 partition_id_t its_partition = configuration_->get_partition_id(_service, _instance);
-                client_endpoints_[its_endpoint_def->get_address()][its_endpoint_def->get_port()][_reliable][its_partition] = its_endpoint;
+                client_endpoints_[_service][its_endpoint_def->get_address()][its_endpoint_def->get_port()][_reliable][its_partition] = its_endpoint;
                 // Set the basic route to the service in the service info
                 auto found_service_info = rm_->find_service(_service, _instance);
                 if (found_service_info) {
@@ -1114,14 +1124,16 @@ void endpoint_manager_impl::log_client_states() const {
         its_client_endpoints = client_endpoints_;
     }
 
-    for (const auto& its_address : its_client_endpoints) {
-        for (const auto& its_port : its_address.second) {
-            for (const auto& its_reliability : its_port.second) {
-                for (const auto& its_partition : its_reliability.second) {
-                    size_t its_queue_size = its_partition.second->get_queue_size();
-                    if (its_queue_size > VSOMEIP_DEFAULT_QUEUE_WARN_SIZE)
-                        its_client_queue_sizes.push_back(
-                                std::make_pair(std::make_tuple(its_address.first, its_port.first, its_reliability.first), its_queue_size));
+    for (const auto& its_service : its_client_endpoints) {
+        for (const auto& its_address : its_service.second) {
+            for (const auto& its_port : its_address.second) {
+                for (const auto& its_reliability : its_port.second) {
+                    for (const auto& its_partition : its_reliability.second) {
+                        size_t its_queue_size = its_partition.second->get_queue_size();
+                        if (its_queue_size > VSOMEIP_DEFAULT_QUEUE_WARN_SIZE)
+                            its_client_queue_sizes.push_back(
+                                    std::make_pair(std::make_tuple(its_address.first, its_port.first, its_reliability.first), its_queue_size));
+                    }
                 }
             }
         }
@@ -1278,7 +1290,7 @@ void endpoint_manager_impl::suspend() {
 }
 
 void endpoint_manager_impl::resume() {
-    std::vector<std::tuple<boost::asio::ip::address, uint16_t, bool, partition_id_t>> clients;
+    std::vector<std::tuple<service_t, boost::asio::ip::address, uint16_t, bool, partition_id_t>> clients;
     std::vector<std::tuple<uint16_t, bool>> servers;
 
     {
@@ -1286,11 +1298,13 @@ void endpoint_manager_impl::resume() {
 
         // restart client endpoints
 
-        for (const auto& [its_address, ports] : client_endpoints_) {
-            for (const auto& [its_port, protocols] : ports) {
-                for (const auto& [its_protocol, partitions] : protocols) {
-                    for (const auto& [its_partition, its_endpoint] : partitions) {
-                        clients.push_back(std::make_tuple(its_address, its_port, its_protocol, its_partition));
+        for (const auto& [its_service, addresses] : client_endpoints_) {
+            for (const auto& [its_address, ports] : addresses) {
+                for (const auto& [its_port, protocols] : ports) {
+                    for (const auto& [its_protocol, partitions] : protocols) {
+                        for (const auto& [its_partition, its_endpoint] : partitions) {
+                            clients.push_back(std::make_tuple(its_service, its_address, its_port, its_protocol, its_partition));
+                        }
                     }
                 }
             }
@@ -1305,14 +1319,19 @@ void endpoint_manager_impl::resume() {
         }
     }
 
-    for (const auto& [its_address, its_port, its_protocol, its_partition] : clients) {
+    for (const auto& [its_service, its_address, its_port, its_protocol, its_partition] : clients) {
         std::shared_ptr<boardnet_endpoint> its_endpoint;
 
         {
             std::scoped_lock its_lock{endpoint_mutex_};
 
-            const auto& ports = client_endpoints_.find(its_address);
-            if (ports == client_endpoints_.end()) {
+            const auto& services = client_endpoints_.find(its_service);
+            if (services == client_endpoints_.end()) {
+                continue;
+            }
+
+            const auto& ports = services->second.find(its_address);
+            if (ports == services->second.end()) {
                 continue;
             }
 


### PR DESCRIPTION
## Problem

When two SOME/IP services are offered on the **same remote address:port**, a client subscribing to both services incorrectly shares a single UDP socket between them.

**Root cause** — `client_endpoints_` in `endpoint_manager_impl` is keyed by `[remote_address][remote_port][reliable][partition_id]`. When `find_remote_client()` is called for a second service whose server endpoint shares address and port with the first, it finds the existing endpoint object and registers it under the second service. `create_remote_client()` is never called for the second service, so:

- The second service's configured local port is never opened.
- Both `SubscribeEventgroup` messages are sent from the first service's socket.
- The second client's local port is never used (Wireshark shows zero traffic from it).

Reported against v3.4.10 on Embedded Linux with two services (`0x9002`, `0x9003`) both offered on UDP port `35699` — closes #899. Related to #380.

## Fix

Add `service_t` as the outermost key of `client_endpoints_t`:

```cpp
// Before:
using client_endpoints_t = std::map<boost::asio::ip::address,
    std::map<uint16_t, std::map<bool, std::map<partition_id_t,
        std::shared_ptr<boardnet_endpoint>>>>>;

// After:
using client_endpoints_t = std::map<service_t,
    std::map<boost::asio::ip::address,
        std::map<uint16_t, std::map<bool, std::map<partition_id_t,
            std::shared_ptr<boardnet_endpoint>>>>>>;
```

Six usage sites updated: `find_remote_client`, `create_remote_client`, `clear_client_endpoints`, `print_status`, `log_client_states`, `resume`.

**Partition-sharing behaviour preserved**: existing logic that lets multiple instances of the *same* service share a client endpoint (via the partition key) is unaffected — the new outermost key is identical for same-service lookups.

## Verification

After the fix, `client_endpoints_[0x9002][addr][35699][false][P0]` and `client_endpoints_[0x9003][addr][35699][false][P0]` are independent map entries. The second service falls through to `create_remote_client()` and obtains its own socket bound to its configured local port. Both subscription messages are sent from the correct per-service source ports.