### PR TITLE
fix: cast port_t subtraction result to suppress -Wconversion error

### DIFF
--- a/implementation/endpoints/src/local_server.cpp
+++ b/implementation/endpoints/src/local_server.cpp
@@ -199,7 +199,7 @@ void local_server::add_connection(client_t _client, [[maybe_unused]] client_t _e
             }
 
             if (peer_endpoint != boost::asio::ip::tcp::endpoint{}) {
-                rh->add_guest(_client, peer_endpoint.address(), peer_endpoint.port() - 1); // -1 taken over from the legacy
+                rh->add_guest(_client, peer_endpoint.address(), static_cast<port_t>(peer_endpoint.port() - 1U)); // -1 taken over from the legacy
             }
 
             if (auto it = clients_.find(_client); it != clients_.end()) {


### PR DESCRIPTION
## Problem

In `local_server::add_connection()`, `peer_endpoint.port()` returns `unsigned short` (`uint16_t` / `port_t`). Subtracting `1` from it applies the usual arithmetic conversions, promoting the result to `int`. Passing that `int` to `routing_host::add_guest()`, which expects `port_t` (`short unsigned int`), triggers a narrowing conversion diagnostic:

```
implementation/endpoints/src/local_server.cpp:184:86: error: conversion from 'int' to
'vsomeip_v3::port_t' {aka 'short unsigned int'} may change value [-Werror=conversion]
  184 |  rh->add_guest(_client, peer_endpoint.address(), peer_endpoint.port() - 1);
```

This becomes a build error when `-Werror=conversion` is in effect (reported in #1013 with GCC and Boost 1.88).

## Fix

Add `static_cast<port_t>(...)` around the subtraction expression and use `1U` to keep the subtraction unsigned throughout. This makes the truncation explicit and silences the diagnostic without changing the runtime value.

Fixes #1013