### PR TITLE
Fix wrappers_qnx.cpp copyright attribution

### DIFF
--- a/implementation/utility/src/wrappers_qnx.cpp
+++ b/implementation/utility/src/wrappers_qnx.cpp
@@ -1,4 +1,4 @@
-// Copyright (C) 2014-2026 Bayerische Motoren Werke Aktiengesellschaft (BMW AG)
+// Copyright (c) 2026, BlackBerry Limited.
 // This Source Code Form is subject to the terms of the Mozilla Public
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.


### PR DESCRIPTION
`wrappers_qnx.cpp`'s code is entirely from QNX, division of BlackBerry. In this merged pull request https://github.com/COVESA/vsomeip/pull/447, I made a mistake of not changing the copyright attribution to BlackBerry Limited. I am using this opportunity to fix the copyright attribution. Thanks.