### PR TITLE
Proper Boost version handling

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -53,7 +53,6 @@ cc_defaults {
     name: "vsomeip_lib_defaults",
 
     cflags: [
-        "-DVSOMEIP_BOOST_VERSION=107500",
         "-DVSOMEIP_INTERNAL_SUPPRESS_DEPRECATED",
         // std::result_of was removed in C++20; force Boost.Asio 1.75 to use
         // std::invoke_result instead (supported since Boost 1.74).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,8 +219,6 @@ endif()
 
 message( STATUS "Using boost version: ${VSOMEIP_BOOST_VERSION}" )
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DVSOMEIP_BOOST_VERSION=${VSOMEIP_BOOST_VERSION}")
-
 find_package(PkgConfig)
 
 # DLT

--- a/implementation/service_discovery/include/service_discovery_impl.hpp
+++ b/implementation/service_discovery/include/service_discovery_impl.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <boost/version.hpp>
 #include <boost/asio/ip/address.hpp>
 #include <map>
 #include <memory>
@@ -30,7 +31,7 @@
 #include "deserializer.hpp"
 #include "message_impl.hpp"
 
-#if VSOMEIP_BOOST_VERSION < 107600
+#if BOOST_VERSION < 107600
 #include <boost/container_hash/hash.hpp>
 
 // Custom hash function for boost::asio::ip::address.
@@ -42,7 +43,7 @@ struct address_hash {
                             : boost::hash<boost::asio::ip::address_v6::bytes_type>()(addr.to_v6().to_bytes());
     }
 };
-#endif // VSOMEIP_BOOST_VERSION < 107600
+#endif // BOOST_VERSION < 107600
 
 namespace vsomeip_v3 {
 
@@ -453,7 +454,7 @@ private:
     std::atomic<uint32_t> offers_received_;
 
 // List of hosts from which we have received unicast and multicast messages.
-#if VSOMEIP_BOOST_VERSION < 107600
+#if BOOST_VERSION < 107600
     std::unordered_map<boost::asio::ip::address, std::tuple<bool, bool>, address_hash> observed_hosts;
 #else
     std::unordered_map<boost::asio::ip::address, std::tuple<bool, bool>> observed_hosts;

--- a/test/common/src/utility.cpp
+++ b/test/common/src/utility.cpp
@@ -57,7 +57,7 @@ std::set<std::string> utility::get_all_files_in_dir(const std::string& _dir_path
                 if (boost::filesystem::is_directory(iter->path())
                     && (std::find(_dir_skip_list.begin(), _dir_skip_list.end(), iter->path().filename()) != _dir_skip_list.end())) {
                     // Boost Filesystem  API to skip current directory iteration
-#if VSOMEIP_BOOST_VERSION < 108100
+#if BOOST_VERSION < 108100
                     iter.no_push();
 #else
                     iter.disable_recursion_pending();

--- a/test/common/src/utility.cpp
+++ b/test/common/src/utility.cpp
@@ -3,6 +3,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+#include <boost/version.hpp>
 #include <common/utility.hpp>
 
 void utility::load_policy_data(std::string _input, std::vector<vsomeip_v3::configuration_element>& _elements,


### PR DESCRIPTION
I got the issue that VSOMEIP_BOOST_VERSION was not proper set via cmake.
The settings of VSOMEIP_BOOST_VERSION are depended which find_package() approach is used. Config or module. And also who builds/generate the BoostConfig.cmake (cmake-package) or FindBoost.cmake. In a conan environment this might be automatically generated.

It's much more stable and cleaner to use  the version from the provide boost/version.hpp header file. Even in the different boost libraries, boost/version.hpp is used.
