### PR TITLE
fix: set sd_route_set_ on non-Linux platforms in start_ip_routing

### DIFF
--- a/implementation/routing/src/routing_manager_impl.cpp
+++ b/implementation/routing/src/routing_manager_impl.cpp
@@ -3391,7 +3391,12 @@ void routing_manager_impl::on_net_interface_or_route_state_changed(bool _is_inte
 
 void routing_manager_impl::start_ip_routing() {
 #if defined(_WIN32) || defined(__QNX__)
+    // On platforms without netlink, on_net_interface_or_route_state_changed
+    // is never called, so sd_route_set_ would remain false and
+    // is_external_routing_ready() would never return true.
+    // Mark both conditions satisfied when IP routing starts on these platforms.
     if_state_running_ = true;
+    sd_route_set_ = true;
 #endif
 
     if (routing_ready_handler_) {


### PR DESCRIPTION
## Problem

`is_external_routing_ready()` returns:
```cpp
return if_state_running_ && (!configuration_->is_sd_enabled() || (configuration_->is_sd_enabled() && sd_route_set_));
```

On Linux, both `if_state_running_` and `sd_route_set_` are set by `on_net_interface_or_route_state_changed()`, which is invoked by the netlink connector when the network interface and SD multicast route become available.

On **`_WIN32` and `__QNX__`** (no netlink connector), `on_net_interface_or_route_state_changed()` is never called:
- `start_ip_routing()` already sets `if_state_running_ = true` for these platforms
- But `sd_route_set_` stays `false` (initialized in the constructor, never updated)

Result: when Service Discovery is enabled, `is_external_routing_ready()` always returns `false` on these platforms, so `discovery_->start()` is never reached and multicast SD never begins. This explains the related issues #979 and #810 on non-Linux targets.

Fixes #994.

## Fix

Set `sd_route_set_ = true` alongside `if_state_running_ = true` inside the existing `#if defined(_WIN32) || defined(__QNX__)` guard in `start_ip_routing()`. Since there is no netlink on these platforms, the route can be considered available when IP routing explicitly starts.

## Testing

Verified on QNX: SD multicast now starts correctly when `wait_route_netlink_notification` is at its default (`true`) and the netlink connector is absent.