### PR TITLE
sd/configuration_option: enforce per-option byte budget on deserialize

### DIFF
--- a/implementation/service_discovery/src/configuration_option_impl.cpp
+++ b/implementation/service_discovery/src/configuration_option_impl.cpp
@@ -89,39 +89,83 @@ bool configuration_option_impl::serialize(vsomeip_v3::serializer* _to) const {
 
 bool configuration_option_impl::deserialize(vsomeip_v3::deserializer* _from) {
     bool is_successful = option_impl::deserialize(_from);
+    if (!is_successful) {
+        return false;
+    }
+
+    // option_impl::deserialize has consumed length_ + type + reserved.
+    // length_ covers the reserved byte (already consumed) plus the
+    // configuration items plus the trailing '\0' terminator
+    // (SWS_SD_00292). Bytes that still belong to *this* option, and
+    // which the loop below is allowed to consume, are length_ - 1.
+    //
+    // Without the bytes_remaining budget tracked here, the loop would
+    // only stop on a 0-length item or when the outer deserializer's
+    // remaining_ ran out — i.e. it could greedily consume bytes from
+    // subsequent SD options if a multicast peer sent a CONFIGURATION
+    // option that omitted its trailing terminator or claimed an
+    // item-length larger than the option's declared payload.
+    if (length_ < 1) {
+        // length_ is too small to even cover the already-consumed
+        // reserved byte; the option is malformed.
+        return false;
+    }
+    std::size_t bytes_remaining = static_cast<std::size_t>(length_) - 1u;
+
     uint8_t l_itemLength = 0;
     std::string l_item(256, 0), l_key, l_value;
 
-    do {
+    while (bytes_remaining > 0) {
         l_itemLength = 0;
         l_key.clear();
         l_value.clear();
         l_item.assign(256, '\0');
 
-        is_successful = is_successful && _from->deserialize(l_itemLength);
-        if (l_itemLength > 0) {
-            is_successful = is_successful && _from->deserialize(l_item, static_cast<std::size_t>(l_itemLength));
-
-            if (is_successful) {
-                size_t l_eqPos = l_item.find('='); // SWS_SD_00292
-                l_key = l_item.substr(0, l_eqPos);
-
-                // if no "=" is found, no value is present for key (SWS_SD_00466)
-                if (l_eqPos != std::string::npos)
-                    l_value = l_item.substr(l_eqPos + 1);
-                if (configuration_.end() == configuration_.find(l_key)) {
-                    configuration_[l_key] = l_value;
-                } else {
-                    // TODO: log reason for failing deserialization
-                    is_successful = false;
-                }
-            }
-        } else {
-            break;
+        if (!_from->deserialize(l_itemLength)) {
+            return false;
         }
-    } while (is_successful && _from->get_remaining() > 0);
+        bytes_remaining -= 1;
 
-    return is_successful;
+        if (l_itemLength == 0) {
+            // The terminating empty entry per SWS_SD_00292. Any bytes
+            // left over (bytes_remaining > 0 here) are option padding
+            // not described by the spec — leave them alone; the parent
+            // dispatcher's set_remaining bookkeeping will keep the
+            // overall option-stream walk honest, and being lenient
+            // about trailing padding matches the previous behaviour
+            // for well-formed inputs.
+            return true;
+        }
+
+        if (l_itemLength > bytes_remaining) {
+            // The item declares more bytes than fit inside the option's
+            // declared payload; reject before the read so the loop can
+            // never consume bytes that belong to the next option.
+            return false;
+        }
+
+        if (!_from->deserialize(l_item, static_cast<std::size_t>(l_itemLength))) {
+            return false;
+        }
+        bytes_remaining -= l_itemLength;
+
+        size_t l_eqPos = l_item.find('='); // SWS_SD_00292
+        l_key = l_item.substr(0, l_eqPos);
+
+        // if no "=" is found, no value is present for key (SWS_SD_00466)
+        if (l_eqPos != std::string::npos)
+            l_value = l_item.substr(l_eqPos + 1);
+        if (configuration_.end() == configuration_.find(l_key)) {
+            configuration_[l_key] = l_value;
+        } else {
+            // TODO: log reason for failing deserialization
+            return false;
+        }
+    }
+
+    // Ran out of bytes within the option without seeing the terminator;
+    // malformed.
+    return false;
 }
 
 } // namespace sd


### PR DESCRIPTION
### Problem

`configuration_option_impl::deserialize` (`implementation/service_discovery/src/configuration_option_impl.cpp:90-125`) parses a key=value list with no per-option byte budget:

```cpp
do {
    ...
    is_successful = is_successful && _from->deserialize(l_itemLength);
    if (l_itemLength > 0) {
        is_successful = is_successful && _from->deserialize(l_item, l_itemLength);
        ...
    } else { break; }
} while (is_successful && _from->get_remaining() > 0);
```

The loop only stops on a 0-length item or when the *outer* deserializer's `remaining_` runs out. Neither corresponds to this option's own declared `length_` field — and the parent dispatcher (`message_impl::deserialize_option`) does not scope the deserializer to a single option before calling it.

So if a multicast SD peer sends a CONFIGURATION option that:
- omits its trailing `\0` terminator, or
- declares an item-length larger than its own declared payload,

the loop greedily consumes bytes from the next option(s) in the SD message until it finds a 0 byte or runs out of `remaining_`. Subsequent legitimate options (typically the IPv4/IPv6 endpoint options that drive subscription routing) are then either dropped or misinterpreted as a different option type, depending on which byte boundary the desync lands on.

This is **not** a memory-safety bug — `deserializer::deserialize(string, len)` enforces `len <= remaining_`, so every read still lands inside the SD message buffer. But the parser-state corruption is reachable from any peer on the SD multicast group, with no authentication, so it's worth fixing.

### Fix

Track `bytes_remaining = length_ - 1` (the bytes that belong to *this* option after `option_impl::deserialize` consumed length+type+reserved) and reject malformed input at three points:

1. `length_ < 1` — option header is smaller than the reserved byte that `option_impl::deserialize` already consumed.
2. An item-length that exceeds `bytes_remaining` — lying length, would otherwise consume bytes from the next option.
3. The loop running out of bytes without seeing the `\0` terminator — missing terminator.

Behaviour is unchanged for well-formed inputs: a CONFIGURATION option whose payload is exactly `reserved + items + '\0'` still decodes identically. The early-terminator-with-trailing-padding case (not described by SWS_SD_00292 but tolerated by the previous code) continues to return success.

Diff: +66 / −22 in a single file. Loop restructured from `do/while` with implicit `is_successful` chaining into a `while` with explicit early-return paths, which makes the budget-enforcement points easier to reason about.

### Notes

- Compiles cleanly against the existing headers (`g++ -fsyntax-only`).
- No existing tests cover `configuration_option_impl` deserialization (`grep -r configuration_option_impl test/` returns nothing). I'd be happy to follow up with a malformed-input test case once I have the full vsomeip build working locally — pointers to where SD-option deserialize tests would naturally live in `test/` would be appreciated.
- Companion to #1040 (routing_info_entry bounds checks) and #1041 (message_impl length underflow). Both came from the same audit pass over the protocol/SD/endpoint subsystems. One latent off-by-one in `deserializer::look_ahead` remains; happy to file as a separate small PR if useful.