### PR TITLE
protocol/routing_info_entry: bounds-check the address/port memcpys

### DIFF
--- a/implementation/protocol/src/routing_info_entry.cpp
+++ b/implementation/protocol/src/routing_info_entry.cpp
@@ -83,7 +83,14 @@ void routing_info_entry::deserialize(const std::vector<byte_t>& _buffer, size_t&
     uint32_t its_size;
     uint32_t its_client_size;
 
-    if (_buffer.size() < _index + sizeof(type_) + sizeof(its_size) + sizeof(client_)) {
+    // The four fixed-width reads at the top of this function consume
+    // sizeof(type_) + sizeof(its_size) + sizeof(its_client_size) +
+    // sizeof(client_) = 1 + 4 + 4 + 2 = 11 bytes. The bound check must
+    // cover all four; missing sizeof(its_client_size) lets a 7-byte
+    // buffer through and allows the its_client_size and client_
+    // memcpy()s to read up to 6 bytes of adjacent heap memory.
+    if (_buffer.size() < _index + sizeof(type_) + sizeof(its_size)
+                         + sizeof(its_client_size) + sizeof(client_)) {
 
         _error = error_e::ERROR_NOT_ENOUGH_BYTES;
         return;
@@ -107,7 +114,37 @@ void routing_info_entry::deserialize(const std::vector<byte_t>& _buffer, size_t&
 
     if (its_client_size > sizeof(client_)) {
 
+        // its_client_size came off the wire from a peer routing client.
+        // Reject values that would underflow the address-size subtraction
+        // below before computing it.
+        if (its_client_size < uint32_t(sizeof(client_t) + sizeof(port_))) {
+
+            _error = error_e::ERROR_MALFORMED;
+            return;
+        }
+
         uint32_t its_address_size = its_client_size - uint32_t(sizeof(client_t) + sizeof(port_));
+
+        // Only IPv4 (4-byte) and IPv6 (16-byte) address sizes are valid;
+        // anything else is malformed input. Validate here so the bounds
+        // check below can rely on a sane its_address_size, and so the
+        // address+port memcpy()s never run with a wire-controlled size.
+        if (its_address_size != sizeof(boost::asio::ip::address_v4::bytes_type)
+                && its_address_size != sizeof(boost::asio::ip::address_v6::bytes_type)) {
+
+            _error = error_e::ERROR_MALFORMED;
+            return;
+        }
+
+        // The address and port reads were previously unguarded — a peer
+        // could set its_client_size to 8 (v4) or 20 (v6) and force the
+        // memcpy()s to read 4–16 bytes plus 2 more for the port from
+        // beyond the buffer end. Bounds-check before any memcpy.
+        if (_buffer.size() < _index + its_address_size + sizeof(port_)) {
+
+            _error = error_e::ERROR_NOT_ENOUGH_BYTES;
+            return;
+        }
 
         if (its_address_size == sizeof(boost::asio::ip::address_v4::bytes_type)) {
 
@@ -116,17 +153,14 @@ void routing_info_entry::deserialize(const std::vector<byte_t>& _buffer, size_t&
             address_ = boost::asio::ip::address_v4(its_array);
             _index += its_array.size();
 
-        } else if (its_address_size == sizeof(boost::asio::ip::address_v6::bytes_type)) {
+        } else {
 
+            // its_address_size is sizeof(address_v6::bytes_type) by the
+            // validation above.
             boost::asio::ip::address_v6::bytes_type its_array;
             std::memcpy(&its_array, &_buffer[_index], its_array.size());
             address_ = boost::asio::ip::address_v6(its_array);
             _index += its_array.size();
-
-        } else {
-
-            _error = error_e::ERROR_MALFORMED;
-            return;
         }
 
         std::memcpy(&port_, &_buffer[_index], sizeof(port_));


### PR DESCRIPTION
### Problem

`routing_info_entry::deserialize` (`implementation/protocol/src/routing_info_entry.cpp`) had two missing bounds checks that let a peer routing client read up to ~22 bytes of adjacent heap memory off the receiving process by sending a malformed `routing_info_command`.

The function ends up being called from `routing_manager_client::on_routing_info` (and the routing-stub side), so the trust boundary here is the local IPC routing socket — which under the default security policy is bounded but is the same surface that vsomeip's security layer is supposed to protect.

#### Bug 1 — initial size check missed `sizeof(its_client_size)`

```cpp
if (_buffer.size() < _index + sizeof(type_) + sizeof(its_size) + sizeof(client_)) {
    _error = error_e::ERROR_NOT_ENOUGH_BYTES;
    return;
}
```

That check covers `1 + 4 + 2 = 7` bytes, but the function actually consumes `1 + 4 + 4 + 2 = 11` bytes from `_buffer` at the top (the `its_client_size` read at line 102 isn't in the check). A peer that writes a routing_info_command whose payload is exactly 7 bytes drives the `memcpy(&its_client_size, ...)` to read 2 bytes past the end of the buffer and the `memcpy(&client_, ...)` to read another 2 bytes past — **4 bytes of OOB read**, into adjacent heap memory of the routing manager's `std::vector<byte_t>`.

#### Bug 2 — address/port `memcpy`s have no `_buffer.size()` check

```cpp
if (its_client_size > sizeof(client_)) {
    uint32_t its_address_size = its_client_size - uint32_t(sizeof(client_t) + sizeof(port_));
    if (its_address_size == sizeof(boost::asio::ip::address_v4::bytes_type)) {
        ...
        std::memcpy(&its_array, &_buffer[_index], its_array.size());   // 4 bytes, no bounds check
        ...
    } else if (its_address_size == sizeof(boost::asio::ip::address_v6::bytes_type)) {
        ...
        std::memcpy(&its_array, &_buffer[_index], its_array.size());   // 16 bytes, no bounds check
        ...
    }
    std::memcpy(&port_, &_buffer[_index], sizeof(port_));               // 2 bytes, no bounds check
}
```

`its_client_size` is wire-controlled. A peer that sets it to `8` selects the v4 branch (4-byte address read) and a peer that sets it to `20` selects the v6 branch (16-byte address read), in both cases plus a 2-byte port read — all unguarded. Total OOB read primitive: **6, 12, or 18 bytes** depending on which combination is reached.

The subtraction `its_client_size - (sizeof(client_t) + sizeof(port_))` also underflows when `its_client_size < 4`, producing a near-`UINT32_MAX` `its_address_size`. The existing `else { ERROR_MALFORMED }` arm catches the underflow case incidentally, but the underflow itself shouldn't have been reachable in the first place.

### Fix

- Extend the initial size check to include `sizeof(its_client_size)` so it actually covers the 11 bytes read at the top.
- Reject `its_client_size` values that would underflow the `its_address_size` subtraction.
- Validate `its_address_size` against the two recognised IP families (v4=4, v6=16) **before** the bounds check, so the bounds check below can rely on a sane value.
- Bounds-check `its_address_size + sizeof(port_)` against the remaining buffer **before** any `memcpy`.
- Restructure the v4 / else-if-v6 / else-MALFORMED dispatch into v4 / else-v6 (the validation above has already rejected anything that isn't one of the two).

Diff: +41 / −7 in a single file.

### Notes

- The trailing services-array section (lines 145+ in the original) was already properly bounds-checked; not touched.
- I haven't been able to run vsomeip's full test suite locally on macOS (boost+CMake setup pending). Pointers to the canonical way to add a malformed-input regression test for this entry would be appreciated; I'd be happy to follow up with a test commit on this branch once I have the build working.
- This was found via a static audit pass over `implementation/protocol/`, `implementation/service_discovery/`, and `implementation/endpoints/`. There are a small number of further findings I'd like to bring up in separate PRs (e.g. `message_impl::deserialize` underflows `header_.length_ - VSOMEIP_SOMEIP_HEADER_SIZE` and passes the result to `data_.reserve()` — a ~4 GB allocation per malformed message). Happy to file those one at a time after this lands.