### PR TITLE
Fix QNX 8 (io-sock) build and runtime support

### DIFF
--- a/implementation/endpoints/include/asio_uds_socket.hpp
+++ b/implementation/endpoints/include/asio_uds_socket.hpp
@@ -26,6 +26,23 @@ private:
 
     [[nodiscard]] bool get_peer_credentials(vsomeip_sec_client_t& _client) override {
         int handle = socket_.native_handle();
+#if defined(__QNX__)
+        // QNX io-sock exposes no SO_PEERCRED/ucred, so the peer UID/GID cannot be
+        // read from the socket here. Report default credentials and SUCCEED rather
+        // than fail: returning false makes the local endpoint's sec_client update
+        // fail, after which vsomeip rejects the application's own routing-manager
+        // connection and never registers/offers.
+        //
+        // NOTE: this disables peer-credential based policy on QNX. It can be
+        // upgraded to a real credential source when one is available -- e.g. the
+        // QNX message-passing side channel (ConnectServerInfo/_client_info) to
+        // obtain the peer pid/uid/gid -- and gated behind vsomeip's security config.
+        (void)handle;
+        _client.user = 0;
+        _client.group = 0;
+        _client.port = VSOMEIP_SEC_PORT_UNUSED;
+        return true;
+#else
         ucred out;
         if (socklen_t len = sizeof(ucred); -1 == ::getsockopt(handle, SOL_SOCKET, SO_PEERCRED, &out, &len)) {
             return false;
@@ -34,6 +51,7 @@ private:
         _client.group = out.gid;
         _client.port = VSOMEIP_SEC_PORT_UNUSED;
         return true;
+#endif
     }
     void set_reuse_address(boost::system::error_code& _ec) { socket_.set_option(boost::asio::socket_base::reuse_address(true), _ec); }
     void async_connect(endpoint const& _ep, connect_handler _handler) override { socket_.async_connect(_ep, std::move(_handler)); }

--- a/implementation/endpoints/include/socket_options.hpp
+++ b/implementation/endpoints/include/socket_options.hpp
@@ -13,6 +13,10 @@
 
 #include <sys/time.h>
 
+#if defined(__QNX__)
+#include "../../utility/include/qnx_helper.hpp"   // IP_PKTINFO / in_pktinfo on QNX
+#endif
+
 namespace vsomeip_v3 {
 
 template<typename Protocol>

--- a/implementation/utility/include/qnx_helper.hpp
+++ b/implementation/utility/include/qnx_helper.hpp
@@ -11,6 +11,11 @@
 #define SO_BINDTODEVICE 0x0800 /* restrict traffic to an interface */
 #define IP_PKTINFO		25 /* int; send interface and src addr */
 
+/* QNX has no privileged SO_RCVBUFFORCE; fall back to the normal set. */
+#ifndef SO_RCVBUFFORCE
+#define SO_RCVBUFFORCE SO_RCVBUF
+#endif
+
 /* Structure used for IP_PKTINFO.  */
 #ifndef _STRUCT_IN_PKTINFO
 struct in_pktinfo {
@@ -20,3 +25,5 @@ struct in_pktinfo {
 };
 #define _STRUCT_IN_PKTINFO
 #endif
+
+#endif // __QNX__  (close the guard opened at the top; HEAD was missing this)

--- a/implementation/utility/src/wrappers_qnx.cpp
+++ b/implementation/utility/src/wrappers_qnx.cpp
@@ -7,148 +7,37 @@
 
 #include <sys/socket.h>
 #include <sys/types.h>
-
 #include <fcntl.h>
-#include <cerrno>
-#include <fcntl.h>
-#include <pthread.h>
-#include <cstdlib>
-#include <string.h>
-#include <sys/dcmd_ip.h>
-#include <sys/netmgr.h>
-#include <sys/sockmsg.h>
 #include <unistd.h>
 
-typedef enum accept_msg_t {
-    ACCEPT1 = 1,
-    ACCEPT4,
-} accept_msg_t;
-
-struct _io_sock_accept {
-    struct _io_openfd msg;
-    accept_msg_t type;
-    int flags;
-    socklen_t anamelen;
-};
-
-typedef union {
-    struct _io_sock_accept i;
-} io_sock_accept_t;
-
-static int __accept(int s, struct sockaddr* addr, socklen_t* addrlen, accept_msg_t msg_type, int flags) {
-    /* This is basically _sopenfd specifying a return buffer for dst address */
-    int fd2;
-    int ret, niov;
-    io_sock_accept_t msg;
-    struct _io_openfd* open;
-    struct _server_info info;
-    iov_t iov[2];
-    socklen_t len;
-
-    if ((addrlen) && (*addrlen > 0) && (!addr)) {
-        /* Prevent addr dereference */
-        errno = EINVAL;
-        return -1;
-    }
-
-    if (s == -1 || ConnectServerInfo(0, s, &info) != s) {
-        errno = EBADF;
-        return -1;
-    }
-
-    fd2 = ConnectAttach(info.nd, info.pid, info.chid, 0, _NTO_COF_CLOEXEC | _NTO_COF_INSECURE);
-    if (fd2 == -1) {
-        return -1;
-    }
-
-    open = &msg.i.msg;
-    memset(open, 0x00, sizeof *open);
-    open->type = _IO_OPENFD;
-    open->combine_len = sizeof open;
-    open->ioflag = 0;
-    open->sflag = 0;
-    open->xtype = _IO_OPENFD_ACCEPT;
-    open->info.pid = getpid();
-    open->info.chid = info.chid;
-    open->info.scoid = info.scoid;
-    open->info.coid = s;
-
-    msg.i.type = msg_type;
-    msg.i.flags = flags;
-    if (addr && addrlen && (*addrlen > 0)) {
-        /* Only send len > 0 if addr is set (accept1() assumption) */
-        len = *addrlen;
-    } else {
-        len = 0;
-    }
-    msg.i.anamelen = len;
-
-    niov = 0;
-    SETIOV(iov + niov, &msg.i, sizeof(msg.i));
-    niov++;
-
-    if (len > 0) {
-        /* Only send buffer space required */
-        SETIOV(iov + niov, addr, len);
-        niov++;
-    }
-
-    ret = MsgSendv(fd2, iov, niov, iov, niov);
-    if (ret == -1) {
-        if (errno == ENOSYS) {
-            errno = ENOTSOCK;
-        }
-        ConnectDetach(fd2);
-        return -1;
-    }
-
-    if (addr && addrlen && (*addrlen > 0)) {
-        *addrlen = msg.i.anamelen;
-    }
-
-    ConnectFlags_r(0, fd2, FD_CLOEXEC, (flags & SOCK_CLOEXEC) ? 1 : 0);
-
-    return fd2;
-}
-
-int accept4(int s, struct sockaddr* addr, socklen_t* addrlen, int flags) {
-    return __accept(s, addr, addrlen, ACCEPT4, flags);
-}
-
 /*
- * These definitions MUST remain in the global namespace.
+ * QNX 8 (io-sock) provides a native accept4() with SOCK_CLOEXEC / SOCK_NONBLOCK,
+ * so the QNX 7 (io-pkt) message-passing accept implementation that used
+ * <sys/sockmsg.h> / _io_openfd is no longer needed (and that header was dropped).
+ * All that remains are the CLOEXEC-adding linker --wrap targets referenced by the
+ * QNX LINK_FLAGS in CMakeLists.txt (-Wl,-wrap,socket / accept / open).
  */
 extern "C" {
-/*
- * The real socket(2), renamed by GCC.
- */
+
 int __real_socket(int domain, int type, int protocol) noexcept;
 
-/*
- * Overrides socket(2) to set SOCK_CLOEXEC by default.
- */
+// Override socket(2) to set SOCK_CLOEXEC by default.
 int __wrap_socket(int domain, int type, int protocol) noexcept {
     return __real_socket(domain, type | SOCK_CLOEXEC, protocol);
 }
 
-/*
- * Overrides accept(2) to set SOCK_CLOEXEC by default.
- */
+// Override accept(2) to set SOCK_CLOEXEC by default (native accept4 on QNX 8).
 int __wrap_accept(int sockfd, struct sockaddr* addr, socklen_t* addrlen) {
     return accept4(sockfd, addr, addrlen, SOCK_CLOEXEC);
 }
 
-/*
- * The real open(2), renamed by GCC.
- */
 int __real_open(const char* pathname, int flags, mode_t mode);
 
-/*
- * Overrides open(2) to set O_CLOEXEC by default.
- */
+// Override open(2) to set O_CLOEXEC by default.
 int __wrap_open(const char* pathname, int flags, mode_t mode) {
     return __real_open(pathname, flags | O_CLOEXEC, mode);
 }
+
 }
 
-#endif
+#endif // __QNX__


### PR DESCRIPTION
## What

The in-tree QNX support targets QNX 7 (io-pkt) and is regressed for QNX 8 (io-sock). This PR makes vsomeip build and run on QNX 8. All changes are guarded by `__QNX__` and have no effect on other platforms.

- **`qnx_helper.hpp`** — add the missing closing `#endif` (the top `#ifdef __QNX__` was unterminated, which breaks every QNX build) and a `SO_RCVBUFFORCE -> SO_RCVBUF` fallback (`SO_RCVBUFFORCE` is Linux-only).
- **`socket_options.hpp`** — include `qnx_helper.hpp` on QNX so `IP_PKTINFO` / `in_pktinfo` are defined.
- **`asio_uds_socket.hpp`** — `get_peer_credentials()` returns success with default credentials on QNX. QNX io-sock has no `SO_PEERCRED`/`ucred`; returning failure makes the local endpoint's `sec_client` update fail, so vsomeip rejects its own routing-manager connection and never registers/offers.
- **`wrappers_qnx.cpp`** — drop the QNX 7 `<sys/sockmsg.h>` message-passing `accept` implementation (that header no longer exists on QNX 8, which provides a native `accept4()` with `SOCK_CLOEXEC`); keep only the CLOEXEC `__wrap_socket` / `__wrap_accept` / `__wrap_open` linker targets.

## Testing

Tested on QNX SDP 8.0 (aarch64, Raspberry Pi 4): a QNX service and a Linux client exchanged a SOME/IP request/response successfully.

## Open question for maintainers

The `get_peer_credentials()` change currently **disables peer-credential-based policy on QNX** (there is no `SO_PEERCRED` equivalent on io-sock). The code comment notes this can be upgraded to a real credential source — e.g. the QNX message-passing side channel (`ConnectServerInfo` / `_client_info`) to obtain the peer pid/uid/gid — and gated behind vsomeip's security config. Happy to rework this along whatever lines you prefer.